### PR TITLE
`GetProperty` extensions

### DIFF
--- a/src/backends/codegen_c.cpp
+++ b/src/backends/codegen_c.cpp
@@ -185,7 +185,7 @@ string unpackTensorProperty(string varname, const GetProperty* op,
     return ret.str();
   }
   
-  taco_iassert(op->dim < tensor->format.getOrder()) <<
+  taco_iassert((size_t)op->dimension < tensor->format.getOrder()) <<
       "Trying to access a nonexistent dimension";
   
   string tp;
@@ -193,9 +193,9 @@ string unpackTensorProperty(string varname, const GetProperty* op,
   // for a Dense level, nnz is an int
   // for a Fixed level, ptr is an int
   // all others are int*
-  if ((tensor->format.getDimensionTypes()[op->dim] == DimensionType::Dense &&
+  if ((tensor->format.getDimensionTypes()[op->dimension] == DimensionType::Dense &&
        op->property == TensorProperty::Dimensions) ||
-      (tensor->format.getDimensionTypes()[op->dim] == DimensionType::Fixed &&
+      (tensor->format.getDimensionTypes()[op->dimension] == DimensionType::Fixed &&
        op->property == TensorProperty::Dimensions)) {
     tp = "int";
     ret << tp << " " << varname << " = *("

--- a/src/backends/codegen_c.cpp
+++ b/src/backends/codegen_c.cpp
@@ -124,25 +124,6 @@ protected:
   
   virtual void visit(const GetProperty *op) {
     if (varMap.count(op) == 0) {
-//      stringstream name;
-//      auto tensor = op->tensor.as<Var>();
-//      name << tensor->name;
-//      switch (op->property) {
-////        case TensorProperty::Size:
-////          name << op->dim << "_size";
-////          break;
-////        case TensorProperty::Index:
-////          name << op->dim << "_idx";
-////          break;
-////        case TensorProperty::Pointer:
-////          name << op->dim << "_pos";
-////          break;
-////        case TensorProperty::Values:
-////          name << "_vals";
-////          break;
-//        case TensorPropertu::
-//      }
-      
       tuple<Expr, TensorProperty, int, int> key({op->tensor,op->property,(size_t)op->dimension,(size_t)op->index});
       if (canonicalPropertyVar.count(key) > 0) {
         varMap[op] = canonicalPropertyVar[key];
@@ -221,7 +202,6 @@ string unpackTensorProperty(string varname, const GetProperty* op,
         << tensor->name << "->indices[" << op->dimension << "][0]);\n";
   } else {
     tp = "int*";
-//    auto nm = op->property == TensorProperty::Indices ? "[0]" : "[1]";
     auto nm = op->index;
     ret << tp << " restrict " << varname << " = ";
     ret << "(int*)(" << tensor->name << "->indices[" << op->dimension;
@@ -258,7 +238,6 @@ string packTensorProperty(string varname, Expr tnsr, TensorProperty property,
     return "";
   } else {
     tp = "int*";
-//    auto nm = property == TensorProperty::Pointer ? "[0]" : "[1]";
     auto nm = index;
     ret << tensor->name << "->indices" <<
       "[" << dim << "][" << nm << "] = (uint8_t*)(" << varname

--- a/src/backends/codegen_c.cpp
+++ b/src/backends/codegen_c.cpp
@@ -54,12 +54,12 @@ public:
   // the variables for which we need to add declarations
   map<Expr, string, ExprCompare> varDecls;
   
-  // this maps from tensor, property, dim to the unique var
-  map<tuple<Expr, TensorProperty, int>, string> canonicalPropertyVar;
+  // this maps from tensor, property, dim, index to the unique var
+  map<tuple<Expr, TensorProperty, int, int>, string> canonicalPropertyVar;
   
   // this is for convenience, recording just the properties unpacked
   // from the output tensor so we can re-save them at the end
-  map<tuple<Expr, TensorProperty, int>, string> outputProperties;
+  map<tuple<Expr, TensorProperty, int, int>, string> outputProperties;
   
   // TODO: should replace this with an unordered set
   vector<Expr> outputTensors;
@@ -124,29 +124,30 @@ protected:
   
   virtual void visit(const GetProperty *op) {
     if (varMap.count(op) == 0) {
-      stringstream name;
-      auto tensor = op->tensor.as<Var>();
-      name << tensor->name;
-      switch (op->property) {
-        case TensorProperty::Size:
-          name << op->dim << "_size";
-          break;
-        case TensorProperty::Index:
-          name << op->dim << "_idx";
-          break;
-        case TensorProperty::Pointer:
-          name << op->dim << "_pos";
-          break;
-        case TensorProperty::Values:
-          name << "_vals";
-          break;
-      }
-      auto key =
-          tuple<Expr,TensorProperty,int>(op->tensor,op->property,op->dim);
+//      stringstream name;
+//      auto tensor = op->tensor.as<Var>();
+//      name << tensor->name;
+//      switch (op->property) {
+////        case TensorProperty::Size:
+////          name << op->dim << "_size";
+////          break;
+////        case TensorProperty::Index:
+////          name << op->dim << "_idx";
+////          break;
+////        case TensorProperty::Pointer:
+////          name << op->dim << "_pos";
+////          break;
+////        case TensorProperty::Values:
+////          name << "_vals";
+////          break;
+//        case TensorPropertu::
+//      }
+      
+      tuple<Expr, TensorProperty, int, int> key({op->tensor,op->property,(size_t)op->dimension,(size_t)op->index});
       if (canonicalPropertyVar.count(key) > 0) {
         varMap[op] = canonicalPropertyVar[key];
       } else {
-        auto unique_name = CodeGen_C::genUniqueName(name.str());
+        auto unique_name = CodeGen_C::genUniqueName(op->name);
         canonicalPropertyVar[key] = unique_name;
         varMap[op] = unique_name;
         varDecls[op] = unique_name;
@@ -212,25 +213,26 @@ string unpackTensorProperty(string varname, const GetProperty* op,
   // for a Fixed level, ptr is an int
   // all others are int*
   if ((tensor->format.getDimensionTypes()[op->dim] == DimensionType::Dense &&
-       op->property == TensorProperty::Size) ||
+       op->property == TensorProperty::Dimensions) ||
       (tensor->format.getDimensionTypes()[op->dim] == DimensionType::Fixed &&
-       op->property == TensorProperty::Size)) {
+       op->property == TensorProperty::Dimensions)) {
     tp = "int";
     ret << tp << " " << varname << " = *("
-        << tensor->name << "->indices[" << op->dim << "][0]);\n";
+        << tensor->name << "->indices[" << op->dimension << "][0]);\n";
   } else {
     tp = "int*";
-    auto nm = op->property == TensorProperty::Pointer ? "[0]" : "[1]";
+//    auto nm = op->property == TensorProperty::Indices ? "[0]" : "[1]";
+    auto nm = op->index;
     ret << tp << " restrict " << varname << " = ";
-    ret << "(int*)(" << tensor->name << "->indices[" << op->dim;
-    ret << "]" << nm << ");\n";
+    ret << "(int*)(" << tensor->name << "->indices[" << op->dimension;
+    ret << "][" << nm << "]);\n";
   }
   
   return ret.str();
 }
 
 string packTensorProperty(string varname, Expr tnsr, TensorProperty property,
-                          int dim) {
+                          int dim, int index) {
   stringstream ret;
   ret << "  ";
   
@@ -250,16 +252,16 @@ string packTensorProperty(string varname, Expr tnsr, TensorProperty property,
   // for a Fixed level, ptr is an int
   // all others are int*
   if ((tensor->format.getDimensionTypes()[dim] == DimensionType::Dense &&
-       property == TensorProperty::Size) ||
+       property == TensorProperty::Dimensions) ||
       (tensor->format.getDimensionTypes()[dim] == DimensionType::Fixed &&
-       property == TensorProperty::Size)) {
+       property == TensorProperty::Dimensions)) {
     return "";
   } else {
     tp = "int*";
-    auto nm = property == TensorProperty::Pointer ? "[0]" : "[1]";
-
+//    auto nm = property == TensorProperty::Pointer ? "[0]" : "[1]";
+    auto nm = index;
     ret << tensor->name << "->indices" <<
-      "[" << dim << "]" << nm << " = (uint8_t*)(" << varname
+      "[" << dim << "][" << nm << "] = (uint8_t*)(" << varname
       << ");\n";
   }
   
@@ -269,7 +271,7 @@ string packTensorProperty(string varname, Expr tnsr, TensorProperty property,
   
 // helper to print declarations
 string printDecls(map<Expr, string, ExprCompare> varMap,
-                   map<tuple<Expr, TensorProperty, int>, string> uniqueProps,
+                   map<tuple<Expr, TensorProperty, int, int>, string> uniqueProps,
                    vector<Expr> inputs, vector<Expr> outputs) {
   stringstream ret;
   unordered_set<string> propsAlreadyGenerated;
@@ -313,12 +315,12 @@ string printUnpack(vector<Expr> inputs, vector<Expr> outputs) {
   return "";
 }
 
-string printPack(map<tuple<Expr, TensorProperty, int>,
+string printPack(map<tuple<Expr, TensorProperty, int, int>,
                  string> outputProperties) {
   stringstream ret;
   for (auto prop: outputProperties) {
     ret << packTensorProperty(prop.second, get<0>(prop.first),
-      get<1>(prop.first), get<2>(prop.first));
+      get<1>(prop.first), get<2>(prop.first), get<3>(prop.first));
   }
   return ret.str();
 }

--- a/src/ir/ir.cpp
+++ b/src/ir/ir.cpp
@@ -486,16 +486,16 @@ Expr GetProperty::make(Expr tensor, TensorProperty property, int dimension) {
       gp->name = tensorVar->name + "_csize";
       break;
     case TensorProperty::DimensionOrder:
-      gp->name = tensorVar->name + "_dim_order" + std::to_string(dimension);
+      gp->name = tensorVar->name  + std::to_string(dimension) + "_dim_order";
       break;
     case TensorProperty::Dimensions:
-      gp->name = tensorVar->name + "_dim" + std::to_string(dimension);
+      gp->name = tensorVar->name + std::to_string(dimension) + "_size";
       break;
     case TensorProperty::Indices:
       taco_ierror << "Must provide both dimension and index for the Indices property";
       break;
     case TensorProperty::DimensionTypes:
-      gp->name = tensorVar->name + "_dim_types" + std::to_string(dimension);
+      gp->name = tensorVar->name  + std::to_string(dimension) + "_dim_type";
       break;
     case TensorProperty::Order:
       gp->name = tensorVar->name + "_order";

--- a/src/ir/ir.cpp
+++ b/src/ir/ir.cpp
@@ -3,8 +3,7 @@
 #include "ir_printer.h"
 
 #include "taco/error.h"
-
-#include <string>
+#include "taco/util/strings.h"
 
 namespace taco {
 namespace ir {
@@ -486,16 +485,16 @@ Expr GetProperty::make(Expr tensor, TensorProperty property, int dimension) {
       gp->name = tensorVar->name + "_csize";
       break;
     case TensorProperty::DimensionOrder:
-      gp->name = tensorVar->name  + std::to_string(dimension) + "_dim_order";
+      gp->name = tensorVar->name  + util::toString(dimension) + "_dim_order";
       break;
     case TensorProperty::Dimensions:
-      gp->name = tensorVar->name + std::to_string(dimension) + "_size";
+      gp->name = tensorVar->name + util::toString(dimension) + "_size";
       break;
     case TensorProperty::Indices:
       taco_ierror << "Must provide both dimension and index for the Indices property";
       break;
     case TensorProperty::DimensionTypes:
-      gp->name = tensorVar->name  + std::to_string(dimension) + "_dim_type";
+      gp->name = tensorVar->name  + util::toString(dimension) + "_dim_type";
       break;
     case TensorProperty::Order:
       gp->name = tensorVar->name + "_order";
@@ -504,7 +503,6 @@ Expr GetProperty::make(Expr tensor, TensorProperty property, int dimension) {
       gp->name = tensorVar->name + "_vals";
       break;
   }
-  std::cout << "CREATED " << gp->name << "\n";
   
   return gp;
 }

--- a/src/ir/ir.cpp
+++ b/src/ir/ir.cpp
@@ -4,6 +4,8 @@
 
 #include "taco/error.h"
 
+#include <string>
+
 namespace taco {
 namespace ir {
 
@@ -446,15 +448,16 @@ Stmt Print::make(std::string fmt, std::vector<Expr> params) {
   pr->params = params;
   return pr;
 }
-
-// GetProperty
-Expr GetProperty::make(Expr tensor, TensorProperty property, size_t dim) {
+  
+Expr GetProperty::make(Expr tensor, TensorProperty property, int dimension, int index, std::string name) {
   GetProperty* gp = new GetProperty;
   gp->tensor = tensor;
   gp->property = property;
-  gp->dim = dim;
+  gp->dimension = dimension;
+  gp->name = name;
+  gp->index = index;
   
-  //TODO: deal with the fact that these are pointers.
+  //TODO: deal with the fact that some of these are pointers
   if (property == TensorProperty::Values)
     gp->type = tensor.type();
   else
@@ -463,6 +466,49 @@ Expr GetProperty::make(Expr tensor, TensorProperty property, size_t dim) {
   return gp;
 }
 
+
+// GetProperty
+Expr GetProperty::make(Expr tensor, TensorProperty property, int dimension) {
+  GetProperty* gp = new GetProperty;
+  gp->tensor = tensor;
+  gp->property = property;
+  gp->dimension = dimension;
+  
+  //TODO: deal with the fact that these are pointers.
+  if (property == TensorProperty::Values)
+    gp->type = tensor.type();
+  else
+    gp->type = Type::Int;
+  
+  const Var* tensorVar = tensor.as<Var>();
+  switch (property) {
+    case TensorProperty::ComponentSize:
+      gp->name = tensorVar->name + "_csize";
+      break;
+    case TensorProperty::DimensionOrder:
+      gp->name = tensorVar->name + "_dim_order" + std::to_string(dimension);
+      break;
+    case TensorProperty::Dimensions:
+      gp->name = tensorVar->name + "_dim" + std::to_string(dimension);
+      break;
+    case TensorProperty::Indices:
+      taco_ierror << "Must provide both dimension and index for the Indices property";
+      break;
+    case TensorProperty::DimensionTypes:
+      gp->name = tensorVar->name + "_dim_types" + std::to_string(dimension);
+      break;
+    case TensorProperty::Order:
+      gp->name = tensorVar->name + "_order";
+      break;
+    case TensorProperty::Values:
+      gp->name = tensorVar->name + "_vals";
+      break;
+  }
+  std::cout << "CREATED " << gp->name << "\n";
+  
+  return gp;
+}
+  
 // visitor methods
 template<> void ExprNode<Literal>::accept(IRVisitorStrict *v)
     const { v->visit((const Literal*)this); }

--- a/src/ir/ir.h
+++ b/src/ir/ir.h
@@ -54,9 +54,12 @@ enum class IRNodeType {
 };
 
 enum class TensorProperty {
-  Size,
-  Index,
-  Pointer,
+  Order,
+  Dimensions,
+  DimensionTypes,
+  ComponentSize,
+  DimensionOrder,
+  Indices,
   Values
 };
 
@@ -603,11 +606,15 @@ public:
  */
 struct GetProperty : public ExprNode<GetProperty> {
 public:
-  TensorProperty property;
-  size_t dim;
   Expr tensor;
+  TensorProperty property;
+  int dimension;
+  int index;
+  std::string name;
   
-  static Expr make(Expr tensor, TensorProperty property, size_t dim=0);
+  
+  static Expr make(Expr tensor, TensorProperty property, int dimension=0);
+  static Expr make(Expr tensor, TensorProperty property, int dimension, int index, std::string name);
   
   static const IRNodeType _type_info = IRNodeType::GetProperty;
 };

--- a/src/ir/ir_printer.cpp
+++ b/src/ir/ir_printer.cpp
@@ -387,20 +387,21 @@ void IRPrinter::visit(const Print* op) {
 
 void IRPrinter::visit(const GetProperty* op) {
   op->tensor.accept(this);
-  switch (op->property) {
-    case TensorProperty::Size:
-      stream << op->dim << "_size";
-      break;
-    case TensorProperty::Index:
-      stream << op->dim << "_idx";
-      break;
-    case TensorProperty::Pointer:
-      stream << op->dim << "_pos";
-      break;
-    case TensorProperty::Values:
-      stream << op->dim << "_vals";
-      break;
-  }
+//  switch (op->property) {
+//    case TensorProperty::Size:
+//      stream << op->dim << "_size";
+//      break;
+//    case TensorProperty::Index:
+//      stream << op->dim << "_idx";
+//      break;
+//    case TensorProperty::Pointer:
+//      stream << op->dim << "_pos";
+//      break;
+//    case TensorProperty::Values:
+//      stream << op->dim << "_vals";
+//      break;
+//  }
+  stream << op->name;
 }
 
 

--- a/src/ir/ir_printer.cpp
+++ b/src/ir/ir_printer.cpp
@@ -386,21 +386,6 @@ void IRPrinter::visit(const Print* op) {
 }
 
 void IRPrinter::visit(const GetProperty* op) {
-  op->tensor.accept(this);
-//  switch (op->property) {
-//    case TensorProperty::Size:
-//      stream << op->dim << "_size";
-//      break;
-//    case TensorProperty::Index:
-//      stream << op->dim << "_idx";
-//      break;
-//    case TensorProperty::Pointer:
-//      stream << op->dim << "_pos";
-//      break;
-//    case TensorProperty::Values:
-//      stream << op->dim << "_vals";
-//      break;
-//  }
   stream << op->name;
 }
 

--- a/src/ir/ir_rewriter.cpp
+++ b/src/ir/ir_rewriter.cpp
@@ -351,7 +351,7 @@ void IRRewriter::visit(const GetProperty* op) {
     expr = op;
   }
   else {
-    expr = GetProperty::make(tensor, op->property, op->dim);
+    expr = GetProperty::make(tensor, op->property, op->dimension, op->index, op->name);
   }
 }
 

--- a/src/lower/lower.cpp
+++ b/src/lower/lower.cpp
@@ -397,13 +397,12 @@ static vector<Stmt> lower(const Target&     target,
             ptrInc = Block::make({ptrInc, resizeIndices});
           }
 
-//          Expr ptrArr = GetProperty::make(resultIterator.getTensor(),
-//                                          TensorProperty::Pointer,
-//                                          resultStep.getStep()+1);
+          int step = resultStep.getStep() + 1;
+          string resultTensorName = resultIterator.getTensor().as<Var>()->name;
           Expr ptrArr = GetProperty::make(resultIterator.getTensor(),
                                           TensorProperty::Indices,
-                                          resultStep.getStep()+1, 0, resultIterator.getTensor().as<Var>()->name
-                                          + util::toString(resultStep.getStep()+1) + "_pos");
+                                          step, 0,
+                                          resultTensorName + util::toString(step) + "_pos");
 
           Expr producedVals =
               Gt::make(Load::make(ptrArr, Add::make(resultPtr,1)),

--- a/src/lower/lower.cpp
+++ b/src/lower/lower.cpp
@@ -397,9 +397,13 @@ static vector<Stmt> lower(const Target&     target,
             ptrInc = Block::make({ptrInc, resizeIndices});
           }
 
+//          Expr ptrArr = GetProperty::make(resultIterator.getTensor(),
+//                                          TensorProperty::Pointer,
+//                                          resultStep.getStep()+1);
           Expr ptrArr = GetProperty::make(resultIterator.getTensor(),
-                                          TensorProperty::Pointer,
-                                          resultStep.getStep()+1);
+                                          TensorProperty::Indices,
+                                          resultStep.getStep()+1, 1, resultIterator.getTensor().as<Var>()->name + "_ptr");
+
           Expr producedVals =
               Gt::make(Load::make(ptrArr, Add::make(resultPtr,1)),
                        Load::make(ptrArr, resultPtr));

--- a/src/lower/lower.cpp
+++ b/src/lower/lower.cpp
@@ -402,7 +402,8 @@ static vector<Stmt> lower(const Target&     target,
 //                                          resultStep.getStep()+1);
           Expr ptrArr = GetProperty::make(resultIterator.getTensor(),
                                           TensorProperty::Indices,
-                                          resultStep.getStep()+1, 1, resultIterator.getTensor().as<Var>()->name + "_ptr");
+                                          resultStep.getStep()+1, 0, resultIterator.getTensor().as<Var>()->name
+                                          + util::toString(resultStep.getStep()+1) + "_pos");
 
           Expr producedVals =
               Gt::make(Load::make(ptrArr, Add::make(resultPtr,1)),

--- a/src/storage/dense_iterator.cpp
+++ b/src/storage/dense_iterator.cpp
@@ -78,7 +78,6 @@ ir::Stmt DenseIterator::resizeIdxStorage(ir::Expr size) const {
 
 ir::Expr DenseIterator::getSizeArr() const {
   return GetProperty::make(tensor, TensorProperty::Dimensions, level);
-  //return GetProperty::make(tensor, TensorProperty::Indices, level, 0, tensor.as<Var>()->name + "_size");
 }
 
 }}

--- a/src/storage/dense_iterator.cpp
+++ b/src/storage/dense_iterator.cpp
@@ -78,6 +78,7 @@ ir::Stmt DenseIterator::resizeIdxStorage(ir::Expr size) const {
 
 ir::Expr DenseIterator::getSizeArr() const {
   return GetProperty::make(tensor, TensorProperty::Dimensions, level);
+  //return GetProperty::make(tensor, TensorProperty::Indices, level, 0, tensor.as<Var>()->name + "_size");
 }
 
 }}

--- a/src/storage/dense_iterator.cpp
+++ b/src/storage/dense_iterator.cpp
@@ -77,7 +77,7 @@ ir::Stmt DenseIterator::resizeIdxStorage(ir::Expr size) const {
 }
 
 ir::Expr DenseIterator::getSizeArr() const {
-  return GetProperty::make(tensor, TensorProperty::Size, level);
+  return GetProperty::make(tensor, TensorProperty::Dimensions, level);
 }
 
 }}

--- a/src/storage/fixed_iterator.cpp
+++ b/src/storage/fixed_iterator.cpp
@@ -68,11 +68,11 @@ ir::Stmt FixedIterator::storeIdx(ir::Expr idx) const {
 }
 
 ir::Expr FixedIterator::getPtrArr() const {
-  return GetProperty::make(tensor, TensorProperty::Size, level);
+  return GetProperty::make(tensor, TensorProperty::Dimensions, level);
 }
 
 ir::Expr FixedIterator::getIdxArr() const {
-  return GetProperty::make(tensor, TensorProperty::Index, level);
+  return GetProperty::make(tensor, TensorProperty::Dimensions, level);
 }
 
 ir::Stmt FixedIterator::resizePtrStorage(ir::Expr size) const {

--- a/src/storage/fixed_iterator.cpp
+++ b/src/storage/fixed_iterator.cpp
@@ -72,7 +72,7 @@ ir::Expr FixedIterator::getPtrArr() const {
 }
 
 ir::Expr FixedIterator::getIdxArr() const {
-  return GetProperty::make(tensor, TensorProperty::Indices, level, 0, tensor.as<Var>()->name + "_size");
+  return GetProperty::make(tensor, TensorProperty::Dimensions, level);
 }
 
 ir::Stmt FixedIterator::resizePtrStorage(ir::Expr size) const {

--- a/src/storage/fixed_iterator.cpp
+++ b/src/storage/fixed_iterator.cpp
@@ -72,7 +72,7 @@ ir::Expr FixedIterator::getPtrArr() const {
 }
 
 ir::Expr FixedIterator::getIdxArr() const {
-  return GetProperty::make(tensor, TensorProperty::Dimensions, level);
+  return GetProperty::make(tensor, TensorProperty::Indices, level, 0, tensor.as<Var>()->name + "_size");
 }
 
 ir::Stmt FixedIterator::resizePtrStorage(ir::Expr size) const {

--- a/src/storage/sparse_iterator.cpp
+++ b/src/storage/sparse_iterator.cpp
@@ -66,11 +66,14 @@ ir::Stmt SparseIterator::storeIdx(ir::Expr idx) const {
 }
 
 ir::Expr SparseIterator::getPtrArr() const {
-  return GetProperty::make(tensor, TensorProperty::Pointer, level);
+//  return GetProperty::make(tensor, TensorProperty::Pointer, level);
+  return GetProperty::make(tensor, TensorProperty::Indices, level, 1, tensor.as<Var>()->name + "_ptr");
+
 }
 
 ir::Expr SparseIterator::getIdxArr() const {
-  return GetProperty::make(tensor, TensorProperty::Index, level);
+//  return GetProperty::make(tensor, TensorProperty::Index, level);
+  return GetProperty::make(tensor, TensorProperty::Indices, level, 0, tensor.as<Var>()->name + "_idx");
 }
 
 ir::Stmt SparseIterator::resizePtrStorage(ir::Expr size) const {

--- a/src/storage/sparse_iterator.cpp
+++ b/src/storage/sparse_iterator.cpp
@@ -67,13 +67,13 @@ ir::Stmt SparseIterator::storeIdx(ir::Expr idx) const {
 
 ir::Expr SparseIterator::getPtrArr() const {
 //  return GetProperty::make(tensor, TensorProperty::Pointer, level);
-  return GetProperty::make(tensor, TensorProperty::Indices, level, 1, tensor.as<Var>()->name + "_ptr");
+  return GetProperty::make(tensor, TensorProperty::Indices, level, 0, tensor.as<Var>()->name + util::toString(level) + "_pos");
 
 }
 
 ir::Expr SparseIterator::getIdxArr() const {
 //  return GetProperty::make(tensor, TensorProperty::Index, level);
-  return GetProperty::make(tensor, TensorProperty::Indices, level, 0, tensor.as<Var>()->name + "_idx");
+  return GetProperty::make(tensor, TensorProperty::Indices, level, 1, tensor.as<Var>()->name + util::toString(level) +  "_idx");
 }
 
 ir::Stmt SparseIterator::resizePtrStorage(ir::Expr size) const {

--- a/src/storage/sparse_iterator.cpp
+++ b/src/storage/sparse_iterator.cpp
@@ -66,14 +66,14 @@ ir::Stmt SparseIterator::storeIdx(ir::Expr idx) const {
 }
 
 ir::Expr SparseIterator::getPtrArr() const {
-//  return GetProperty::make(tensor, TensorProperty::Pointer, level);
-  return GetProperty::make(tensor, TensorProperty::Indices, level, 0, tensor.as<Var>()->name + util::toString(level) + "_pos");
+  return GetProperty::make(tensor, TensorProperty::Indices, level, 0,
+                           tensor.as<Var>()->name + util::toString(level) + "_pos");
 
 }
 
 ir::Expr SparseIterator::getIdxArr() const {
-//  return GetProperty::make(tensor, TensorProperty::Index, level);
-  return GetProperty::make(tensor, TensorProperty::Indices, level, 1, tensor.as<Var>()->name + util::toString(level) +  "_idx");
+  return GetProperty::make(tensor, TensorProperty::Indices, level, 1,
+                           tensor.as<Var>()->name + util::toString(level) +  "_idx");
 }
 
 ir::Stmt SparseIterator::resizePtrStorage(ir::Expr size) const {


### PR DESCRIPTION
This PR extends `GetProperty` in the backend IR to be able to access all parts of the `taco_tensor_t` struct.