### PR TITLE
Fix 105

### DIFF
--- a/include/taco/expr.h
+++ b/include/taco/expr.h
@@ -20,7 +20,7 @@ class ExprVisitorStrict;
 }
 
 /// An index variable. Index variables are used in index expressions, where they
-/// represent iteration over a tensor dimension.
+/// represent iteration over a tensor mode.
 class IndexVar : public util::Comparable<IndexVar> {
 public:
   IndexVar();

--- a/include/taco/format.h
+++ b/include/taco/format.h
@@ -59,7 +59,7 @@ extern const Format CSC;
 extern const Format DCSR;
 extern const Format DCSC;
 
-/// True if all dimensions are Dense
+/// True if all modes are Dense
 bool isDense(const Format&);
 
 }

--- a/include/taco/ir/ir.h
+++ b/include/taco/ir/ir.h
@@ -57,9 +57,9 @@ enum class IRNodeType {
 enum class TensorProperty {
   Order,
   Dimensions,
-  DimensionTypes,
   ComponentSize,
-  DimensionOrder,
+  ModeOrder,
+  ModeTypes,
   Indices,
   Values
 };
@@ -594,12 +594,12 @@ struct GetProperty : public ExprNode<GetProperty> {
 public:
   Expr tensor;
   TensorProperty property;
-  int dimension;
+  int mode;
   int index = 0;
   std::string name;
 
-  static Expr make(Expr tensor, TensorProperty property, int dimension=0);
-  static Expr make(Expr tensor, TensorProperty property, int dimension,
+  static Expr make(Expr tensor, TensorProperty property, int mode=0);
+  static Expr make(Expr tensor, TensorProperty property, int mode,
                    int index, std::string name);
   
   static const IRNodeType _type_info = IRNodeType::GetProperty;

--- a/include/taco/parser/parser.h
+++ b/include/taco/parser/parser.h
@@ -26,9 +26,9 @@ enum class Token;
 class Parser : public util::Uncopyable {
 public:
   Parser(std::string expression, const std::map<std::string,Format>& formats,
-         const std::map<std::string,std::vector<int>>& dimensionSizes,
+         const std::map<std::string,std::vector<int>>& tensorDimensions,
          const std::map<std::string,TensorBase>& tensors,
-         int dimensionDefault=5);
+         int defaultDimension=5);
 
   /// Parse the expression.
   /// @throws ParseError if there's a parser error

--- a/include/taco/storage/array_util.h
+++ b/include/taco/storage/array_util.h
@@ -14,7 +14,7 @@ namespace taco {
 namespace storage {
 
 /// Construct an index array. The ownership policy determines whether the
-/// dimension index will free/delete the memory or leave the responsibility for
+/// mode index will free/delete the memory or leave the responsibility for
 /// freeing to the user.
 template <typename T>
 Array makeArray(T* data, size_t size, Array::Policy policy=Array::UserOwns) {

--- a/include/taco/storage/pack.h
+++ b/include/taco/storage/pack.h
@@ -19,7 +19,7 @@ class Storage;
 /// Pack tensor coordinates into a format. The coordinates must be stored as a
 /// structure of arrays, that is one vector per axis coordinate and one vector
 /// for the values. The coordinates must be sorted lexicographically.
-Storage pack(const std::vector<int>&              dimensionSizes,
+Storage pack(const std::vector<int>&              dimensions,
              const Format&                        format,
              const std::vector<std::vector<int>>& coordinates,
              const std::vector<double>            values);

--- a/include/taco/storage/storage.h
+++ b/include/taco/storage/storage.h
@@ -11,9 +11,9 @@ class Index;
 class Array;
 
 /// Storage for a tensor object.  Tensor storage consists of a value array that
-/// contains the tensor values and one index per dimension.  The type of each
-/// dimension index is determined by the dimension type in the format, and the
-/// ordere of the dimension indices is determined by the format dimension order.
+/// contains the tensor values and one index per mode.  The type of each
+/// mode index is determined by the mode type in the format, and the
+/// order of the mode indices is determined by the format mode order.
 class Storage {
 public:
 

--- a/include/taco/taco_tensor_t.h
+++ b/include/taco/taco_tensor_t.h
@@ -5,17 +5,16 @@
 #ifndef TACO_TENSOR_T_DEFINED
 #define TACO_TENSOR_T_DEFINED
 
-typedef enum { taco_dim_dense, taco_dim_sparse } taco_dim_t;
+typedef enum { taco_mode_dense, taco_mode_sparse } taco_mode_t;
 
 typedef struct {
-  int32_t     order;      // tensor order (number of dimensions)
-  int32_t*    dims;       // tensor dimensions
-  taco_dim_t* dim_types;  // dimension storage types
-  int32_t     csize;      // component size
-  
-  int32_t*    dim_order;  // dimension storage order
-  uint8_t***  indices;    // tensor index data (per dimension)
-  uint8_t*    vals;       // tensor values
+  int32_t      order;      // tensor order (number of modes)
+  int32_t*     dimensions; // tensor dimensions
+  int32_t      csize;      // component size
+  int32_t*     mode_order; // mode storage order
+  taco_mode_t* mode_types; // mode storage types
+  uint8_t***   indices;    // tensor index data (per mode)
+  uint8_t*     vals;       // tensor values
 } taco_tensor_t;
 
 #endif

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -54,7 +54,7 @@ public:
   size_t getOrder() const;
 
   /// Get the size of a tensor mode.
-  int getDimension(size_t dim) const;
+  int getDimension(size_t mode) const;
 
   /// Get a vector with the size of each tensor mode.
   const std::vector<int>& getDimensions() const;
@@ -281,8 +281,8 @@ public:
         curVal.second = getValue<double>(tensor->getStorage().getValues(), idx);
 
         for (size_t i = 0; i < lvl; ++i) {
-          const size_t dim = modeOrder[i];
-          curVal.first[dim] = coord[i];
+          const size_t mode = modeOrder[i];
+          curVal.first[mode] = coord[i];
         }
 
         advance = true;

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -53,10 +53,10 @@ public:
   /// Get the order of the tensor (the number of modes).
   size_t getOrder() const;
 
-  /// Get the size of a tensor mode.
+  /// Get the dimension of a tensor mode.
   int getDimension(size_t mode) const;
 
-  /// Get a vector with the size of each tensor mode.
+  /// Get a vector with the dimension of each tensor mode.
   const std::vector<int>& getDimensions() const;
 
   /// Return the type of the tensor components (e.g. double).

--- a/include/taco/util/fill.h
+++ b/include/taco/util/fill.h
@@ -35,7 +35,7 @@ const std::map<FillMethod,double> fillFactors = {
 };
 const double doubleLowerBound = -10e6;
 const double doubleUpperBound =  10e6;
-const int blockDim=4;
+const int blockDimension=4;
 const FillMethod blockFillMethod=FillMethod::FEM;
 
 void fillTensor(TensorBase& tens, const FillMethod& fill, double fillValue=-1.0);
@@ -64,7 +64,7 @@ void fillTensor(TensorBase& tens, const FillMethod& fill, double fillValue/*=-1.
     }
     default:
       taco_uerror << "Impossible to fill tensor " << tens.getName() <<
-        " of dimension " << tens.getOrder() << std::endl;
+        " of order " << tens.getOrder() << std::endl;
   }
 }
 
@@ -223,18 +223,18 @@ void fillMatrix(TensorBase& tens, const FillMethod& fill, double fillValue) {
       break;
     }
     case FillMethod::Blocked: {
-      std::vector<int> dimensionSizes;
-      dimensionSizes.push_back(tensorSize[0]/blockDim);
-      dimensionSizes.push_back(tensorSize[1]/blockDim);
-      Tensor<double> BaseTensor(tens.getName(), dimensionSizes,
+      std::vector<int> dimensions;
+      dimensions.push_back(tensorSize[0]/blockDimension);
+      dimensions.push_back(tensorSize[1]/blockDimension);
+      Tensor<double> BaseTensor(tens.getName(), dimensions,
                                 tens.getFormat());
       fillMatrix(BaseTensor, blockFillMethod, fillValue);
       for (const auto& elem : BaseTensor) {
-        int row = elem.first[0]*blockDim;
-        int col = elem.first[1]*blockDim;
+        int row = elem.first[0]*blockDimension;
+        int col = elem.first[1]*blockDimension;
         double value = elem.second;
-        for (int i=0; i<blockDim; i++) {
-          for (int j=0; j<blockDim; j++) {
+        for (int i=0; i<blockDimension; i++) {
+          for (int j=0; j<blockDimension; j++) {
             tens.insert({row+i,col+j},value/(i+1));
           }
         }
@@ -316,7 +316,7 @@ void fillTensor3(TensorBase& tens, const FillMethod& fill, double fillValue) {
     }
 
     default: {
-      taco_uerror << "FillMethod not available for tensors of 3 dimensions "
+      taco_uerror << "FillMethod not available for tensors of order 3"
                   << std::endl;
       break;
     }

--- a/src/error/error_checks.h
+++ b/src/error/error_checks.h
@@ -27,7 +27,7 @@ bool containsTranspose(const Format& resultFormat,
                        const IndexExpr& expr);
 
 /// Returns true iff the index expression distributes values over result
-/// dimensions.
+/// modes.
 bool containsDistribution(const std::vector<IndexVar>& resultVars,
                           const IndexExpr& expr);
 

--- a/src/format.cpp
+++ b/src/format.cpp
@@ -46,13 +46,13 @@ const std::vector<int>& Format::getModeOrder() const {
 }
 
 bool operator==(const Format& a, const Format& b){
-  auto aDimTypes = a.getModeTypes();
-  auto bDimTypes = b.getModeTypes();
-  auto aDimOrder = a.getModeOrder();
-  auto bDimOrder = b.getModeOrder();
-  if (aDimTypes.size() == bDimTypes.size()) {
-    for (size_t i = 0; i < aDimTypes.size(); i++) {
-      if ((aDimTypes[i] != bDimTypes[i]) || (aDimOrder[i] != bDimOrder[i])) {
+  auto aModeTypes = a.getModeTypes();
+  auto bModeTypes = b.getModeTypes();
+  auto aModeOrder = a.getModeOrder();
+  auto bModeOrder = b.getModeOrder();
+  if (aModeTypes.size() == bModeTypes.size()) {
+    for (size_t i = 0; i < aModeTypes.size(); i++) {
+      if ((aModeTypes[i] != bModeTypes[i]) || (aModeOrder[i] != bModeOrder[i])) {
         return false;
       }
     }

--- a/src/ir/ir.cpp
+++ b/src/ir/ir.cpp
@@ -473,14 +473,14 @@ Expr GetProperty::make(Expr tensor, TensorProperty property, int mode) {
     case TensorProperty::ComponentSize:
       gp->name = tensorVar->name + "_csize";
       break;
-    case TensorProperty::Indices:
-      taco_ierror << "Must provide both mode and index for the Indices property";
-      break;
     case TensorProperty::ModeOrder:
       gp->name = tensorVar->name  + util::toString(mode + 1) + "_mode_order";
       break;
     case TensorProperty::ModeTypes:
       gp->name = tensorVar->name  + util::toString(mode + 1) + "_mode_type";
+      break;
+    case TensorProperty::Indices:
+      taco_ierror << "Must provide both mode and index for the Indices property";
       break;
     case TensorProperty::Values:
       gp->name = tensorVar->name + "_vals";

--- a/src/ir/ir.cpp
+++ b/src/ir/ir.cpp
@@ -430,12 +430,12 @@ Stmt Print::make(std::string fmt, std::vector<Expr> params) {
   return pr;
 }
   
-Expr GetProperty::make(Expr tensor, TensorProperty property, int dimension,
+Expr GetProperty::make(Expr tensor, TensorProperty property, int mode,
                        int index, std::string name) {
   GetProperty* gp = new GetProperty;
   gp->tensor = tensor;
   gp->property = property;
-  gp->dimension = dimension;
+  gp->mode = mode;
   gp->name = name;
   gp->index = index;
   
@@ -450,11 +450,11 @@ Expr GetProperty::make(Expr tensor, TensorProperty property, int dimension,
 
 
 // GetProperty
-Expr GetProperty::make(Expr tensor, TensorProperty property, int dimension) {
+Expr GetProperty::make(Expr tensor, TensorProperty property, int mode) {
   GetProperty* gp = new GetProperty;
   gp->tensor = tensor;
   gp->property = property;
-  gp->dimension = dimension;
+  gp->mode = mode;
   
   //TODO: deal with the fact that these are pointers.
   if (property == TensorProperty::Values)
@@ -464,23 +464,23 @@ Expr GetProperty::make(Expr tensor, TensorProperty property, int dimension) {
   
   const Var* tensorVar = tensor.as<Var>();
   switch (property) {
+    case TensorProperty::Order:
+      gp->name = tensorVar->name + "_order";
+      break;
+    case TensorProperty::Dimensions:
+      gp->name = tensorVar->name + util::toString(mode + 1) + "_dimension";
+      break;
     case TensorProperty::ComponentSize:
       gp->name = tensorVar->name + "_csize";
       break;
-    case TensorProperty::DimensionOrder:
-      gp->name = tensorVar->name  + util::toString(dimension + 1) + "_dim_order";
-      break;
-    case TensorProperty::Dimensions:
-      gp->name = tensorVar->name + util::toString(dimension + 1) + "_size";
-      break;
     case TensorProperty::Indices:
-      taco_ierror << "Must provide both dimension and index for the Indices property";
+      taco_ierror << "Must provide both mode and index for the Indices property";
       break;
-    case TensorProperty::DimensionTypes:
-      gp->name = tensorVar->name  + util::toString(dimension + 1) + "_dim_type";
+    case TensorProperty::ModeOrder:
+      gp->name = tensorVar->name  + util::toString(mode + 1) + "_mode_order";
       break;
-    case TensorProperty::Order:
-      gp->name = tensorVar->name + "_order";
+    case TensorProperty::ModeTypes:
+      gp->name = tensorVar->name  + util::toString(mode + 1) + "_mode_type";
       break;
     case TensorProperty::Values:
       gp->name = tensorVar->name + "_vals";

--- a/src/ir/ir_rewriter.cpp
+++ b/src/ir/ir_rewriter.cpp
@@ -351,7 +351,7 @@ void IRRewriter::visit(const GetProperty* op) {
     expr = op;
   }
   else {
-    expr = GetProperty::make(tensor, op->property, op->dimension, op->index, op->name);
+    expr = GetProperty::make(tensor, op->property, op->mode, op->index, op->name);
   }
 }
 

--- a/src/lower/iteration_schedule.cpp
+++ b/src/lower/iteration_schedule.cpp
@@ -58,7 +58,7 @@ IterationSchedule IterationSchedule::make(const TensorBase& tensor) {
     void visit(const expr_nodes::ReadNode* op) {
       taco_iassert(op->tensor.getOrder() == op->indexVars.size()) <<
           "Tensor access " << IndexExpr(op) << " but tensor format only has " <<
-          op->tensor.getOrder() << " dimensions.";
+          op->tensor.getOrder() << " modes.";
       Format format = op->tensor.getFormat();
 
       // copy index variables to path

--- a/src/lower/lower.cpp
+++ b/src/lower/lower.cpp
@@ -585,8 +585,8 @@ Stmt lower(TensorBase tensor, string funcName, set<Property> properties) {
         init.push_back(allocVals);
       }
 
-      // If the output is dense and if either an output dimension is merged with 
-      // a sparse input dimension or if the emitted code is a scatter code, then 
+      // If the output is dense and if either an output mode is merged with 
+      // a sparse input mode or if the emitted code is a scatter code, then 
       // we also need to zero the output.
       if (!isa<Var>(size)) {
         if (isa<Literal>(size)) {

--- a/src/lower/tensor_path.h
+++ b/src/lower/tensor_path.h
@@ -16,7 +16,7 @@ class TensorPathStep;
 /// A tensor Read expression such as A(i,j,k) results in a path in an iteration
 /// schedule through i,j,k. The exact path (i->j->k, j->k->i, etc.) is dictated
 /// by the order of the levels in the tensor storage tree. The index variable
-/// that indexes into the dimension at the first level is the first index
+/// that indexes into the mode at the first level is the first index
 /// variable in the path, and so forth.
 class TensorPath : public util::Comparable<TensorPath> {
 public:

--- a/src/storage/dense_iterator.cpp
+++ b/src/storage/dense_iterator.cpp
@@ -8,7 +8,7 @@ namespace taco {
 namespace storage {
 
 DenseIterator::DenseIterator(std::string name, const Expr& tensor, int level,
-                             size_t dimSize, Iterator previous)
+                             size_t dimension, Iterator previous)
       : IteratorImpl(previous, tensor) {
   this->tensor = tensor;
   this->level = level;
@@ -18,7 +18,7 @@ DenseIterator::DenseIterator(std::string name, const Expr& tensor, int level,
                      Type(Type::Int));
   idxVar = Var::make(indexVarName, Type(Type::Int));
 
-  this->dimSize = (int)dimSize;
+  this->dimension = (int)dimension;
 }
 
 bool DenseIterator::isDense() const {
@@ -55,8 +55,8 @@ Expr DenseIterator::begin() const {
 }
 
 Expr DenseIterator::end() const {
-  if (isa<Literal>(dimSize) && to<Literal>(dimSize)->value <= 16) {
-    return dimSize;
+  if (isa<Literal>(dimension) && to<Literal>(dimension)->value <= 16) {
+    return dimension;
   }
   return getSizeArr();
 }

--- a/src/storage/dense_iterator.h
+++ b/src/storage/dense_iterator.h
@@ -12,7 +12,7 @@ namespace storage {
 class DenseIterator : public IteratorImpl {
 public:
   DenseIterator(std::string name, const ir::Expr& tensor, int level,
-                size_t dimSize, Iterator previous);
+                size_t dimension, Iterator previous);
   virtual ~DenseIterator() {};
 
   bool isDense() const;
@@ -44,7 +44,7 @@ private:
   ir::Expr ptrVar;
   ir::Expr idxVar;
 
-  ir::Expr dimSize;
+  ir::Expr dimension;
 
   ir::Expr getSizeArr() const;
 };

--- a/src/storage/index.cpp
+++ b/src/storage/index.cpp
@@ -48,17 +48,17 @@ ModeIndex Index::getModeIndex(int i) {
 size_t Index::getSize() const {
   size_t size = 1;
   for (size_t i = 0; i < getFormat().getOrder(); i++) {
-    auto dimType  = getFormat().getModeTypes()[i];
-    auto dimIndex = getModeIndex(i);
-    switch (dimType) {
+    auto modeType  = getFormat().getModeTypes()[i];
+    auto modeIndex = getModeIndex(i);
+    switch (modeType) {
       case ModeType::Dense:
-        size *= getValue<size_t>(dimIndex.getIndexArray(0), 0);
+        size *= getValue<size_t>(modeIndex.getIndexArray(0), 0);
         break;
       case ModeType::Sparse:
-        size = getValue<size_t>(dimIndex.getIndexArray(0), size);
+        size = getValue<size_t>(modeIndex.getIndexArray(0), size);
         break;
       case ModeType::Fixed:
-        size *= getValue<size_t>(dimIndex.getIndexArray(0), 0);
+        size *= getValue<size_t>(modeIndex.getIndexArray(0), 0);
         break;
     }
   }
@@ -69,9 +69,9 @@ std::ostream& operator<<(std::ostream& os, const Index& index) {
   auto& format = index.getFormat();
   for (size_t i = 0; i < format.getOrder(); i++) {
     os << format.getModeTypes()[i] << " (" << format.getModeOrder()[i] << "): ";
-    auto dimIndex = index.getModeIndex(i);
-    for (size_t j = 0; j < dimIndex.numIndexArrays(); j++) {
-      os << endl << "  " << dimIndex.getIndexArray(j);
+    auto modeIndex = index.getModeIndex(i);
+    for (size_t j = 0; j < modeIndex.numIndexArrays(); j++) {
+      os << endl << "  " << modeIndex.getIndexArray(j);
     }
     if (i < format.getOrder()-1) os << endl;
   }

--- a/src/storage/iterator.cpp
+++ b/src/storage/iterator.cpp
@@ -29,28 +29,28 @@ Iterator Iterator::makeRoot(const ir::Expr& tensor) {
 }
 
 Iterator Iterator::make(string name, const ir::Expr& tensorVar,
-                        int dim, ModeType dimType, int dimOrder,
+                        int mode, ModeType modeType, int modeOrder,
                         Iterator parent, const TensorBase& tensor) {
   Iterator iterator;
 
-  switch (dimType) {
+  switch (modeType) {
     case ModeType::Dense: {
-      size_t dimSize = tensor.getDimension(dimOrder);
+      size_t dimension = tensor.getDimension(modeOrder);
       iterator.iterator =
-          std::make_shared<DenseIterator>(name, tensorVar, dim, dimSize,
+          std::make_shared<DenseIterator>(name, tensorVar, mode, dimension,
                                           parent);
       break;
     }
     case ModeType::Sparse: {
       iterator.iterator =
-          std::make_shared<SparseIterator>(name, tensorVar, dim, parent);
+          std::make_shared<SparseIterator>(name, tensorVar, mode, parent);
       break;
     }
     case ModeType::Fixed: {
-      auto dimIndex = tensor.getStorage().getIndex().getModeIndex(dim);
-      int fixedSize = getValue<int>(dimIndex.getIndexArray(0), 0);
+      auto modeIndex = tensor.getStorage().getIndex().getModeIndex(mode);
+      int fixedSize = getValue<int>(modeIndex.getIndexArray(0), 0);
       iterator.iterator =
-          std::make_shared<FixedIterator>(name, tensorVar, dim, fixedSize,
+          std::make_shared<FixedIterator>(name, tensorVar, mode, fixedSize,
                                           parent);
       break;
     }

--- a/src/storage/iterator.h
+++ b/src/storage/iterator.h
@@ -27,7 +27,7 @@ public:
 
   static Iterator makeRoot(const ir::Expr& tensor);
   static Iterator make(std::string name, const ir::Expr& tensorVar,
-                       int dim, ModeType modeType, int dimOrder,
+                       int mode, ModeType modeType, int modeOrder,
                        Iterator parent, const TensorBase& tensor);
 
   /// Get the parent of this iterator in its iterator list.
@@ -36,7 +36,7 @@ public:
   /// Returns the tensor this iterator is iterating over.
   ir::Expr getTensor() const;
 
-  /// Returns true if the iterator iterates over the entire tensor dimension
+  /// Returns true if the iterator iterates over the entire tensor mode
   bool isDense() const;
 
   /// Returns true if the iterator iterates over ranges of fixed size.

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -85,9 +85,9 @@ TensorBase::TensorBase(string name, Type ctype, vector<int> dimensions,
                        Format format) : content(new Content) {
   taco_uassert(format.getOrder() == dimensions.size() ||
                format.getOrder() == 1) <<
-      "The number of format levels (" << format.getOrder() << ") " <<
+      "The number of format mode types (" << format.getOrder() << ") " <<
       "must match the tensor order (" << dimensions.size() << "), " <<
-      "or there must be a single level.";
+      "or there must be a single mode type.";
 
   if (dimensions.size() == 0) {
     format = Format();

--- a/test/format-tests.cpp
+++ b/test/format-tests.cpp
@@ -32,13 +32,13 @@ std::vector<TensorData<double>> packageInputs(Ts... inputs) {
   return {inputs...};
 }
 
-const auto dimTypes1 = generateModeTypes(1);
-const auto dimTypes2 = generateModeTypes(2);
-const auto dimTypes3 = generateModeTypes(3);
+const auto modeTypes1 = generateModeTypes(1);
+const auto modeTypes2 = generateModeTypes(2);
+const auto modeTypes3 = generateModeTypes(3);
 
-const auto dimOrders1 = generateDimensionOrders(1);
-const auto dimOrders2 = generateDimensionOrders(2);
-const auto dimOrders3 = generateDimensionOrders(3);
+const auto modeOrders1 = generateModeOrders(1);
+const auto modeOrders2 = generateModeOrders(2);
+const auto modeOrders3 = generateModeOrders(3);
 
 INSTANTIATE_TEST_CASE_P(vector, format, Combine(
     Values(
@@ -47,19 +47,19 @@ INSTANTIATE_TEST_CASE_P(vector, format, Combine(
         packageInputs(d5a_data()),
         packageInputs(d5b_data()),
         packageInputs(d5c_data())
-    ), ValuesIn(dimTypes1), ValuesIn(dimOrders1)));
+    ), ValuesIn(modeTypes1), ValuesIn(modeOrders1)));
 
 INSTANTIATE_TEST_CASE_P(matrix, format, Combine(
     Values(
         packageInputs(d33a_data()),
         packageInputs(d33b_data())
-    ), ValuesIn(dimTypes2), ValuesIn(dimOrders2)));
+    ), ValuesIn(modeTypes2), ValuesIn(modeOrders2)));
 
 INSTANTIATE_TEST_CASE_P(tensor3, format, Combine(
     Values(
         packageInputs(d233a_data()),
         packageInputs(d233b_data())
-    ), ValuesIn(dimTypes3), ValuesIn(dimOrders3)));
+    ), ValuesIn(modeTypes3), ValuesIn(modeOrders3)));
 
 TEST(format, sparse) {
   Tensor<double> A = d33a("A", Sparse);

--- a/test/io-tests.cpp
+++ b/test/io-tests.cpp
@@ -7,8 +7,8 @@ using namespace taco;
 TEST(io, tns) {
   TensorBase tensor = read(testDataDirectory()+"3tensor.tns", Sparse);
   ASSERT_EQ(3u, tensor.getOrder());
-  for (ModeType dimType : tensor.getFormat().getModeTypes()) {
-    ASSERT_EQ(Sparse, dimType);
+  for (ModeType modeType : tensor.getFormat().getModeTypes()) {
+    ASSERT_EQ(Sparse, modeType);
   }
 
   TensorBase expected(Float(64), {1073,1,7});
@@ -23,8 +23,8 @@ TEST(io, tns) {
 TEST(io, mtx) {
   TensorBase tensor = read(testDataDirectory()+"2tensor.mtx", Sparse);
   ASSERT_EQ(2u, tensor.getOrder());
-  for (ModeType dimType : tensor.getFormat().getModeTypes()) {
-    ASSERT_EQ(Sparse, dimType);
+  for (ModeType modeType : tensor.getFormat().getModeTypes()) {
+    ASSERT_EQ(Sparse, modeType);
   }
 
   TensorBase expected(Float(64), {32,32});
@@ -39,8 +39,8 @@ TEST(io, mtx) {
 TEST(io, tensor) {
   Tensor<double> tensor = read(testDataDirectory()+"3tensor.tns", Sparse);
   ASSERT_EQ(3u, tensor.getOrder());
-  for (ModeType dimType : tensor.getFormat().getModeTypes()) {
-    ASSERT_EQ(Sparse, dimType);
+  for (ModeType modeType : tensor.getFormat().getModeTypes()) {
+    ASSERT_EQ(Sparse, modeType);
   }
 
   TensorBase expected(Float(64), {1073,1,7});
@@ -56,8 +56,8 @@ TEST(io, tensor) {
 TEST(io, ttxdense) {
   Tensor<double> tensor = read(testDataDirectory()+"d432.ttx", Dense);
   ASSERT_EQ(3u, tensor.getOrder());
-  for (ModeType dimType : tensor.getFormat().getModeTypes()) {
-    ASSERT_EQ(Dense, dimType);
+  for (ModeType modeType : tensor.getFormat().getModeTypes()) {
+    ASSERT_EQ(Dense, modeType);
   }
 
   TensorBase expected(Float(64), {4,3,2}, Dense);
@@ -94,8 +94,8 @@ TEST(io, ttxdense) {
 TEST(io, ttxsparse) {
   Tensor<double> tensor = read(testDataDirectory()+"d567.ttx", Sparse);
   ASSERT_EQ(3u, tensor.getOrder());
-  for (ModeType dimType : tensor.getFormat().getModeTypes()) {
-    ASSERT_EQ(Sparse, dimType);
+  for (ModeType modeType : tensor.getFormat().getModeTypes()) {
+    ASSERT_EQ(Sparse, modeType);
   }
 
   TensorBase expected(Float(64), {5,6,7}, Sparse);
@@ -112,8 +112,8 @@ TEST(io, ttxsparse) {
 TEST(io, mtxsymmetric) {
   Tensor<double> tensor = read(testDataDirectory()+"ds33.mtx", Sparse);
   ASSERT_EQ(2u, tensor.getOrder());
-  for (ModeType dimType : tensor.getFormat().getModeTypes()) {
-    ASSERT_EQ(Sparse, dimType);
+  for (ModeType modeType : tensor.getFormat().getModeTypes()) {
+    ASSERT_EQ(Sparse, modeType);
   }
 
   TensorBase expected(Float(64), {3,3}, Sparse);

--- a/test/test.h
+++ b/test/test.h
@@ -74,12 +74,12 @@ void ASSERT_STORAGE_EQUALS(vector<vector<vector<int>>> expectedIndices,
 
   auto index = storage.getIndex();
   for (size_t i=0; i < storage.getFormat().getOrder(); ++i) {
-    auto dimIndex = index.getModeIndex(i);
+    auto modeIndex = index.getModeIndex(i);
     switch (storage.getFormat().getModeTypes()[i]) {
       case ModeType::Dense: {
         taco_iassert(expectedIndices[i].size() == 1);
-        ASSERT_EQ(1u, dimIndex.numIndexArrays());
-        auto size = dimIndex.getIndexArray(0);
+        ASSERT_EQ(1u, modeIndex.numIndexArrays());
+        auto size = modeIndex.getIndexArray(0);
         ASSERT_ARRAY_EQ(expectedIndices[i][0],
                         {(int*)size.getData(), size.getSize()});
         break;
@@ -87,9 +87,9 @@ void ASSERT_STORAGE_EQUALS(vector<vector<vector<int>>> expectedIndices,
       case ModeType::Sparse:
       case ModeType::Fixed: {
         taco_iassert(expectedIndices[i].size() == 2);
-        ASSERT_EQ(2u, dimIndex.numIndexArrays());
-        auto pos = dimIndex.getIndexArray(0);
-        auto idx = dimIndex.getIndexArray(1);
+        ASSERT_EQ(2u, modeIndex.numIndexArrays());
+        auto pos = modeIndex.getIndexArray(0);
+        auto idx = modeIndex.getIndexArray(1);
         ASSERT_ARRAY_EQ(expectedIndices[i][0],
                         {(int*)pos.getData(), pos.getSize()});
         ASSERT_ARRAY_EQ(expectedIndices[i][1],

--- a/test/test_tensors.cpp
+++ b/test/test_tensors.cpp
@@ -43,18 +43,18 @@ std::vector<std::vector<ModeType>> generateModeTypes(size_t order) {
   return levels;
 }
 
-std::vector<std::vector<int>> generateDimensionOrders(size_t order) {
-  std::vector<int> dimOrder(order);
+std::vector<std::vector<int>> generateModeOrders(size_t order) {
+  std::vector<int> modeOrder(order);
   for (size_t i = 0; i < order; ++i) {
-    dimOrder[i] = i;
+    modeOrder[i] = i;
   }
 
-  std::vector<std::vector<int>> dimOrders;
+  std::vector<std::vector<int>> modeOrders;
   do {
-    dimOrders.push_back(dimOrder);
-  } while (std::next_permutation(dimOrder.begin(), dimOrder.end()));
+    modeOrders.push_back(modeOrder);
+  } while (std::next_permutation(modeOrder.begin(), modeOrder.end()));
 
-  return dimOrders;
+  return modeOrders;
 }
 
 TensorData<double> da_data() {

--- a/test/test_tensors.h
+++ b/test/test_tensors.h
@@ -16,7 +16,7 @@ namespace taco {
 namespace test {
 
 std::vector<std::vector<ModeType>> generateModeTypes(size_t order);
-std::vector<std::vector<int>> generateDimensionOrders(size_t order);
+std::vector<std::vector<int>> generateModeOrders(size_t order);
 
 template <typename T>
 struct TensorData {

--- a/tools/taco.cpp
+++ b/tools/taco.cpp
@@ -83,9 +83,9 @@ static void printUsageInfo() {
   cout << endl;
   cout << "Options:" << endl;
   printFlag("d=<var/tensor>:<size>",
-            "Specify the size of tensor dimensions. This can be done by either "
-            "specifying the size of index variables, or by specifying the size "
-            "of tensor dimensions. All sizes defaults to 42. "
+            "Specify the dimension of tensor modes. This can be done by either "
+            "specifying the dimension of index variables, or by specifying the "
+            "dimension of tensor modes. All dimensions default to 42. "
             "Examples: i:5, j:100, b:5, A:10,10.");
   cout << endl;
   printFlag("f=<tensor>:<format>",
@@ -231,7 +231,7 @@ int main(int argc, char* argv[]) {
       string tensorName = descriptor[0];
       string formatString = descriptor[1];
       std::vector<ModeType> modeTypes;
-      std::vector<int> dimensionOrder;
+      std::vector<int> modeOrder;
       for (size_t i = 0; i < formatString.size(); i++) {
         switch (formatString[i]) {
           case 'd':
@@ -244,16 +244,16 @@ int main(int argc, char* argv[]) {
             return reportError("Incorrect format descriptor", 3);
             break;
         }
-        dimensionOrder.push_back(i);
+        modeOrder.push_back(i);
       }
       if (descriptor.size() > 2) {
-        std::vector<std::string> dims = util::split(descriptor[2], ",");
-        dimensionOrder.clear();
-        for (const auto dim : dims) {
-          dimensionOrder.push_back(std::stoi(dim));
+        std::vector<std::string> modes = util::split(descriptor[2], ",");
+        modeOrder.clear();
+        for (const auto mode : modes) {
+          modeOrder.push_back(std::stoi(mode));
         }
       }
-      formats.insert({tensorName, Format(modeTypes, dimensionOrder)});
+      formats.insert({tensorName, Format(modeTypes, modeOrder)});
     }
     else if ("-d" == argName) {
       vector<string> descriptor = util::split(argValue, ":");

--- a/tools/taco.cpp
+++ b/tools/taco.cpp
@@ -199,7 +199,7 @@ int main(int argc, char* argv[]) {
 
   string exprStr;
   map<string,Format> formats;
-  map<string,std::vector<int>> tensorsSize;
+  map<string,std::vector<int>> tensorsDimensions;
   map<string,taco::util::FillMethod> tensorsFill;
   map<string,string> inputFilenames;
   map<string,string> outputFilenames;
@@ -263,7 +263,7 @@ int main(int argc, char* argv[]) {
       for (size_t j=0; j<dimensions.size(); j++ ) {
         tensorDimensions.push_back(std::stoi(dimensions[j]));
       }
-      tensorsSize.insert({tensorName, tensorDimensions});
+      tensorsDimensions.insert({tensorName, tensorDimensions});
 
     }
     else if ("-c" == argName) {
@@ -437,7 +437,7 @@ int main(int argc, char* argv[]) {
   }
 
   TensorBase tensor;
-  parser::Parser parser(exprStr, formats, tensorsSize, loadedTensors, 42);
+  parser::Parser parser(exprStr, formats, tensorsDimensions, loadedTensors, 42);
   try {
     parser.parse();
     tensor = parser.getResultTensor();
@@ -497,7 +497,7 @@ int main(int argc, char* argv[]) {
       try {
         auto operands = parser.getTensors();
         operands.erase(parser.getResultTensor().getName());
-        parser::Parser parser2(exprStr, formats, tensorsSize,
+        parser::Parser parser2(exprStr, formats, tensorsDimensions,
                                operands, 42);
         parser2.parse();
         kernelTensor = parser2.getResultTensor();


### PR DESCRIPTION
I have renamed all uses of the word dimension in variable naming schemes to be mode, as described in #105. This affects the IR and taco_tensor_t.h, as well as several internal and user-facing variable names and function names. This is an initial pass to make my fix of #106 easier and not change as much all at once.

I have renamed all applicable uses of the word "size" to be "dimension”. I did not unify the meaning of the word “size” because that would be too complicated and not necessarily helpful. To see what I mean, try `pcregrep -r --include '.*\.h$' --include '.*\.c$' --include '.*\.cpp$' '\b.*[sS][iI][zZ][eE]\b(?<!size)(?<!getSize)' .`