### PR TITLE
Pja/threadsafetmps

### DIFF
--- a/include/taco/util/env.h
+++ b/include/taco/util/env.h
@@ -22,22 +22,31 @@ inline std::string getFromEnv(std::string flag, std::string dflt) {
 
 inline std::string getTmpdir() {
   // use POSIX logic for finding a temp dir
-  auto tmpdir = getFromEnv("TMPDIR", "/tmp/");
-  
+  auto tmpdirtemplate = getFromEnv("TMPDIR", "/tmp/");
+
   // if the directory does not have a trailing slash, add one
-  if (tmpdir.back() != '/') {
-    tmpdir += '/';
+  if (tmpdirtemplate.back() != '/') {
+    tmpdirtemplate += '/';
   }
-  
+
   // ensure it is an absolute path
-   taco_uassert(tmpdir.front() == '/') <<
+   taco_uassert(tmpdirtemplate.front() == '/') <<
     "The TMPDIR environment variable must be an absolute path";
 
-  taco_uassert(access(tmpdir.c_str(), W_OK) == 0) <<
+  taco_uassert(access(tmpdirtemplate.c_str(), W_OK) == 0) <<
     "Unable to write to temporary directory for code generation. "
     "Please set the environment variable TMPDIR to somewhere writable";
 
-  return tmpdir;
+  // ensure that we use a taco tmpdir unique to this process.
+
+  tmpdirtemplate += "taco_tmp_XXXXXX";
+  char tmpdir[tmpdirtemplate.length() + 1]
+  std::strcpy(tmpdir, tmpdirtemplate.c_str());
+  tmpdir = mkdtemp(tmpdir);
+  taco_uassert(tmpdir != NULL) <<
+    "Unable to create taco temporary directory for code generation. Please set"
+    "the environment variable TMPDIR to somewhere searchable and writable";
+  return std::string(tmpdir);
 }
 
 }}

--- a/include/taco/util/env.h
+++ b/include/taco/util/env.h
@@ -25,7 +25,7 @@ inline std::string getFromEnv(std::string flag, std::string dflt) {
 inline std::string getTmpdir() {
   if (cachedtmpdir == ""){
     // use posix logic for finding a temp dir
-    auto tmpdir = getFromEnv("tmpdir", "/tmp/");
+    auto tmpdir = getFromEnv("TMPDIR", "/tmp/");
 
     // if the directory does not have a trailing slash, add one
     if (tmpdir.back() != '/') {
@@ -60,10 +60,8 @@ inline std::string getTmpdir() {
 
     //cleanup unless we are in debug mode
     #ifndef TACO_DEBUG
-      printf("FOOFODODOD\n");
       atexit(cachedtmpdirCleanup);
     #endif
-    printf("barbarwobble%s\n", cachedtmpdir.c_str());
   }
   return cachedtmpdir;
 }

--- a/include/taco/util/env.h
+++ b/include/taco/util/env.h
@@ -11,6 +11,7 @@ namespace util {
 std::string getFromEnv(std::string flag, std::string dflt);
 std::string getTmpdir();
 extern std::string cachedtmpdir;
+extern void cachedtmpdirCleanup(void);
 
 inline std::string getFromEnv(std::string flag, std::string dflt) {
   char const *ret = getenv(flag.c_str());
@@ -23,8 +24,8 @@ inline std::string getFromEnv(std::string flag, std::string dflt) {
 
 inline std::string getTmpdir() {
   if (cachedtmpdir == ""){
-    // use POSIX logic for finding a temp dir
-    auto tmpdir = getFromEnv("TMPDIR", "/tmp/");
+    // use posix logic for finding a temp dir
+    auto tmpdir = getFromEnv("tmpdir", "/tmp/");
 
     // if the directory does not have a trailing slash, add one
     if (tmpdir.back() != '/') {
@@ -56,6 +57,13 @@ inline std::string getTmpdir() {
     }
 
     cachedtmpdir = tacotmpdir;
+
+    //cleanup unless we are in debug mode
+    #ifndef TACO_DEBUG
+      printf("FOOFODODOD\n");
+      atexit(cachedtmpdirCleanup);
+    #endif
+    printf("barbarwobble%s\n", cachedtmpdir.c_str());
   }
   return cachedtmpdir;
 }

--- a/src/util/env.cpp
+++ b/src/util/env.cpp
@@ -1,0 +1,7 @@
+#include "taco/util/env.h"
+
+namespace taco {
+namespace util {
+
+std::string cachedtmpdir = "";
+}}

--- a/src/util/env.cpp
+++ b/src/util/env.cpp
@@ -22,6 +22,5 @@ void cachedtmpdirCleanup(void) {
     taco_uassert(rv == 0) <<
       "Unable to create cleanup taco temporary directory. Sorry.";
   }
-  printf("Fooooooo\n");
 }
 }}

--- a/src/util/env.cpp
+++ b/src/util/env.cpp
@@ -1,7 +1,27 @@
 #include "taco/util/env.h"
+#include <ftw.h>
+#include <unistd.h>
+#include <stdio.h>
 
 namespace taco {
 namespace util {
 
 std::string cachedtmpdir = "";
+
+int unlink_cb(const char *fpath, const struct stat *sb, int typeflag, struct FTW *ftwbuf)
+{
+    int rv = remove(fpath);
+    taco_uassert(rv == 0) <<
+      "Unable to create cleanup taco temporary directory. Sorry.";
+    return rv;
+}
+
+void cachedtmpdirCleanup(void) {
+  if (cachedtmpdir != ""){
+    int rv = nftw(cachedtmpdir.c_str(), unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
+    taco_uassert(rv == 0) <<
+      "Unable to create cleanup taco temporary directory. Sorry.";
+  }
+  printf("Fooooooo\n");
+}
 }}


### PR DESCRIPTION
This pull request add "process-safe" temporary directory semantics. each taco process will now create a unique temporary directory to hold temporary files. The directories will be deleted at program exit unless the TACO_DEBUG flag is set (unless this is a debug build).