### PR TITLE
Simple Transpose

### DIFF
--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -17,6 +17,8 @@
 #include "taco/storage/index.h"
 #include "taco/storage/array.h"
 #include "taco/storage/array_util.h"
+#include "taco/util/name_generator.h"
+
 
 
 namespace taco {
@@ -257,6 +259,25 @@ public:
     taco_uassert(tensor.getComponentType() == type<CType>()) <<
         "Assigning TensorBase with " << tensor.getComponentType() <<
         " components to a Tensor<" << type<CType>() << ">";
+  }
+
+  /// Simple transpose that packs a new tensor from the values in the current tensor
+  Tensor<CType> transpose(std::string name, std::vector<int> dimensions) const {
+    return transpose(name, dimensions, getFormat());
+  }
+  Tensor<CType> transpose(std::vector<int> dimensions) const {
+    return transpose(util::uniqueName('A'), dimensions, getFormat());
+  }
+  Tensor<CType> transpose(std::vector<int> dimensions, Format format) const {
+    return transpose(util::uniqueName('A'), dimensions, format);
+  }
+  Tensor<CType> transpose(std::string name, std::vector<int> dimensions, Format format) const {
+    Tensor<CType> newTensor(name, getComponentType(), dimensions, format);
+    for (std::pair<std::vector<int>,CType>& value : this) {
+      newTensor.insert(value.first, value.second);
+    }
+    newTensor.pack();
+    return newTensor;
   }
 
   class const_iterator {

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -262,19 +262,29 @@ public:
   }
 
   /// Simple transpose that packs a new tensor from the values in the current tensor
-  Tensor<CType> transpose(std::string name, std::vector<int> dimensions) const {
-    return transpose(name, dimensions, getFormat());
+  Tensor<CType> transpose(std::string name, std::vector<int> newModeOrdering) const {
+    return transpose(name, newModeOrdering, getFormat());
   }
-  Tensor<CType> transpose(std::vector<int> dimensions) const {
-    return transpose(util::uniqueName('A'), dimensions, getFormat());
+  Tensor<CType> transpose(std::vector<int> newModeOrdering) const {
+    return transpose(util::uniqueName('A'), newModeOrdering);
   }
-  Tensor<CType> transpose(std::vector<int> dimensions, Format format) const {
-    return transpose(util::uniqueName('A'), dimensions, format);
+  Tensor<CType> transpose(std::vector<int> newModeOrdering, Format format) const {
+    return transpose(util::uniqueName('A'), newModeOrdering, format);
   }
-  Tensor<CType> transpose(std::string name, std::vector<int> dimensions, Format format) const {
-    Tensor<CType> newTensor(name, getComponentType(), dimensions, format);
-    for (std::pair<std::vector<int>,CType>& value : this) {
-      newTensor.insert(value.first, value.second);
+  Tensor<CType> transpose(std::string name, std::vector<int> newModeOrdering, Format format) const {
+    // Reorder dimensions to match new mode ordering
+    std::vector<int> newDimensions;
+    for (int mode : newModeOrdering) {
+      newDimensions.push_back(getDimensions()[mode]);
+    }
+
+    Tensor<CType> newTensor(name, newDimensions, format);
+    for (const std::pair<std::vector<int>,CType>& value : *this) {
+      std::vector<int> newCoordinate;
+      for (int mode : newModeOrdering) {
+        newCoordinate.push_back(value.first[mode]);
+      }
+      newTensor.insert(newCoordinate, value.second);
     }
     newTensor.pack();
     return newTensor;

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -20,7 +20,6 @@
 #include "taco/util/name_generator.h"
 
 
-
 namespace taco {
 
 /// TensorBase is the super-class for all tensors. You can use it directly to

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -852,5 +852,4 @@ void packOperands(const TensorBase& tensor) {
     operand.pack();
   }
 }
-
 }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -852,4 +852,5 @@ void packOperands(const TensorBase& tensor) {
     operand.pack();
   }
 }
+  
 }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -852,5 +852,5 @@ void packOperands(const TensorBase& tensor) {
     operand.pack();
   }
 }
-  
+
 }

--- a/test/tensor-tests.cpp
+++ b/test/tensor-tests.cpp
@@ -1,5 +1,6 @@
 #include "test.h"
 #include "taco/tensor.h"
+#include "test_tensors.h"
 
 #include <vector>
 #include "taco/util/collections.h"
@@ -61,4 +62,35 @@ TEST(tensor, duplicates) {
     ASSERT_TRUE(util::contains(vals, val.first));
     ASSERT_EQ(vals.at(val.first), val.second);
   }
+}
+
+TEST(tensor, transpose) {
+  TensorData<double> testData = TensorData<double>({5, 3, 2}, {
+    {{0,0,0}, 0.0},
+    {{0,0,1}, 1.0},
+    {{0,1,0}, 2.0},
+    {{0,1,1}, 3.0},
+    {{2,0,0}, 4.0},
+    {{2,0,1}, 5.0},
+    {{4,0,0}, 6.0},
+  });
+  TensorData<double> transposedTestData = TensorData<double>({2, 5, 3}, {
+    {{0,0,0}, 0.0},
+    {{1,0,0}, 1.0},
+    {{0,0,1}, 2.0},
+    {{1,0,1}, 3.0},
+    {{0,2,0}, 4.0},
+    {{1,2,0}, 5.0},
+    {{0,4,0}, 6.0},
+  });
+
+  Tensor<double> tensor = testData.makeTensor("a", Format({Sparse, Dense, Sparse}, {1, 0, 2}));
+  tensor.pack();
+  Tensor<double> transposedTensor = transposedTestData.makeTensor("b", Format({Sparse, Dense, Sparse}, {1, 0, 2}));
+  transposedTensor.pack();
+  ASSERT_TRUE(equals(tensor.transpose("b", {2,0,1}), transposedTensor));
+
+  Tensor<double> transposedTensor2 = transposedTestData.makeTensor("b", Format({Sparse, Sparse, Dense}, {2, 1, 0}));
+  transposedTensor2.pack();
+  ASSERT_TRUE(equals(tensor.transpose("b", {2,0,1}, Format({Sparse, Sparse, Dense}, {2, 1, 0})), transposedTensor2));
 }

--- a/test/tensor-tests.cpp
+++ b/test/tensor-tests.cpp
@@ -88,10 +88,10 @@ TEST(tensor, transpose) {
   tensor.pack();
   Tensor<double> transposedTensor = transposedTestData.makeTensor("b", Format({Sparse, Dense, Sparse}, {1, 0, 2}));
   transposedTensor.pack();
-  ASSERT_TRUE(equals(tensor.transpose("b", {2,0,1}), transposedTensor));
+  ASSERT_TRUE(equals(tensor.transpose({2,0,1}), transposedTensor));
 
   Tensor<double> transposedTensor2 = transposedTestData.makeTensor("b", Format({Sparse, Sparse, Dense}, {2, 1, 0}));
   transposedTensor2.pack();
-  ASSERT_TRUE(equals(tensor.transpose("b", {2,0,1}, Format({Sparse, Sparse, Dense}, {2, 1, 0})), transposedTensor2));
-  ASSERT_TRUE(equals(tensor.transpose("b", {0,1,2}), tensor));
+  ASSERT_TRUE(equals(tensor.transpose({2,0,1}, Format({Sparse, Sparse, Dense}, {2, 1, 0})), transposedTensor2));
+  ASSERT_TRUE(equals(tensor.transpose({0,1,2}), tensor));
 }

--- a/test/tensor-tests.cpp
+++ b/test/tensor-tests.cpp
@@ -93,4 +93,5 @@ TEST(tensor, transpose) {
   Tensor<double> transposedTensor2 = transposedTestData.makeTensor("b", Format({Sparse, Sparse, Dense}, {2, 1, 0}));
   transposedTensor2.pack();
   ASSERT_TRUE(equals(tensor.transpose("b", {2,0,1}, Format({Sparse, Sparse, Dense}, {2, 1, 0})), transposedTensor2));
+  ASSERT_TRUE(equals(tensor.transpose("b", {0,1,2}), tensor));
 }


### PR DESCRIPTION
#82 Simple transpose implementation for tensors by creating a new tensor from the values in a current tensor. This allows for arbitrarily reordering modes or changing the format of the output tensor. I am still working on a more efficient transpose algorithm that reuses structure from the input tensor.