### PR TITLE
handle non-exhausted lp in subtraction

### DIFF
--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -265,6 +265,8 @@ public:
   Literal(std::complex<float>);
   Literal(std::complex<double>);
 
+  static IndexExpr zero(Datatype);
+
   /// Returns the literal value.
   template <typename T> T getVal() const;
 

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -541,6 +541,27 @@ Literal::Literal(std::complex<float> val) : Literal(new LiteralNode(val)) {
 Literal::Literal(std::complex<double> val) : Literal(new LiteralNode(val)) {
 }
 
+IndexExpr Literal::zero(Datatype type) {
+  switch (type.getKind()) {
+    case Datatype::Bool:        return Literal(false);
+    case Datatype::UInt8:       return Literal(uint8_t(0));
+    case Datatype::UInt16:      return Literal(uint16_t(0));
+    case Datatype::UInt32:      return Literal(uint32_t(0));
+    case Datatype::UInt64:      return Literal(uint64_t(0));
+    case Datatype::Int8:        return Literal(int8_t(0));
+    case Datatype::Int16:       return Literal(int16_t(0));
+    case Datatype::Int32:       return Literal(int32_t(0));
+    case Datatype::Int64:       return Literal(int64_t(0));
+    case Datatype::Float32:     return Literal(float(0.0));
+    case Datatype::Float64:     return Literal(double(0.0));
+    case Datatype::Complex64:   return Literal(std::complex<float>());
+    case Datatype::Complex128:  return Literal(std::complex<double>());
+    default:                    taco_ierror << "unsupported type";
+  };
+
+  return IndexExpr();
+}
+
 template <typename T> T Literal::getVal() const {
   return getNode(*this)->getVal<T>();
 }

--- a/src/lower/merge_lattice_old.cpp
+++ b/src/lower/merge_lattice_old.cpp
@@ -438,7 +438,14 @@ MergeLattice mergeUnion(MergeLattice a, MergeLattice b) {
   util::append(allPoints, a.getPoints());
 
   // Append the merge points of b
-  util::append(allPoints, b.getPoints());
+  for (auto &bLatticePoint : b.getPoints()) {
+    Datatype type = bLatticePoint.getExpr().getDataType();
+    IndexExpr expr = new op(Literal::zero(type), bLatticePoint.getExpr());
+    allPoints.push_back(MergePoint(bLatticePoint.getIterators(),
+                        bLatticePoint.getRangers(),
+                        bLatticePoint.getMergers(),
+                        expr));
+  }
 
   taco_iassert(allPoints.size() > 0) <<
       "A lattice must have at least one point";

--- a/test/tests-expr.cpp
+++ b/test/tests-expr.cpp
@@ -39,6 +39,27 @@ TEST(expr, accumulate) {
   ASSERT_TRUE(equals(expected,a)) << endl << expected << endl << endl << a;
 }
 
+TEST(expr, sub) {
+  Tensor<double> a("a", {2}, Format({Sparse}, {0}));
+  Tensor<double> b("b", {2}, Format({Sparse}, {0}));
+  Tensor<double> c("c", {2}, Format({Dense}, {0}));
+  Tensor<double> expected("c_soln", {2}, Format({Dense}, {0}));
+
+  a.insert({0}, 1.0);
+  a.pack();
+
+  b.insert({1}, 1.0);
+  b.pack();
+
+  expected.insert({0}, 1.0);
+  expected.insert({1}, -1.0);
+  expected.pack();
+
+  c(i) = a(i) - b(i);
+  c.evaluate();
+  ASSERT_TRUE(equals(expected, c));
+}
+
 TEST(expr, simplify_neg) {
   Type mat(type<double>(), {3,3});
   TensorVar B("B", mat);


### PR DESCRIPTION
Taco does not handle subtraction when there are non exhausted points in the merge lattice.
It generates code looking like this
```
// compute `a - b'
if (both_a_and_b())
   t = a - b
else if (just_a())
   t = a
else
   // should be `t = -b'
   t = b
```