### PR TITLE
CUDA Code Generation Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,13 @@ Build taco using CMake 2.8.3 or greater:
     cmake -DCMAKE_BUILD_TYPE=Release ..
     make -j8
   
-To build taco for NVIDIA CUDA (must be preinstalled), use the following cmake line with the instructions above:
+To build taco for NVIDIA CUDA, use the following cmake line with the instructions above:
 
     cmake -DCMAKE_BUILD_TYPE=Release -DCUDA=ON ..
+
+Please also make sure that you have CUDA installed properly and that the following environment variables are set correctly:
+
+If you do not have CUDA installed, you can still use the taco cli to generate CUDA code with the -cuda flag
 
 Run the test suite:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ To build taco for NVIDIA CUDA, use the following cmake line with the instruction
     cmake -DCMAKE_BUILD_TYPE=Release -DCUDA=ON ..
 
 Please also make sure that you have CUDA installed properly and that the following environment variables are set correctly:
-
+    
+    PATH=/usr/local/cuda-10.0/bin:$PATH
+    LD_LIBRARY_PATH=/usr/local/cuda-[CUDA-VERSION]/lib64:$LD_LIBRARY_PATH
+    LIBRARY_PATH=/usr/local/cuda-[CUDA-VERSION]/lib64:$LIBRARY_PATH
+    
 If you do not have CUDA installed, you can still use the taco cli to generate CUDA code with the -cuda flag
 
 Run the test suite:

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ To build taco for NVIDIA CUDA, use the following cmake line with the instruction
 
 Please also make sure that you have CUDA installed properly and that the following environment variables are set correctly:
     
-    PATH=/usr/local/cuda-10.0/bin:$PATH
-    LD_LIBRARY_PATH=/usr/local/cuda-[CUDA-VERSION]/lib64:$LD_LIBRARY_PATH
-    LIBRARY_PATH=/usr/local/cuda-[CUDA-VERSION]/lib64:$LIBRARY_PATH
+    export PATH=/usr/local/cuda/bin:$PATH
+    export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+    export LIBRARY_PATH=/usr/local/cuda/lib64:$LIBRARY_PATH
     
 If you do not have CUDA installed, you can still use the taco cli to generate CUDA code with the -cuda flag
 

--- a/include/taco/cuda.h
+++ b/include/taco/cuda.h
@@ -11,10 +11,14 @@
 
 namespace taco {
 /// Functions used by taco to interface with CUDA (especially unified memory)
-/// Check if should use CUDA codegen (built and not disabled by user)
+/// Check if should use CUDA codegen
 bool should_use_CUDA_codegen();
-/// Disable CUDA codgen
-bool disable_CUDA_codegen();
+/// Check if should use CUDA unified memory
+bool should_use_CUDA_unified_memory();
+/// Enable/Disable CUDA codegen
+void set_CUDA_codegen_enabled(bool enabled);
+/// Enable/Disable CUDA unified memory
+void set_CUDA_unified_memory_enabled(bool enabled);
 /// Gets default compiler flags by checking current gpu model
 std::string get_default_CUDA_compiler_flags();
 /// Allocates memory using unified memory (and checks for errors)

--- a/include/taco/util/collections.h
+++ b/include/taco/util/collections.h
@@ -160,7 +160,7 @@ template <typename T>
 T* copyToArray(const std::vector<T>& vec) {
   size_t size = vec.size() * sizeof(T);
   T* array;
-  if (should_use_CUDA_codegen()) {
+  if (should_use_CUDA_unified_memory()) {
     array = static_cast<T*>(cuda_unified_alloc(size));
   }
   else {

--- a/src/codegen/codegen_cuda.cpp
+++ b/src/codegen/codegen_cuda.cpp
@@ -32,7 +32,7 @@ const string cHeaders =
   "#include <stdlib.h>\n"
   "#include <stdint.h>\n"
   "#include <math.h>\n"
-  "#include <complex>\n"
+  "#include <thrust/complex.h>\n"
   "#define TACO_MIN(_a,_b) ((_a) < (_b) ? (_a) : (_b))\n"
   "#define TACO_MAX(_a,_b) ((_a) > (_b) ? (_a) : (_b))\n"
   "#ifndef TACO_TENSOR_T_DEFINED\n"
@@ -270,10 +270,10 @@ string toCType(Datatype type, bool is_ptr) {
   stringstream ret;
   if (type.isComplex()) {
       if (type.getKind() == Complex64) {
-          ret << "std::complex<float>";
+          ret << "thrust::complex<float>";
       }
       else if (type.getKind() == Complex128) {
-          ret << "std::complex<double>";
+          ret << "thrust::complex<double>";
       }
       else {
           taco_ierror;
@@ -1023,11 +1023,11 @@ void CodeGen_CUDA::visit(const Literal* op) {
 
     if(op->type.getKind() == Complex64) {
       std::complex<float> val = op->getValue<std::complex<float>>();
-      stream << "std::complex<float>(" << val.real() << ", " << val.imag() << ")";
+      stream << "thrust::complex<float>(" << val.real() << ", " << val.imag() << ")";
     }
     else if(op->type.getKind() == Complex128) {
       std::complex<double> val = op->getValue<std::complex<double>>();
-      stream << "std::complex<double>(" << val.real() << ", " << val.imag() << ")";
+      stream << "thrust::complex<double>(" << val.real() << ", " << val.imag() << ")";
     }
     else {
       taco_ierror << "Undefined type in IR";

--- a/src/cuda.cpp
+++ b/src/cuda.cpp
@@ -8,14 +8,23 @@
 using namespace std;
 namespace taco {
 /// Functions used by taco to interface with CUDA (especially unified memory)
-static bool enable_CUDA_codegen = true;
+static bool CUDA_codegen_enabled = CUDA_BUILT;
+static bool CUDA_unified_memory_enabled = CUDA_BUILT;
 bool should_use_CUDA_codegen() {
-  return CUDA_BUILT && enable_CUDA_codegen;
+  return CUDA_codegen_enabled;
 }
 
-bool disable_CUDA_codegen() {
-  enable_CUDA_codegen = false;
-  return CUDA_BUILT;
+bool should_use_CUDA_unified_memory() {
+  return CUDA_unified_memory_enabled;
+}
+
+void set_CUDA_codegen_enabled(bool enabled) {
+  CUDA_codegen_enabled = enabled;
+}
+
+void set_CUDA_unified_memory_enabled(bool enabled) {
+  taco_iassert(CUDA_BUILT);
+  CUDA_unified_memory_enabled = enabled;
 }
 
 string get_default_CUDA_compiler_flags() {

--- a/src/lower/lower_old.cpp
+++ b/src/lower/lower_old.cpp
@@ -331,8 +331,7 @@ static vector<Stmt> lower(const Target&      target,
                           const IndexVar&    indexVar,
                           IndexExpr          indexExpr,
                           const set<Access>& exhausted,
-                          Ctx&           ctx,
-                          bool addedDeviceLoop = false) {
+                          Ctx&           ctx) {
   IterationGraph iterationGraph = ctx.iterationGraph;
 
   MergeLattice lattice = MergeLattice::make(indexExpr, indexVar,
@@ -634,7 +633,7 @@ static vector<Stmt> lower(const Target&      target,
             // level with the temporary
             lqexpr = replace(lqexpr, {{childExpr,taco::Access(t)}});
           }
-          auto childCode = lower(childTarget, child, childExpr, exhausted, ctx, addedDeviceLoop || !emitMerge);
+          auto childCode = lower(childTarget, child, childExpr, exhausted, ctx);
           util::append(caseBody, childCode);
         }
 
@@ -674,7 +673,7 @@ static vector<Stmt> lower(const Target&      target,
             childVars.push_back(childVar);
           }
 
-          auto childCode = lower(childTarget, child, childExpr, exhausted, ctx, addedDeviceLoop || !emitMerge);
+          auto childCode = lower(childTarget, child, childExpr, exhausted, ctx);
           util::append(caseBody, childCode);
         }
 
@@ -842,7 +841,7 @@ static vector<Stmt> lower(const Target&      target,
         Iterator iter = lpRangeIterators[0];
         return For::make(iter.getIteratorVar(), iterFunc.getResults()[0],
                          iterFunc.getResults()[1], 1ll, mergeLoopBody,
-                         doParallelize(indexVar, iter.getTensor(), ctx), !addedDeviceLoop && doParallelize(indexVar, iter.getTensor(), ctx) != LoopKind::Serial && !target.tensor.type().isComplex());
+                         doParallelize(indexVar, iter.getTensor(), ctx), doParallelize(indexVar, iter.getTensor(), ctx) != LoopKind::Serial);
       }();
     loops.push_back(mergeLoop);
   }

--- a/src/storage/array.cpp
+++ b/src/storage/array.cpp
@@ -25,7 +25,7 @@ struct Array::Content : util::Uncopyable {
         // do nothing
         break;
       case Free:
-        if (should_use_CUDA_codegen()) {
+        if (should_use_CUDA_unified_memory()) {
           cuda_unified_free(data);
         }
         else {
@@ -210,7 +210,7 @@ std::ostream& operator<<(std::ostream& os, Array::Policy policy) {
 }
 
 Array makeArray(Datatype type, size_t size) {
-  if (should_use_CUDA_codegen()) {
+  if (should_use_CUDA_unified_memory()) {
     return Array(type, cuda_unified_alloc(size * type.getNumBytes()), size, Array::Free);
   }
   else {

--- a/src/storage/file_io_rb.cpp
+++ b/src/storage/file_io_rb.cpp
@@ -35,14 +35,14 @@ void readFile(std::istream &hbfile,
              &ptrfmt, &indfmt, &valfmt, &rhsfmt);
 
   if (*colptr) {
-    if (should_use_CUDA_codegen()) {
+    if (should_use_CUDA_unified_memory()) {
       cuda_unified_free(*colptr);
     }
     else {
       free(*colptr);
     }
   }
-  if (should_use_CUDA_codegen()) {
+  if (should_use_CUDA_unified_memory()) {
     (*colptr) = (int*)cuda_unified_alloc((*ncol+1) * sizeof(int));
   }
   else {
@@ -51,14 +51,14 @@ void readFile(std::istream &hbfile,
   readIndices(hbfile, ptrcrd, *colptr);
 
   if (*rowind) {
-    if (should_use_CUDA_codegen()) {
+    if (should_use_CUDA_unified_memory()) {
       cuda_unified_free(*rowind);
     }
     else {
       free(*rowind);
     }
   }
-  if (should_use_CUDA_codegen()) {
+  if (should_use_CUDA_unified_memory()) {
     (*rowind) = (int*)cuda_unified_alloc(nnzero * sizeof(int));
   }
   else {
@@ -67,7 +67,7 @@ void readFile(std::istream &hbfile,
   readIndices(hbfile, indcrd, *rowind);
 
   if (*values) {
-    if (should_use_CUDA_codegen()) {
+    if (should_use_CUDA_unified_memory()) {
       cuda_unified_free(*values);
     }
     else {
@@ -75,7 +75,7 @@ void readFile(std::istream &hbfile,
     }
   }
   (*values) = (double*)malloc(nnzero * sizeof(double));
-  if (should_use_CUDA_codegen()) {
+  if (should_use_CUDA_unified_memory()) {
     (*values) = (double*)cuda_unified_alloc(nnzero * sizeof(double));
   }
   else {

--- a/src/taco_tensor_t.cpp
+++ b/src/taco_tensor_t.cpp
@@ -8,7 +8,7 @@ void free_mem(void *ptr);
 
 // Allocates from unified memory or using malloc depending on what memory is being used
 void * alloc_mem(size_t size) {
-  if (taco::should_use_CUDA_codegen()) {
+  if (taco::should_use_CUDA_unified_memory()) {
     return taco::cuda_unified_alloc(size);
   }
   else {
@@ -18,7 +18,7 @@ void * alloc_mem(size_t size) {
 
 // Free from unified memory or using free depending on what memory is being used
 void free_mem(void *ptr) {
-  if (taco::should_use_CUDA_codegen()) {
+  if (taco::should_use_CUDA_unified_memory()) {
     taco::cuda_unified_free(ptr);
   }
   else {

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -46,7 +46,7 @@ bool Datatype::isComplex() const {
   
 Datatype max_type(Datatype a, Datatype b) {
   taco_iassert(!a.isBool() && !b.isBool()) <<
-  "Can't do arithmetic onmax_type booleans.";
+  "Can't do arithmetic on booleans.";
   
   if (a == b) {
     return a;

--- a/tools/taco.cpp
+++ b/tools/taco.cpp
@@ -182,10 +182,8 @@ static void printUsageInfo() {
   printFlag("print-nocolor", "Print without colors.");
   cout << endl;
   printFlag("new-lower", "Use the new lowering machinery.");
-#if CUDA_BUILT
   cout << endl;
-  printFlag("no-gpu", "Generate CPU-only code (defaults to false)");
-#endif
+  printFlag("cuda", "Generate CUDA code for NVIDIA GPUs");
 }
 
 static int reportError(string errorMessage, int errorCode) {
@@ -259,6 +257,7 @@ int main(int argc, char* argv[]) {
 
   bool color               = true;
   bool readKernels         = false;
+  bool cuda                = false;
 
   taco::util::TimeResults compileTime;
   taco::util::TimeResults assembleTime;
@@ -507,8 +506,8 @@ int main(int argc, char* argv[]) {
     else if ("-new-lower" == argName) {
       newLower = true;
     }
-    else if ("-no-gpu" == argName) {
-      disable_CUDA_codegen();
+    else if ("-cuda" == argName) {
+      cuda = true;
     }
     else if ("-print-kernels" == argName) {
       printKernels = true;
@@ -595,6 +594,19 @@ int main(int argc, char* argv[]) {
     if (!util::contains(loadedTensors, tensor.second.getName())) {
       benchmark = false;
     }
+  }
+
+  if (cuda) {
+    if (newLower) {
+      return reportError("CUDA code generation does not yet work with new lowering", 2);
+    }
+    if (!CUDA_BUILT && benchmark) {
+      return reportError("TACO must be built for CUDA (cmake -DCUDA=ON ..) to benchmark", 2);
+    }
+    set_CUDA_codegen_enabled(true);
+  }
+  else {
+    set_CUDA_codegen_enabled(false);
   }
 
   ir::Stmt assemble;
@@ -715,8 +727,17 @@ int main(int argc, char* argv[]) {
       tensor.compileSource(util::toString(kernel));
     }
     else {
-      TOOL_BENCHMARK_TIMER(tensor.compile(computeWithAssemble),
-                           "Compile: ",compileTime);
+      set<old::Property> assembleProperties, computeProperties, evaluateProperties;
+      assembleProperties.insert(old::Assemble);
+      computeProperties.insert(old::Compute);
+      evaluateProperties.insert(old::Assemble);
+      evaluateProperties.insert(old::Compute);
+      assemble = old::lower(tensor.getAssignment(), "assemble", assembleProperties,
+                            tensor.getAllocSize());
+      compute = old::lower(tensor.getAssignment(), "compute", computeProperties,
+                           tensor.getAllocSize());
+      evaluate = old::lower(tensor.getAssignment(), "evaluate", evaluateProperties,
+                            tensor.getAllocSize());
     }
   }
 
@@ -728,10 +749,11 @@ int main(int argc, char* argv[]) {
   }
 
   bool hasPrinted = false;
-  ir::IRPrinter printer(cout, color, true);
+  std::shared_ptr<ir::CodeGen> codegen = ir::CodeGen::init_default(cout, ir::CodeGen::C99Implementation);
+  codegen->setColor(true);
   if (printAssemble) {
     if (assemble.defined()) {
-      printer.print(assemble);
+      codegen->compile(assemble, false);
     }
     else {
       tensor.printAssembleIR(cout,color, true);
@@ -747,7 +769,7 @@ int main(int argc, char* argv[]) {
     }
 
     if (compute.defined()) {
-      printer.print(compute);
+      codegen->compile(compute, false);
     }
     else {
       tensor.printComputeIR(cout, color, true);
@@ -761,7 +783,7 @@ int main(int argc, char* argv[]) {
     if (hasPrinted) {
       cout << endl;
     }
-    printer.print(evaluate);
+    codegen->compile(evaluate, false);
     hasPrinted = true;
     std::cout << std::endl;
   }
@@ -770,10 +792,6 @@ int main(int argc, char* argv[]) {
     if (hasPrinted) {
       cout << endl;
     }
-    
-    std::shared_ptr<ir::CodeGen> codegen = ir::CodeGen::init_default(cout, ir::CodeGen::C99Implementation);
-    codegen->setColor(true);
-
     if (assemble.defined() ) {
       codegen->compile(assemble, false);
       cout << endl << endl;


### PR DESCRIPTION
- Allow generating CUDA code even if taco is not built with CUDA (changes -no-gpu cli flag to -cuda flag)
- Use same parallelization preconditions as generating openmp pragmas
- Updated CUDA complex number support to use thrust/complex.h (preinstalled with CUDA >= 4.0)
(see issue #129  for more updates)
- CLI does not invoke system compiler unless code will be benchmarked