### PR TITLE
Removing TensorBase dependencies from the parser

### DIFF
--- a/include/taco/parser/parser.h
+++ b/include/taco/parser/parser.h
@@ -14,8 +14,10 @@ namespace taco {
 class TensorBase;
 class Format;
 class IndexVar;
+class TensorVar;
 class IndexExpr;
 class Access;
+class Assignment;
 
 namespace parser {
 enum class Token;
@@ -39,6 +41,9 @@ public:
   /// Returns the result (lhs) tensor of the index expression.
   const TensorBase& getResultTensor() const;
 
+  /// Returns the result assignment of the index expression.
+  const Assignment& getAssignment() const;
+
   /// Returns true if the index variable appeared in the expression
   bool hasIndexVar(std::string name) const;
 
@@ -53,6 +58,15 @@ public:
 
   /// Retrieve a map from tensor names to tensors.
   const std::map<std::string,TensorBase>& getTensors() const;
+
+  /// Returns true if the tensor variable appeared in the expression
+  bool hasTensorVar(std::string name) const;
+
+  /// Retrieve the tensor var with the given name
+  const TensorVar& getTensorVar(std::string name) const;
+
+  /// Retrieve a map from tensor names to tensors.
+  const std::map<std::string,TensorVar>& getTensorVars() const;
 
 private:
   struct Content;

--- a/include/taco/parser/parser.h
+++ b/include/taco/parser/parser.h
@@ -28,36 +28,27 @@ enum class Token;
 /// lhs, and taken to be a summation variable otherwise.
 class Parser : public util::Uncopyable {
 public:
-  Parser(std::string expression, const std::map<std::string,Format>& formats,
+  Parser(std::string expression, const std::map<std::string, Format>& formats,
          const std::map<std::string, Datatype>& dataTypes,
-         const std::map<std::string,std::vector<int>>& tensorDimensions,
-         const std::map<std::string,TensorBase>& tensors,
+         const std::map<std::string, std::vector<int>>& tensorDimensions,
+         const std::map<std::string, TensorVar>& tensorVars,
          int defaultDimension=5);
 
   /// Parse the expression.
   /// @throws ParseError if there's a parser error
   void parse();
 
-  /// Returns the result (lhs) tensor of the index expression.
-  const TensorBase& getResultTensor() const;
-
   /// Returns the result assignment of the index expression.
   const Assignment& getAssignment() const;
+
+  /// Returns the result tensorVar of the index expression.
+  const TensorVar& getResultTensorVar() const;
 
   /// Returns true if the index variable appeared in the expression
   bool hasIndexVar(std::string name) const;
 
   /// Retrieve the index variable with the given name
   IndexVar getIndexVar(std::string name) const;
-
-  /// Returns true if the tensor appeared in the expression
-  bool hasTensor(std::string name) const;
-
-  /// Retrieve the tensor with the given name
-  const TensorBase& getTensor(std::string name) const;
-
-  /// Retrieve a map from tensor names to tensors.
-  const std::map<std::string,TensorBase>& getTensors() const;
 
   /// Returns true if the tensor variable appeared in the expression
   bool hasTensorVar(std::string name) const;
@@ -74,7 +65,7 @@ private:
 
   /// assign ::= access '=' expr
   ///          | access '+=' expr
-  TensorBase parseAssign();
+  Assignment parseAssign();
 
   /// expr ::= term {('+' | '-') term}
   IndexExpr parseExpr();

--- a/include/taco/parser/parser.h
+++ b/include/taco/parser/parser.h
@@ -11,7 +11,6 @@
 
 namespace taco {
 
-class TensorBase;
 class Format;
 class IndexVar;
 class TensorVar;

--- a/include/taco/storage/file_io_mtx.h
+++ b/include/taco/storage/file_io_mtx.h
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "taco/format.h"
+#include "taco/storage/storage.h"
 
 namespace taco {
 class TensorBase;
@@ -35,6 +36,28 @@ TensorBase readSparse(std::istream& stream, const Format& format,
 TensorBase readDense(std::istream& stream, const Format& format, 
                      bool symm = false);
 
+/// Read an mtx matrix from a file.
+TensorStorage readToStorageMTX(std::string filename, const ModeFormat& modetype);
+
+/// Read an mtx matrix from a file.
+TensorStorage readToStorageMTX(std::string filename, const Format& format);
+
+/// Read an mtx matrix from a stream.
+TensorStorage readToStorageMTX(std::istream& stream, const ModeFormat& modetype);
+
+/// Read an mtx matrix from a stream.
+TensorStorage readToStorageMTX(std::istream& stream, const Format& format);
+
+TensorStorage readToStorageSparse(std::istream& stream, const ModeFormat& modetype, 
+                                  bool symm = false);
+TensorStorage readToStorageDense(std::istream& stream, const ModeFormat& modetype, 
+                                 bool symm = false);
+
+TensorStorage readToStorageSparse(std::istream& stream, const Format& format, 
+                                  bool symm = false);
+TensorStorage readToStorageDense(std::istream& stream, const Format& format, 
+                                 bool symm = false);
+
 /// Write an mtx matrix to a file.
 void writeMTX(std::string filename, const TensorBase& tensor);
 
@@ -42,6 +65,14 @@ void writeMTX(std::string filename, const TensorBase& tensor);
 void writeMTX(std::ostream& stream, const TensorBase& tensor);
 void writeSparse(std::ostream& stream, const TensorBase& tensor);
 void writeDense(std::ostream& stream, const TensorBase& tensor);
+
+/// Write an mtx matrix to a file.
+void writeFromStorageMTX(std::string filename, const TensorStorage& storage);
+
+/// Write an mtx matrix to a stream.
+void writeFromStorageMTX(std::ostream& stream, const TensorStorage& storage);
+void writeFromStorageSparse(std::ostream& stream, const TensorStorage& storage);
+void writeFromStorageDense(std::ostream& stream, const TensorStorage& storage);
 
 }
 

--- a/include/taco/storage/file_io_rb.h
+++ b/include/taco/storage/file_io_rb.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "taco/format.h"
+#include "taco/storage/storage.h"
 
 namespace taco {
 class TensorBase;
@@ -63,6 +64,25 @@ void writeRB(std::string filename, const TensorBase& tensor);
 
 /// Write an rb matrix to a stream
 void writeRB(std::ostream& stream, const TensorBase& tensor);
+
+
+/// Read an rb matrix from a file.
+TensorStorage readToStorageRB(std::string filename, const ModeFormat& modetype);
+
+/// Read an rb matrix from a file.
+TensorStorage readToStorageRB(std::string filename, const Format& format);
+
+/// Read an rb matrix from a stream
+TensorStorage readToStorageRB(std::istream& stream, const ModeFormat& modetype);
+
+/// Read an rb matrix from a stream
+TensorStorage readToStorageRB(std::istream& stream, const Format& format);
+
+/// Write an rb matrix to a file
+void writeFromStorageRB(std::string filename, const TensorStorage& storage);
+
+/// Write an rb matrix to a stream
+void writeFromStorageRB(std::ostream& stream, const TensorStorage& storage);
 
 }
 #endif

--- a/include/taco/storage/file_io_tns.h
+++ b/include/taco/storage/file_io_tns.h
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "taco/format.h"
+#include "taco/storage/storage.h"
 
 namespace taco {
 class TensorBase;
@@ -25,11 +26,29 @@ TensorBase readTNS(std::istream& stream, const ModeFormat& modetype,
 /// Read a tns tensor from a stream.
 TensorBase readTNS(std::istream& stream, const Format& format, bool pack=true);
 
+/// Read a tns tensor from a file.
+TensorStorage readToStorageTNS(std::string filename, const ModeFormat& modetype);
+
+/// Read a tns tensor from a file.
+TensorStorage readToStorageTNS(std::string filename, const Format& format);
+
+/// Read a tns tensor from a stream.
+TensorStorage readToStorageTNS(std::istream& stream, const ModeFormat& modetype);
+
+/// Read a tns tensor from a stream.
+TensorStorage readToStorageTNS(std::istream& stream, const Format& format);
+
 /// Write a tns tensor to a file.
 void writeTNS(std::string filename, const TensorBase& tensor);
 
 /// Write a tns tensor to a stream.
 void writeTNS(std::ostream& stream, const TensorBase& tensor);
+
+/// Write a tns tensor to a file.
+void writeFromStorageTNS(std::string filename, const TensorBase& tensor);
+
+/// Write a tns tensor to a stream.
+void writeFromStorageTNS(std::ostream& stream, const TensorBase& tensor);
 
 }
 

--- a/include/taco/storage/file_io_tns.h
+++ b/include/taco/storage/file_io_tns.h
@@ -45,10 +45,10 @@ void writeTNS(std::string filename, const TensorBase& tensor);
 void writeTNS(std::ostream& stream, const TensorBase& tensor);
 
 /// Write a tns tensor to a file.
-void writeFromStorageTNS(std::string filename, const TensorBase& tensor);
+void writeFromStorageTNS(std::string filename, const TensorStorage& tensor);
 
 /// Write a tns tensor to a stream.
-void writeFromStorageTNS(std::ostream& stream, const TensorBase& tensor);
+void writeFromStorageTNS(std::ostream& stream, const TensorStorage& tensor);
 
 }
 

--- a/include/taco/storage/storage.h
+++ b/include/taco/storage/storage.h
@@ -242,13 +242,67 @@ private:
   std::shared_ptr<Content> content;
 };
 
-
-
 /// Compare tensor storage objects.
 bool equals(TensorStorage a, TensorStorage b);
 
 /// Print Storage objects to a stream.
 std::ostream& operator<<(std::ostream&, const TensorStorage&);
+
+/// The file formats supported by the taco file readers and writers.
+enum class FileType {
+  /// .tns - The frostt sparse tensor format.  It consists of zero or more
+  ///        comment lines preceded by '#', followed by any number of lines with
+  ///        one coordinate/value per line.  The tensor dimensions are inferred
+  ///        from the largest coordinates.
+  tns,
+
+  /// .mtx - The matrix market matrix format.  It consists of a header
+  ///        line preceded by '%%', zero or more comment lines preceded by '%',
+  ///        a line with the number of rows, the number of columns and the
+  //         number of non-zeroes. For sparse matrix and any number of lines
+  ///        with one coordinate/value per line, and for dense a list of values.
+  mtx,
+
+  /// .ttx - The tensor format derived from matrix market format. It consists
+  ///        with the same header file and coordinates/values list.
+  ttx,
+
+  /// .rb  - The rutherford-boeing sparse matrix format.
+  rb
+};
+
+/// Read a tensor from a file. The file format is inferred from the filename
+/// and the tensor is returned packed by default.
+TensorStorage readToStorage(std::string filename, ModeFormat modeType);
+
+/// Read a tensor from a file. The file format is inferred from the filename
+/// and the tensor is returned packed by default.
+TensorStorage readToStorage(std::string filename, Format format);
+
+/// Read a tensor from a file of the given file format and the tensor is
+/// returned packed by default.
+TensorStorage readToStorage(std::string filename, FileType filetype, ModeFormat modetype);
+
+/// Read a tensor from a file of the given file format and the tensor is
+/// returned packed by default.
+TensorStorage readToStorage(std::string filename, FileType filetype, Format format);
+
+/// Read a tensor from a stream of the given file format. The tensor is returned
+/// packed by default.
+TensorStorage readToStorage(std::istream& stream, FileType filetype, ModeFormat modetype);
+
+/// Read a tensor from a stream of the given file format. The tensor is returned
+/// packed by default.
+TensorStorage readToStorage(std::istream& stream, FileType filetype, Format format);
+
+/// Write a tensor to a file. The file format is inferred from the filename.
+void writeFromStorage(std::string filename, const TensorStorage& storage);
+
+/// Write a tensor to a file in the given file format.
+void writeFromStorage(std::string filename, FileType filetype, const TensorStorage& storage);
+
+/// Write a tensor to a stream in the given file format.
+void writeFromStorage(std::ostream& file, FileType filetype, const TensorStorage& storage);
 
 }
 #endif

--- a/include/taco/storage/storage.h
+++ b/include/taco/storage/storage.h
@@ -30,6 +30,10 @@ public:
   TensorStorage(Datatype componentType, const std::vector<int>& dimensions,
                 Format format);
 
+  /// Construct tensor storage for the given mode format type.
+  TensorStorage(Datatype componentType, const std::vector<int>& dimensions,
+                ModeFormat modeType);
+
   /// Returns the tensor storage format.
   const Format& getFormat() const;
 
@@ -229,7 +233,7 @@ public:
   /// Example usage:
   /// for (auto& value : storage.iterator<int, double>()) { ... }
   template<typename T, typename CType>
-  iterator_wrapper<T,CType> iterator() {
+  iterator_wrapper<T,CType> iterator() const {
     return iterator_wrapper<T,CType>(this);
   }
 

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -247,7 +247,6 @@ public:
   friend std::ostream& operator<<(std::ostream&, const TensorBase&);
 
 private:
-
   struct Content;
   std::shared_ptr<Content> content;
 

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -186,8 +186,18 @@ public:
   /// Assemble the tensor storage, including index and value arrays.
   void assemble();
 
+  /// Assemble the tensor storage, including index and value arrays
+  /// using the given packed arguments (arguments must correspont to
+  /// the tensor Assignments)
+  void assemble(std::vector<void*> arguments);
+
   /// Compute the given expression and put the values in the tensor storage.
   void compute();
+
+  /// Compute the given expression and put the values in the tensor storage
+  /// using the given packed arguments (arguments must correspont to
+  /// the tensor Assignments)
+  void compute(std::vector<void*> arguments);
 
   /// Compile, assemble and compute as needed.
   void evaluate();

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -350,30 +350,6 @@ public:
   void operator=(const IndexExpr& expr) {TensorBase::operator=(expr);}
 };
 
-
-/// The file formats supported by the taco file readers and writers.
-enum class FileType {
-  /// .tns - The frostt sparse tensor format.  It consists of zero or more
-  ///        comment lines preceded by '#', followed by any number of lines with
-  ///        one coordinate/value per line.  The tensor dimensions are inferred
-  ///        from the largest coordinates.
-  tns,
-
-  /// .mtx - The matrix market matrix format.  It consists of a header
-  ///        line preceded by '%%', zero or more comment lines preceded by '%',
-  ///        a line with the number of rows, the number of columns and the
-  //         number of non-zeroes. For sparse matrix and any number of lines
-  ///        with one coordinate/value per line, and for dense a list of values.
-  mtx,
-
-  /// .ttx - The tensor format derived from matrix market format. It consists
-  ///        with the same header file and coordinates/values list.
-  ttx,
-
-  /// .rb  - The rutherford-boeing sparse matrix format.
-  rb
-};
-
 /// Read a tensor from a file. The file format is inferred from the filename
 /// and the tensor is returned packed by default.
 TensorBase read(std::string filename, ModeFormat modeType, bool pack = true);

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -44,7 +44,10 @@ public:
     this->insert({}, val);
     pack();
   }
-  
+
+  /// Create a tensor matching the given TensorVar.
+  TensorBase(TensorVar tensorVar);
+
   /// Create a tensor with the given dimensions. The format defaults to sparse 
   /// in every mode.
   TensorBase(Datatype ctype, std::vector<int> dimensions, 
@@ -234,6 +237,7 @@ public:
   friend std::ostream& operator<<(std::ostream&, const TensorBase&);
 
 private:
+
   struct Content;
   std::shared_ptr<Content> content;
 

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -328,155 +328,22 @@ public:
     return newTensor;
   }
 
-  template<typename T>
-  class const_iterator {
-  public:
-    typedef const_iterator self_type;
-    typedef std::pair<std::vector<T>,CType>  value_type;
-    typedef std::pair<std::vector<T>,CType>& reference;
-    typedef std::pair<std::vector<T>,CType>* pointer;
-    typedef std::forward_iterator_tag iterator_category;
-
-    const_iterator(const const_iterator&) = default;
-
-    const_iterator operator++() {
-      advanceIndex();
-      return *this;
-    }
-
-   const_iterator operator++(int) {
-     const_iterator result = *this;
-     ++(*this);
-     return result;
-    }
-
-    const std::pair<std::vector<T>,CType>& operator*() const {
-      return curVal;
-    }
-
-    const std::pair<std::vector<T>,CType>* operator->() const {
-      return &curVal;
-    }
-
-    bool operator==(const const_iterator& rhs) {
-      return tensor == rhs.tensor && count == rhs.count;
-    }
-
-    bool operator!=(const const_iterator& rhs) {
-      return !(*this == rhs);
-    }
-
-  private:
-    friend class Tensor;
-
-    const_iterator(const Tensor<CType>* tensor, bool isEnd = false) :
-        tensor(tensor),
-        coord(TypedIndexVector(type<T>(), tensor->getOrder())),
-        ptrs(TypedIndexVector(type<T>(), tensor->getOrder())),
-        curVal({std::vector<T>(tensor->getOrder()), 0}),
-        count(1 + (size_t)isEnd * tensor->getStorage().getIndex().getSize()),
-        advance(false) {
-      advanceIndex();
-    }
-
-    void advanceIndex() {
-      advanceIndex(0);
-      ++count;
-    }
-
-    bool advanceIndex(int lvl) {
-      const auto& modeTypes = tensor->getFormat().getModeFormats();
-      const auto& modeOrdering = tensor->getFormat().getModeOrdering();
-
-      if (lvl == tensor->getOrder()) {
-        if (advance) {
-          advance = false;
-          return false;
-        }
-
-        const TypedIndexVal idx = (lvl == 0) ? TypedIndexVal(type<T>(), 0) : ptrs[lvl - 1];
-        curVal.second = ((CType *)tensor->getStorage().getValues().getData())[idx.getAsIndex()];
-
-        for (int i = 0; i < lvl; ++i) {
-          const size_t mode = modeOrdering[i];
-          curVal.first[mode] = (T)coord[i].getAsIndex();
-        }
-
-        advance = true;
-        return true;
-      }
-      
-      const auto storage = tensor->getStorage();
-      const auto modeIndex = storage.getIndex().getModeIndex(lvl);
-
-      if (modeTypes[lvl] == Dense) {
-        TypedIndexVal size(type<T>(),
-                           (int)modeIndex.getIndexArray(0)[0].getAsIndex());
-        TypedIndexVal base = ptrs[lvl - 1] * size;
-        if (lvl == 0) base.set(0);
-
-        if (advance) {
-          goto resume_dense;  // obligatory xkcd: https://xkcd.com/292/
-        }
-
-        for (coord[lvl] = 0; coord[lvl] < size; ++coord[lvl]) {
-          ptrs[lvl] = base + coord[lvl];
-
-        resume_dense:
-          if (advanceIndex(lvl + 1)) {
-            return true;
-          }
-        }
-      } else if (modeTypes[lvl] == Sparse) {
-        const auto& pos = modeIndex.getIndexArray(0);
-        const auto& idx = modeIndex.getIndexArray(1);
-        TypedIndexVal k = (lvl == 0) ? TypedIndexVal(type<T>(),0) : ptrs[lvl-1];
-
-        if (advance) {
-          goto resume_sparse;
-        }
-
-        for (ptrs[lvl] = (int)pos.get((int)k.getAsIndex()).getAsIndex();
-             ptrs[lvl] < (int)pos.get((int)k.getAsIndex()+1).getAsIndex();
-             ++ptrs[lvl]) {
-          coord[lvl] = (int)idx.get((int)ptrs[lvl].getAsIndex()).getAsIndex();
-
-        resume_sparse:
-          if (advanceIndex(lvl + 1)) {
-            return true;
-          }
-        }
-      } else {
-        taco_not_supported_yet;
-      }
-
-      return false;
-    }
-
-    const Tensor<CType>*             tensor;
-    TypedIndexVector                 coord;
-    TypedIndexVector                 ptrs;
-    std::pair<std::vector<T>,CType>  curVal;
-    size_t                           count;
-    bool                             advance;
-  };
-
-  const_iterator<size_t> begin() const {
-    return const_iterator<size_t>(this);
+  TensorStorage::const_iterator<size_t,CType> begin() const {
+    return getStorage().template iterator<size_t,CType>().begin();
   }
 
-  const_iterator<size_t> end() const {
-    return const_iterator<size_t>(this, true);
+  TensorStorage::const_iterator<size_t,CType> end() const {
+    return getStorage().template iterator<size_t,CType>().end();
   }
 
   template<typename T>
-  const_iterator<T> beginTyped() const {
-    return const_iterator<T>(this);
+  TensorStorage::const_iterator<T,CType> beginTyped() const {
+    return getStorage().template iterator<T,CType>().begin();
   }
 
   template<typename T>
-  const_iterator<T> endTyped() const {
-    return const_iterator<T>(this, true);
+  TensorStorage::const_iterator<T,CType> endTyped() const {
+    return getStorage().template iterator<T,CType>().end();
   }
 
   /// Assign an expression to a scalar tensor.

--- a/include/taco/type.h
+++ b/include/taco/type.h
@@ -270,6 +270,8 @@ std::ostream& operator<<(std::ostream&, const Shape&);
 /// A tensor type consists of a shape and a component/data type.
 class Type {
 public:
+  static std::vector<Dimension> convert(const std::vector<int>& dimensions);
+
   /// Create a default tensor type (double scalar)
   Type();
 

--- a/include/taco/type.h
+++ b/include/taco/type.h
@@ -270,7 +270,11 @@ std::ostream& operator<<(std::ostream&, const Shape&);
 /// A tensor type consists of a shape and a component/data type.
 class Type {
 public:
-  static std::vector<Dimension> convert(const std::vector<int>& dimensions);
+  /// Transforms a integer dimension vector to a Dimension vector
+  static std::vector<Dimension> makeDimensionVector(const std::vector<int>& dimensions);
+
+  /// Transforms a Dimension vector to a int vector
+  static std::vector<int> makeIntVector(const Shape dimensions);
 
   /// Create a default tensor type (double scalar)
   Type();

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -162,7 +162,7 @@ Assignment Parser::parseAssign() {
         }
         else {
           tensorVar = TensorVar(op->tensorVar.getName(),
-                                Type(op->tensorVar.getType().getDataType(), Type::convert(dimensions)),
+                                Type(op->tensorVar.getType().getDataType(), Type::makeDimensionVector(dimensions)),
                                 op->tensorVar.getFormat());
           tensorVars.insert({tensorVar.getName(), tensorVar});
         }
@@ -333,7 +333,7 @@ Access Parser::parseAccess() {
     if (util::contains(content->dataTypes, tensorName)) {
       dataType = content->dataTypes.at(tensorName);
     }
-    tensorVar = TensorVar(tensorName, Type(dataType, Type::convert(tensorDimensions)), format);
+    tensorVar = TensorVar(tensorName, Type(dataType, Type::makeDimensionVector(tensorDimensions)), format);
 
     for (size_t i = 0; i < tensorDimensions.size(); i++) {
       if (modesWithDefaults[i]) {

--- a/src/storage/file_io_mtx.cpp
+++ b/src/storage/file_io_mtx.cpp
@@ -277,8 +277,11 @@ TensorStorage dispatchReadMTX(std::istream& stream, const T& format) {
 
   if (formats=="coordinate")
     return readToStorageSparse(stream,format,symm);
-  else //(formats=="array")
+  else if (formats=="array")
     return readToStorageDense(stream,format,symm);
+  else
+    taco_uerror << "MatrixMarket format not available";
+    return TensorStorage(Datatype::Undefined, std::vector<int>(), Format());
 }
 
 TensorStorage readToStorageMTX(std::istream& stream, const ModeFormat& modetype) {

--- a/src/storage/file_io_mtx.cpp
+++ b/src/storage/file_io_mtx.cpp
@@ -9,6 +9,7 @@
 #include "taco/tensor.h"
 #include "taco/format.h"
 #include "taco/error.h"
+#include "taco/storage/pack.h"
 #include "taco/util/strings.h"
 #include "taco/util/timers.h"
 #include "taco/util/files.h"
@@ -16,6 +17,8 @@
 using namespace std;
 
 namespace taco {
+
+// TensorBase read functions ---
 
 template <typename T>
 TensorBase dispatchReadMTX(std::string filename, const T& format, bool pack) {
@@ -230,6 +233,231 @@ TensorBase readDense(std::istream& stream, const Format& format, bool symm) {
   return dispatchReadDense(stream, format, symm);
 }
 
+// TensorStorage read functions ---
+
+template <typename T>
+TensorStorage dispatchReadMTX(std::string filename, const T& format) {
+  std::fstream file;
+  util::openStream(file, filename, fstream::in);
+  TensorStorage storage = readToStorageMTX(file, format);
+  file.close();
+  return storage;
+}
+
+TensorStorage readToStorageMTX(std::string filename, const ModeFormat& modetype) {
+  return dispatchReadMTX(filename, modetype);
+}
+
+TensorStorage readToStorageMTX(std::string filename, const Format& format) {
+  return dispatchReadMTX(filename, format);
+}
+
+template <typename T>
+TensorStorage dispatchReadMTX(std::istream& stream, const T& format) {
+  string line;
+  bool streamIsEmpty = !std::getline(stream, line);
+  taco_uassert(streamIsEmpty) << "The provided input stream is empty. Can't generate a TensorStorage object.";
+
+  // Read Header
+  std::stringstream lineStream(line);
+  string head, type, formats, field, symmetry;
+  lineStream >> head >> type >> formats >> field >> symmetry;
+  taco_uassert(head=="%%MatrixMarket") << "Unknown header of MatrixMarket";
+  // type = [matrix tensor]
+  taco_uassert((type=="matrix") || (type=="tensor"))
+                                       << "Unknown type of MatrixMarket";
+  // formats = [coordinate array]
+  // field = [real integer complex pattern]
+  taco_uassert(field=="real")          << "MatrixMarket field not available";
+  // symmetry = [general symmetric skew-symmetric Hermitian]
+  taco_uassert((symmetry=="general") || (symmetry=="symmetric"))
+                                       << "MatrixMarket symmetry not available";
+
+  bool symm = (symmetry=="symmetric");
+
+  if (formats=="coordinate")
+    return readToStorageSparse(stream,format,symm);
+  else //(formats=="array")
+    return readToStorageDense(stream,format,symm);
+}
+
+TensorStorage readToStorageMTX(std::istream& stream, const ModeFormat& modetype) {
+  return dispatchReadMTX(stream, modetype);
+}
+
+TensorStorage readToStorageMTX(std::istream& stream, const Format& format) {
+  return dispatchReadMTX(stream, format);
+}
+
+template <typename T>
+TensorStorage dispatchReadToStorageSparse(std::istream& stream, const T& format, 
+                              bool symm) {
+  string line;
+  std::getline(stream,line);
+
+  // Skip comments at the top of the file
+  string token;
+  do {
+    std::stringstream lineStream(line);
+    lineStream >> token;
+    if (token[0] != '%') {
+      break;
+    }
+  } while (std::getline(stream, line));
+
+  // The first non-comment line is the header with dimensions
+  vector<int> dimensions;
+  char* linePtr = (char*)line.data();
+  while (size_t dimension = strtoul(linePtr, &linePtr, 10)) {
+    taco_uassert(dimension <= INT_MAX) << "Dimension exceeds INT_MAX";
+    dimensions.push_back(static_cast<int>(dimension));
+  }
+  size_t nnz = dimensions[dimensions.size()-1];
+  dimensions.pop_back();
+  if (symm)
+    taco_uassert(dimensions.size()==2) << "Symmetry only available for matrix";
+
+  vector<int> coordinates;
+  vector<double> values;
+  coordinates.reserve(nnz*dimensions.size());
+  values.reserve(nnz);
+
+  while (std::getline(stream, line)) {
+    linePtr = (char*)line.data();
+    for (size_t i=0; i < dimensions.size(); i++) {
+      long index = strtol(linePtr, &linePtr, 10);
+      taco_uassert(index <= INT_MAX) << "Index exceeds INT_MAX";
+      coordinates.push_back(static_cast<int>(index));
+    }
+    double val = strtod(linePtr, &linePtr);
+    values.push_back(val);
+  }
+
+  size_t order = dimensions.size();
+
+  // Create matrix
+  TensorStorage storage(type<double>(), dimensions, format);
+  std::vector<TypedIndexVector> coords(order, TypedIndexVector(type<double>(), nnz * (1 + symm)));
+
+  // Insert coordinates
+  std::vector<int> coord;
+  size_t symmOffset = 0;
+  for (size_t i = 0; i < nnz; i++) {
+    coord.clear();
+    for (size_t mode = 0; mode < order; mode++) {
+      coord.push_back(coordinates[i * order + mode] -1);
+      coords[mode][i] = coord[mode];
+    }
+    // Symm value
+    if (symm && coord.front() != coord.back()) {
+      std::reverse(coord.begin(), coord.end());
+      for (size_t mode = 0; mode < order; mode++) {
+        coords[mode][nnz + symmOffset] = coord[mode];
+      }
+      symmOffset++;
+      values.push_back(values[i]);
+    }
+  }
+  for (size_t mode = 0; mode < order; mode++) {
+    coords[mode].resize(nnz + symmOffset);
+  }
+
+  return pack(type<double>(), dimensions, format, coords, values.data());
+}
+
+TensorStorage readToStorageSparse(std::istream& stream, const ModeFormat& modetype, 
+                      bool symm) {
+  return dispatchReadToStorageSparse(stream, modetype, symm);
+}
+
+TensorStorage readToStorageSparse(std::istream& stream, const Format& format, bool symm) {
+  return dispatchReadToStorageSparse(stream, format, symm);
+}
+
+template <typename T>
+TensorStorage dispatchReadToStorageDense(std::istream& stream, const T& format, bool symm) {
+  string line;
+  std::getline(stream,line);
+
+  // Skip comments at the top of the file
+  string token;
+  do {
+    std::stringstream lineStream(line);
+    lineStream >> token;
+    if (token[0] != '%') {
+      break;
+    }
+  } while (std::getline(stream, line));
+
+  // The first non-comment line is the header with dimension sizes
+  vector<int> dimensions;
+  char* linePtr = (char*)line.data();
+  while (size_t dimension = strtoul(linePtr, &linePtr, 10)) {
+    taco_uassert(dimension <= INT_MAX) << "Dimension exceeds INT_MAX";
+    dimensions.push_back(static_cast<int>(dimension));
+  }
+  if (symm)
+    taco_uassert(dimensions.size()==2) << "Symmetry only available for matrix";
+
+  vector<double> values;
+  auto size = std::accumulate(begin(dimensions), end(dimensions),
+                              1, std::multiplies<double>());
+  values.reserve(size);
+
+  while (std::getline(stream, line)) {
+    linePtr = (char*)line.data();
+    double val = strtod(linePtr, &linePtr);
+    values.push_back(val);
+  }
+
+  size_t order = dimensions.size();
+
+  TensorStorage storage(type<double>(), dimensions, format);
+  std::vector<TypedIndexVector> coords(order, TypedIndexVector(type<double>(), size * (1 + symm)));
+
+  // Insert coordinates
+  std::vector<int> coord;
+  size_t symmOffset = 0;
+  for (auto i = 0; i < size; i++) {
+    coord.clear();
+    auto index = i;
+    for (size_t mode = 0; mode < order - 1; mode++) {
+      coord.push_back(index % dimensions[mode]);
+      index = index / dimensions[mode];
+    }
+    coord.push_back(index);
+    for (size_t mode = 0; mode < order; mode++) {
+      coords[mode][i] = coord[mode];
+    }
+
+    // Insert Symm value
+    if (symm && coord.front() != coord.back()) {
+      std::reverse(coord.begin(), coord.end());
+      for (size_t mode = 0; mode < order; mode++) {
+        coords[mode][size + symmOffset] = coord[mode];
+      }
+      symmOffset++;
+      values.push_back(values[i]);
+    }
+  }
+  for (size_t mode = 0; mode < order; mode++) {
+    coords[mode].resize(size + symmOffset);
+  }
+
+  return pack(type<double>(), dimensions, format, coords, values.data());
+}
+
+TensorStorage readToStorageDense(std::istream& stream, const ModeFormat& modetype, 
+                        bool symm) {
+  return dispatchReadToStorageDense(stream, modetype, symm);
+}
+
+TensorStorage readToStorageDense(std::istream& stream, const Format& format, bool symm) {
+  return dispatchReadToStorageDense(stream, format, symm);
+}
+
+// TensorBase write functions   ---
+
 void writeMTX(std::string filename, const TensorBase& tensor) {
   std::fstream file;
   util::openStream(file, filename, fstream::out);
@@ -268,6 +496,48 @@ void writeDense(std::ostream& stream, const TensorBase& tensor) {
   stream << "%"                                        << std::endl;
   stream << util::join(tensor.getDimensions(), " ") << " " << endl;
   for (auto& value : iterate<double>(tensor)) {
+    stream << value.second << endl;
+  }
+}
+
+void writeFromStorageMTX(std::string filename, const TensorStorage& storage) {
+  std::fstream file;
+  util::openStream(file, filename, fstream::out);
+  writeFromStorageMTX(file, storage);
+  file.close();
+}
+
+void writeFromStorageMTX(std::ostream& stream, const TensorStorage& storage) {
+  if (isDense(storage.getFormat()))
+    writeFromStorageDense(stream, storage);
+  else
+    writeFromStorageSparse(stream, storage);
+}
+
+void writeFromStorageSparse(std::ostream& stream, const TensorStorage& storage) {
+  if(storage.getOrder() == 2)
+    stream << "%%MatrixMarket matrix coordinate real general" << std::endl;
+  else
+    stream << "%%MatrixMarket tensor coordinate real general" << std::endl;
+  stream << "%"                                             << std::endl;
+  stream << util::join(storage.getDimensions(), " ") << " ";
+  stream << storage.getIndex().getSize() << endl;
+  for (auto& value : storage.iterator<size_t,double>()) {
+    for (size_t coord : value.first) {
+      stream << coord+1 << " ";
+    }
+    stream << value.second << endl;
+  }
+}
+
+void writeFromStorageDense(std::ostream& stream, const TensorStorage& storage) {
+  if(storage.getOrder() == 2)
+    stream << "%%MatrixMarket matrix array real general" << std::endl;
+  else
+    stream << "%%MatrixMarket tensor array real general" << std::endl;
+  stream << "%"                                        << std::endl;
+  stream << util::join(storage.getDimensions(), " ") << " " << endl;
+  for (auto& value : storage.iterator<size_t,double>()) {
     stream << value.second << endl;
   }
 }

--- a/src/storage/file_io_tns.cpp
+++ b/src/storage/file_io_tns.cpp
@@ -83,6 +83,8 @@ TensorBase dispatchReadTNS(std::istream& stream, const T& format, bool pack) {
     tensor.insert(coordinate, values[i]);
   }
 
+  cout << values[3] << endl;
+
   if (pack) {
     tensor.pack();
   }
@@ -124,7 +126,7 @@ TensorStorage dispatchReadTNS(std::istream& stream, const T& format) {
 
   std::string line;
   bool streamIsEmpty = !std::getline(stream, line);
-  taco_uassert(streamIsEmpty) << "The provided input stream is empty. Can't generate a TensorStorage object.";
+  taco_uassert(!streamIsEmpty) << "The provided input stream is empty. Can't generate a TensorStorage object.";
 
   // Infer tensor order from the first coordinate
   vector<string> toks = util::split(line, " ");
@@ -157,6 +159,7 @@ TensorStorage dispatchReadTNS(std::istream& stream, const T& format) {
       coords[j][i] = coordinates[i * order + j];
     }
   }
+  cout << values[3] << endl;
   return pack(type<double>(), dimensions, format, coords, values.data());
 }
 

--- a/src/storage/file_io_tns.cpp
+++ b/src/storage/file_io_tns.cpp
@@ -11,12 +11,16 @@
 #include "taco/tensor.h"
 #include "taco/format.h"
 #include "taco/error.h"
+#include "taco/storage/pack.h"
 #include "taco/util/strings.h"
 #include "taco/util/files.h"
 
 using namespace std;
 
 namespace taco {
+
+
+// TensorBase read functions ---
 
 template <typename T>
 TensorBase dispatchReadTNS(std::string filename, const T& format, bool pack) {
@@ -94,6 +98,80 @@ TensorBase readTNS(std::istream& stream, const Format& format, bool pack) {
   return dispatchReadTNS(stream, format, pack);
 }
 
+// TensorStorage read functions --
+
+template <typename T>
+TensorStorage dispatchReadTNS(std::string filename, const T& format) {
+  std::fstream file;
+  util::openStream(file, filename, fstream::in);
+  TensorStorage storage = readToStorageTNS(file, format);
+  file.close();
+  return storage;
+}
+
+TensorStorage readToStorageTNS(std::string filename, const ModeFormat& modetype) {
+  return dispatchReadTNS(filename, modetype);
+}
+
+TensorStorage readToStorageTNS(std::string filename, const Format& format) {
+  return dispatchReadTNS(filename, format);
+}
+
+template <typename T>
+TensorStorage dispatchReadTNS(std::istream& stream, const T& format) {
+  std::vector<int>    coordinates;
+  std::vector<double> values;
+
+  std::string line;
+  bool streamIsEmpty = !std::getline(stream, line);
+  taco_uassert(streamIsEmpty) << "The provided input stream is empty. Can't generate a TensorStorage object.";
+
+  // Infer tensor order from the first coordinate
+  vector<string> toks = util::split(line, " ");
+  size_t order = toks.size() - 1;
+  std::vector<int> dimensions(order);
+  std::vector<int> coordinate(order);
+
+  // Load data
+  do {
+    char* linePtr = (char*)line.data();
+    for (size_t i = 0; i < order; i++) {
+      long idx = strtol(linePtr, &linePtr, 10);
+      taco_uassert(idx <= INT_MAX) << "Coordinate in file is larger than INT_MAX";
+      coordinate[i] = (int)idx - 1;
+      dimensions[i] = std::max(dimensions[i], (int)idx);
+    }
+    coordinates.insert(coordinates.end(), coordinate.begin(), coordinate.end());
+    double val = strtod(linePtr, &linePtr);
+    values.push_back(val);
+
+  } while (std::getline(stream, line));
+
+  // Create tensorStorage
+  TensorStorage storage(type<double>(), dimensions, format);
+  const size_t nnz = values.size();
+  std::vector<TypedIndexVector> coords(order, TypedIndexVector(type<double>(), nnz));
+
+
+  // Insert coordinates (TODO add and use bulk insertion)
+  for (size_t i = 0; i < nnz; i++) {
+    for (size_t j = 0; j < order; j++) {
+      coords[j][i] = coordinates[i * order + j];
+    }
+  }
+  return pack(type<double>(), dimensions, format, coords, values.data());
+}
+
+TensorStorage readToStorageTNS(std::istream& stream, const ModeFormat& modetype) {
+  return dispatchReadTNS(stream, modetype);
+}
+
+TensorStorage readToStorageTNS(std::istream& stream, const Format& format) {
+  return dispatchReadTNS(stream, format);
+}
+
+// Write functions --
+
 void writeTNS(std::string filename, const TensorBase& tensor) {
   std::fstream file;
   util::openStream(file, filename, fstream::out);
@@ -103,6 +181,22 @@ void writeTNS(std::string filename, const TensorBase& tensor) {
 
 void writeTNS(std::ostream& stream, const TensorBase& tensor) {
   for (auto& value : iterate<double>(tensor)) {
+    for (size_t coord : value.first) {
+      stream << coord+1 << " ";
+    }
+    stream << value.second << endl;
+  }
+}
+
+void writeFromStorageTNS(std::string filename, const TensorStorage& storage) {
+  std::fstream file;
+  util::openStream(file, filename, fstream::out);
+  writeFromStorageTNS(file, storage);
+  file.close();
+}
+
+void writeFromStorageTNS(std::ostream& stream, const TensorStorage& tensor) {
+  for (auto& value : storage.iterator<size_t,double>()) {
     for (size_t coord : value.first) {
       stream << coord+1 << " ";
     }

--- a/src/storage/file_io_tns.cpp
+++ b/src/storage/file_io_tns.cpp
@@ -152,8 +152,6 @@ TensorStorage dispatchReadTNS(std::istream& stream, const T& format) {
   const size_t nnz = values.size();
   std::vector<TypedIndexVector> coords(order, TypedIndexVector(type<double>(), nnz));
 
-
-  // Insert coordinates (TODO add and use bulk insertion)
   for (size_t i = 0; i < nnz; i++) {
     for (size_t j = 0; j < order; j++) {
       coords[j][i] = coordinates[i * order + j];
@@ -195,7 +193,7 @@ void writeFromStorageTNS(std::string filename, const TensorStorage& storage) {
   file.close();
 }
 
-void writeFromStorageTNS(std::ostream& stream, const TensorStorage& tensor) {
+void writeFromStorageTNS(std::ostream& stream, const TensorStorage& storage) {
   for (auto& value : storage.iterator<size_t,double>()) {
     for (size_t coord : value.first) {
       stream << coord+1 << " ";

--- a/src/storage/pack.cpp
+++ b/src/storage/pack.cpp
@@ -125,6 +125,8 @@ TensorStorage pack(Datatype                             componentType,
   taco_iassert(sameSize(coordinates));
   taco_iassert(dimensions.size() > 0) << "Scalar packing not supported";
 
+  cout << ((double*)values)[3] << endl;
+
   size_t order = dimensions.size();
   size_t numCoordinates = coordinates[0].size();
 

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -7,8 +7,11 @@
 #include "taco/type.h"
 #include "taco/format.h"
 #include "taco/error.h"
-#include "taco/storage/index.h"
 #include "taco/storage/array.h"
+#include "taco/storage/file_io_tns.h"
+#include "taco/storage/file_io_mtx.h"
+#include "taco/storage/file_io_rb.h"
+#include "taco/storage/index.h"
 #include "taco/util/strings.h"
 
 using namespace std;
@@ -175,6 +178,134 @@ std::ostream& operator<<(std::ostream& os, const TensorStorage& storage) {
     os << storage.getIndex() << std::endl;
   }
   return os << storage.getValues();
+}
+
+// File IO
+
+static string getExtension(string filename) {
+  return filename.substr(filename.find_last_of(".") + 1);
+}
+
+template <typename T, typename U>
+TensorStorage dispatchRead(T& file, FileType filetype, U format) {
+  switch (filetype) {
+    case FileType::ttx:
+    case FileType::mtx:
+      return readToStorageMTX(file, format);
+      break;
+    case FileType::tns:
+      return readToStorageTNS(file, format);
+      break;
+    case FileType::rb:
+      return readToStorageRB(file, format);
+      break;
+  }
+}
+
+template <typename U>
+TensorStorage dispatchRead(std::string filename, U format) {
+  string extension = getExtension(filename);
+
+  if (extension == "ttx") {
+    return dispatchRead(filename, FileType::ttx, format);
+  }
+  else if (extension == "tns") {
+    return dispatchRead(filename, FileType::tns, format);
+  }
+  else if (extension == "mtx") {
+    return dispatchRead(filename, FileType::mtx, format);
+  }
+  else if (extension == "rb") {
+    return dispatchRead(filename, FileType::rb, format);
+  }
+  else {
+    taco_uerror << "File extension not recognized: " << filename << std::endl;
+    return TensorStorage(Datatype::Undefined, std::vector<int>(), Format());
+  }
+}
+
+TensorStorage readToStorage(std::string filename, ModeFormat modetype) {
+  return dispatchRead(filename, modetype);
+}
+
+TensorStorage readToStorage(std::string filename, Format format) {
+  return dispatchRead(filename, format);
+}
+
+TensorStorage readToStorage(string filename, FileType filetype, ModeFormat modetype) {
+  return dispatchRead(filename, filetype, modetype);
+}
+
+TensorStorage readToStorage(string filename, FileType filetype, Format format) {
+  return dispatchRead(filename, filetype, format);
+}
+
+TensorStorage readToStorage(istream& stream, FileType filetype, ModeFormat modetype) {
+  return dispatchRead(stream, filetype, modetype);
+}
+
+TensorStorage readToStorage(istream& stream, FileType filetype, Format format) {
+  return dispatchRead(stream, filetype, format);
+}
+
+void dispatchWrite(string file, const TensorStorage& storage, FileType filetype) {
+  switch (filetype) {
+    case FileType::ttx:
+    case FileType::mtx:
+      writeFromStorageMTX(file, storage);
+      break;
+    case FileType::tns:
+      writeFromStorageTNS(file, storage);
+      break;
+    case FileType::rb:
+      writeFromStorageRB(file, storage);
+      break;
+  }
+}
+
+void dispatchWrite(ostream& file, const TensorStorage& storage, FileType filetype) {
+  switch (filetype) {
+    case FileType::ttx:
+    case FileType::mtx:
+      writeFromStorageMTX(file, storage);
+      break;
+    case FileType::tns:
+      writeFromStorageTNS(file, storage);
+      break;
+    case FileType::rb:
+      writeFromStorageRB(file, storage);
+      break;
+  }
+}
+
+void writeFromStorage(string filename, const TensorStorage& storage) {
+  string extension = getExtension(filename);
+  if (extension == "ttx") {
+    dispatchWrite(filename, storage, FileType::ttx);
+  }
+  else if (extension == "tns") {
+    dispatchWrite(filename, storage, FileType::tns);
+  }
+  else if (extension == "mtx") {
+    taco_iassert(storage.getOrder() == 2) <<
+       "The .mtx format only supports matrices. Consider using the .ttx format "
+       "instead";
+    dispatchWrite(filename, storage, FileType::mtx);
+  }
+  else if (extension == "rb") {
+    dispatchWrite(filename, storage, FileType::rb);
+  }
+  else {
+    taco_uerror << "File extension not recognized: " << filename << std::endl;
+  }
+}
+
+void writeFromStorage(string filename, FileType filetype, const TensorStorage& storage) {
+  dispatchWrite(filename, storage, filetype);
+}
+
+void writeFromStorage(ostream& stream, FileType filetype, const TensorStorage& storage) {
+  dispatchWrite(stream, storage, filetype);
 }
 
 }

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -63,6 +63,12 @@ TensorStorage::TensorStorage(Datatype componentType,
     : content(new Content(componentType, dimensions, format)) {
 }
 
+TensorStorage::TensorStorage(Datatype componentType, const std::vector<int>& dimensions,
+                ModeFormat modeType)
+    : TensorStorage(componentType, dimensions,
+                    std::vector<ModeFormatPack>(dimensions.size(), modeType)) {
+}
+
 const Format& TensorStorage::getFormat() const {
   return content->format;
 }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -45,22 +45,6 @@ using namespace taco::ir;
 
 namespace taco {
 
-static vector<Dimension> convert(const vector<int>& dimensions) {
-  vector<Dimension> dims;
-  for (auto& dim : dimensions) {
-    dims.push_back(dim);
-  }
-  return dims;
-}
-
-static vector<int> convert(const Shape dimensions) {
-  vector<int> dims;
-  for (auto& dim : dimensions) {
-    dims.push_back(dim.getSize());
-  }
-  return dims;
-}
-
 struct TensorBase::Content {
   Datatype           dataType;
   vector<int>        dimensions;
@@ -81,7 +65,7 @@ struct TensorBase::Content {
           Format format)
       : dataType(dataType), dimensions(dimensions),
         storage(TensorStorage(dataType, dimensions, format)),
-        tensorVar(TensorVar(name, Type(dataType,convert(dimensions)),format)) {}
+        tensorVar(TensorVar(name, Type(dataType,Type::makeDimensionVector(dimensions)),format)) {}
 };
 
 TensorBase::TensorBase() : TensorBase(Float()) {
@@ -98,7 +82,7 @@ TensorBase::TensorBase(std::string name, Datatype ctype)
 TensorBase::TensorBase(TensorVar tensorVar)
     : TensorBase(tensorVar.getName(),
                  tensorVar.getType().getDataType(),
-                 convert(tensorVar.getType().getShape()),
+                 Type::makeIntVector(tensorVar.getType().getShape()),
                  tensorVar.getFormat())  {
 }
 

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -53,6 +53,14 @@ static vector<Dimension> convert(const vector<int>& dimensions) {
   return dims;
 }
 
+static vector<int> convert(const Shape dimensions) {
+  vector<int> dims;
+  for (auto& dim : dimensions) {
+    dims.push_back(dim.getSize());
+  }
+  return dims;
+}
+
 struct TensorBase::Content {
   Datatype           dataType;
   vector<int>        dimensions;
@@ -85,6 +93,13 @@ TensorBase::TensorBase(Datatype ctype)
 
 TensorBase::TensorBase(std::string name, Datatype ctype)
     : TensorBase(name, ctype, {}, Format())  {
+}
+
+TensorBase::TensorBase(TensorVar tensorVar)
+    : TensorBase(tensorVar.getName(),
+                 tensorVar.getType().getDataType(),
+                 convert(tensorVar.getType().getShape()),
+                 tensorVar.getFormat())  {
 }
 
 TensorBase::TensorBase(Datatype ctype, vector<int> dimensions, 

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -306,10 +306,18 @@ std::ostream& operator<<(std::ostream& os, const Shape& shape) {
   return os;
 }
 
-std::vector<Dimension> Type::convert(const std::vector<int>& dimensions) {
+std::vector<Dimension> Type::makeDimensionVector(const std::vector<int>& dimensions) {
   vector<Dimension> dims;
   for (auto& dim : dimensions) {
     dims.push_back(dim);
+  }
+  return dims;
+}
+
+vector<int> Type::makeIntVector(const Shape dimensions) {
+  vector<int> dims;
+  for (auto& dim : dimensions) {
+    dims.push_back(dim.getSize());
   }
   return dims;
 }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -306,6 +306,13 @@ std::ostream& operator<<(std::ostream& os, const Shape& shape) {
   return os;
 }
 
+std::vector<Dimension> Type::convert(const std::vector<int>& dimensions) {
+  vector<Dimension> dims;
+  for (auto& dim : dimensions) {
+    dims.push_back(dim);
+  }
+  return dims;
+}
 
 // class TensorType
 Type::Type() : dtype(type<double>()) {


### PR DESCRIPTION
Additions:
- Parser uses TensorVar objects instead of TensorBase objects for creating IndexExpr and Assignment objects.
- New conversion functions between vector<int> and vector<Dimension> for the Type class.
- New TensorBase constructor with TensorVar as single input.
- New assemble and compute TensorBase functions which take in pre-packed arguments.