### PR TITLE
Remove TensorBase dependencies from Parser

### DIFF
--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -45,9 +45,6 @@ public:
     pack();
   }
 
-  /// Create a tensor matching the given TensorVar.
-  TensorBase(TensorVar tensorVar);
-
   /// Create a tensor with the given dimensions. The format defaults to sparse 
   /// in every mode.
   TensorBase(Datatype ctype, std::vector<int> dimensions, 
@@ -186,18 +183,8 @@ public:
   /// Assemble the tensor storage, including index and value arrays.
   void assemble();
 
-  /// Assemble the tensor storage, including index and value arrays
-  /// using the given packed arguments (arguments must correspont to
-  /// the tensor Assignments)
-  void assemble(std::vector<void*> arguments);
-
   /// Compute the given expression and put the values in the tensor storage.
   void compute();
-
-  /// Compute the given expression and put the values in the tensor storage
-  /// using the given packed arguments (arguments must correspont to
-  /// the tensor Assignments)
-  void compute(std::vector<void*> arguments);
 
   /// Compile, assemble and compute as needed.
   void evaluate();
@@ -245,6 +232,32 @@ public:
 
   /// Print a tensor to a stream.
   friend std::ostream& operator<<(std::ostream&, const TensorBase&);
+
+
+  /// Create a tensor matching the given TensorVar.
+  ///
+  /// Temporary method to facilitate removal of TensorBase dependencies.
+  /// Note: Do not use this method.
+  /// TODO(pnoyola): deprecate and remove method.
+  TensorBase(TensorVar tensorVar);
+
+  /// Assemble the tensor storage, including index and value arrays
+  /// using the given packed arguments (arguments must correspont to
+  /// the tensor Assignments)
+  ///
+  /// Temporary method to facilitate removal of TensorBase dependencies.
+  /// Note: Do not use this method.
+  /// TODO(pnoyola): deprecate and remove method.
+  void assemble(std::vector<void*> arguments);
+
+  /// Compute the given expression and put the values in the tensor storage
+  /// using the given packed arguments (arguments must correspont to
+  /// the tensor Assignments)
+  ///
+  /// Temporary method to facilitate removal of TensorBase dependencies.
+  /// Note: Do not use this method.
+  /// TODO(pnoyola): deprecate and remove method.
+  void compute(std::vector<void*> arguments);
 
 private:
   struct Content;

--- a/include/taco/type.h
+++ b/include/taco/type.h
@@ -270,12 +270,6 @@ std::ostream& operator<<(std::ostream&, const Shape&);
 /// A tensor type consists of a shape and a component/data type.
 class Type {
 public:
-  /// Transforms a integer dimension vector to a Dimension vector
-  static std::vector<Dimension> makeDimensionVector(const std::vector<int>& dimensions);
-
-  /// Transforms a Dimension vector to a int vector
-  static std::vector<int> makeIntVector(const Shape dimensions);
-
   /// Create a default tensor type (double scalar)
   Type();
 
@@ -299,6 +293,12 @@ std::ostream& operator<<(std::ostream&, const Type&);
 
 /// Check whether the type is a scalar (0-order tensor)
 bool isScalar(const Type& type);
+
+/// Transforms a integer dimension vector to a Dimension vector
+std::vector<Dimension> makeDimensionVector(const std::vector<int>& dimensions);
+
+/// Transforms a Dimension vector to a int vector
+std::vector<int> makeIntVector(const Shape dimensions);
 
 }
 #endif

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -4,6 +4,7 @@
 
 #include "taco/parser/lexer.h"
 #include "taco/tensor.h"
+#include "taco/type.h"
 #include "taco/format.h"
 
 #include "taco/index_notation/index_notation.h"
@@ -162,7 +163,7 @@ Assignment Parser::parseAssign() {
         }
         else {
           tensorVar = TensorVar(op->tensorVar.getName(),
-                                Type(op->tensorVar.getType().getDataType(), Type::makeDimensionVector(dimensions)),
+                                Type(op->tensorVar.getType().getDataType(), makeDimensionVector(dimensions)),
                                 op->tensorVar.getFormat());
           tensorVars.insert({tensorVar.getName(), tensorVar});
         }
@@ -333,7 +334,7 @@ Access Parser::parseAccess() {
     if (util::contains(content->dataTypes, tensorName)) {
       dataType = content->dataTypes.at(tensorName);
     }
-    tensorVar = TensorVar(tensorName, Type(dataType, Type::makeDimensionVector(tensorDimensions)), format);
+    tensorVar = TensorVar(tensorName, Type(dataType, makeDimensionVector(tensorDimensions)), format);
 
     for (size_t i = 0; i < tensorDimensions.size(); i++) {
       if (modesWithDefaults[i]) {

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -65,7 +65,7 @@ struct TensorBase::Content {
           Format format)
       : dataType(dataType), dimensions(dimensions),
         storage(TensorStorage(dataType, dimensions, format)),
-        tensorVar(TensorVar(name, Type(dataType,Type::makeDimensionVector(dimensions)),format)) {}
+        tensorVar(TensorVar(name, Type(dataType,makeDimensionVector(dimensions)),format)) {}
 };
 
 TensorBase::TensorBase() : TensorBase(Float()) {
@@ -82,7 +82,7 @@ TensorBase::TensorBase(std::string name, Datatype ctype)
 TensorBase::TensorBase(TensorVar tensorVar)
     : TensorBase(tensorVar.getName(),
                  tensorVar.getType().getDataType(),
-                 Type::makeIntVector(tensorVar.getType().getShape()),
+                 makeIntVector(tensorVar.getType().getShape()),
                  tensorVar.getFormat())  {
 }
 

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -306,22 +306,6 @@ std::ostream& operator<<(std::ostream& os, const Shape& shape) {
   return os;
 }
 
-std::vector<Dimension> Type::makeDimensionVector(const std::vector<int>& dimensions) {
-  vector<Dimension> dims;
-  for (auto& dim : dimensions) {
-    dims.push_back(dim);
-  }
-  return dims;
-}
-
-vector<int> Type::makeIntVector(const Shape dimensions) {
-  vector<int> dims;
-  for (auto& dim : dimensions) {
-    dims.push_back(dim.getSize());
-  }
-  return dims;
-}
-
 // class TensorType
 Type::Type() : dtype(type<double>()) {
 }
@@ -363,6 +347,23 @@ std::ostream& operator<<(std::ostream& os, const Type& type) {
 
 bool isScalar(const Type& type) {
   return type.getOrder() == 0;
+}
+
+
+std::vector<Dimension> makeDimensionVector(const std::vector<int>& dimensions) {
+  vector<Dimension> dims;
+  for (auto& dim : dimensions) {
+    dims.push_back(dim);
+  }
+  return dims;
+}
+
+vector<int> makeIntVector(const Shape dimensions) {
+  vector<int> dims;
+  for (auto& dim : dimensions) {
+    dims.push_back(dim.getSize());
+  }
+  return dims;
 }
 
 }

--- a/tools/taco.cpp
+++ b/tools/taco.cpp
@@ -929,9 +929,9 @@ int main(int argc, char* argv[]) {
   if (outputDirectory != "") {
     string outputFileName = outputDirectory + "/" + tensor.getName() + ".tns";
     write(outputFileName, FileType::tns, tensor);
-    TensorVar paramTensor;
+    TensorBase paramTensor;
     for (const auto &fills : tensorsFill ) {
-      paramTensor = parser.getTensorVar(fills.first);
+      paramTensor = loadedTensors.at(fills.first);
       outputFileName = outputDirectory + "/" + paramTensor.getName() + ".tns";
       write(outputFileName, FileType::tns, paramTensor);
     }


### PR DESCRIPTION
Additions:
- Parser uses TensorVar objects instead of TensorBase objects for creating IndexExpr and Assignment objects.
- New conversion functions between vector<int> and vector<Dimension> for the Type class.
- New TensorBase constructor with TensorVar as single input.
- New assemble and compute TensorBase functions which take in pre-packed arguments.