### PR TITLE
Do not do default -print-compute if -print-evaluate is present

### DIFF
--- a/tools/taco.cpp
+++ b/tools/taco.cpp
@@ -522,9 +522,9 @@ int main(int argc, char* argv[]) {
   }
 
   // Print compute is the default if nothing else was asked for
-  if (!printAssemble && !printIterationGraph && !printLattice && !loaded &&
+  if (!printAssemble && !printEvaluate && !printIterationGraph && !printLattice &&
       !writeCompute && !writeAssemble && !writeKernels && !readKernels &&
-      !printKernels) {
+      !printKernels && !loaded) {
     printCompute = true;
   }
 


### PR DESCRIPTION
The command line tool is supposed to check if any directives were provided; if not, then `-print-compute` is the default. However, `-print-evaluate` was not properly checked so `-print-compute` was always printed alongside it. This fixes that.