### PR TITLE
Blocked format api

### DIFF
--- a/include/taco/format.h
+++ b/include/taco/format.h
@@ -97,7 +97,7 @@ public:
   bool isBlocked();
 
   /// Gets the number of nested block levels in the format
-  int numberOfBlocks();
+  int numBlockLevels();
 
   /// Gets all the block fixed-sizes.
   ///
@@ -148,7 +148,7 @@ public:
   /// Properties of a mode format
   enum Property {
     FULL, NOT_FULL, ORDERED, NOT_ORDERED, UNIQUE, NOT_UNIQUE, BRANCHLESS,
-    NOT_BRANCHLESS, COMPACT, NOT_COMPACT
+    NOT_BRANCHLESS, COMPACT, NOT_COMPACT, SIZE_FIXED, SIZE_NOT_FIXED
   };
 
   /// Instantiates an undefined mode format
@@ -203,9 +203,6 @@ public:
 
 private:
   std::shared_ptr<const ModeFormatImpl> impl;
-
-  bool sizeFixed = false;
-  int blockSize;
 
   friend class ModePack;
   friend class Iterator;

--- a/include/taco/lower/mode_format_compressed.h
+++ b/include/taco/lower/mode_format_compressed.h
@@ -9,11 +9,12 @@ class CompressedModeFormat : public ModeFormatImpl {
 public:
   CompressedModeFormat();
   CompressedModeFormat(bool isFull, bool isOrdered,
-                       bool isUnique, long long allocSize = DEFAULT_ALLOC_SIZE);
+                       bool isUnique, bool hasFixedSize = false,
+                       int size = 0, long long allocSize = DEFAULT_ALLOC_SIZE);
 
   virtual ~CompressedModeFormat() {}
 
-  virtual ModeFormat copy(std::vector<ModeFormat::Property> properties) const;
+  virtual ModeFormat copy(std::vector<ModeFormat::Property> properties, int size = 0) const;
   
   virtual ModeFunction posIterBounds(ir::Expr parentPos, Mode mode) const;
   virtual ModeFunction posIterAccess(ir::Expr pos, std::vector<ir::Expr> coords,

--- a/include/taco/lower/mode_format_dense.h
+++ b/include/taco/lower/mode_format_dense.h
@@ -8,11 +8,12 @@ namespace taco {
 class DenseModeFormat : public ModeFormatImpl {
 public:
   DenseModeFormat();
-  DenseModeFormat(const bool isOrdered, const bool isUnique);
+  DenseModeFormat(const bool isOrdered, const bool isUnique,
+                  const bool hasFixedSize = false, const int size = 0);
 
   virtual ~DenseModeFormat() {}
 
-  virtual ModeFormat copy(std::vector<ModeFormat::Property> properties) const;
+  virtual ModeFormat copy(std::vector<ModeFormat::Property> properties, int size = 0) const;
   
   virtual ModeFunction locate(ir::Expr parentPos, std::vector<ir::Expr> coords,
                               Mode mode) const;

--- a/include/taco/lower/mode_format_dense_old.h
+++ b/include/taco/lower/mode_format_dense_old.h
@@ -9,11 +9,12 @@ namespace old {
 class DenseModeFormat : public ModeFormatImpl {
 public:
   DenseModeFormat();
-  DenseModeFormat(const bool isOrdered, const bool isUnique);
+  DenseModeFormat(const bool isOrdered, const bool isUnique,
+                  const bool hasFixedSize = false, const int size = 0);
 
   virtual ~DenseModeFormat() {}
 
-  virtual ModeFormat copy(std::vector<ModeFormat::Property> properties) const;
+  virtual ModeFormat copy(std::vector<ModeFormat::Property> properties, int size = 0) const;
 
   virtual ModeFunction coordIterBounds(std::vector<ir::Expr> parentCoords,
                                    Mode mode) const;

--- a/include/taco/lower/mode_format_impl.h
+++ b/include/taco/lower/mode_format_impl.h
@@ -66,13 +66,13 @@ public:
   ModeFormatImpl(std::string name, bool isFull, bool isOrdered, bool isUnique, 
                  bool isBranchless, bool isCompact, bool hasCoordValIter, 
                  bool hasCoordPosIter, bool hasLocate, bool hasInsert, 
-                 bool hasAppend);
+                 bool hasAppend, bool hasFixedSize = false, int size = 0);
 
   virtual ~ModeFormatImpl();
 
   /// Create a copy of the mode type with different properties.
   virtual ModeFormat copy(
-      std::vector<ModeFormat::Property> properties) const = 0;
+      std::vector<ModeFormat::Property> properties, int size = 0) const = 0;
 
 
   /// The coordinate iteration capability's iterator function computes a range
@@ -172,6 +172,8 @@ public:
   const bool hasInsert;
   const bool hasAppend;
 
+  bool hasFixedSize;
+  int size;
 protected:
   /// Check if other mode format is identical. Can assume that this method will 
   /// always be called with an argument that is of the same class.

--- a/include/taco/lower/mode_format_singleton.h
+++ b/include/taco/lower/mode_format_singleton.h
@@ -9,11 +9,12 @@ class SingletonModeFormat : public ModeFormatImpl {
 public:
   SingletonModeFormat();
   SingletonModeFormat(bool isFull, bool isOrdered,
-                      bool isUnique, long long allocSize = DEFAULT_ALLOC_SIZE);
+                      bool isUnique, bool hasFixedSize = false,
+                      int size = 0, long long allocSize = DEFAULT_ALLOC_SIZE);
 
   virtual ~SingletonModeFormat() {}
 
-  virtual ModeFormat copy(std::vector<ModeFormat::Property> properties) const;
+  virtual ModeFormat copy(std::vector<ModeFormat::Property> properties, int size = 0) const;
 
   virtual ModeFunction posIterBounds(ir::Expr parentPos, Mode mode) const;
   virtual ModeFunction posIterAccess(ir::Expr pos, std::vector<ir::Expr> coords,

--- a/src/format.cpp
+++ b/src/format.cpp
@@ -102,14 +102,14 @@ std::vector<ModeFormat> Format::blockInit(
         blockSizes[block_i][dim_i] = format.size();
       } else {
         taco_uassert(freeSizeBlock[dim_i] == -1) <<
-            "Each dimmension requires at most one free-size block.";
+            "Each dimension requires at most one free-size block.";
         freeSizeBlock[dim_i] = block_i;
       }
     }
   }
   for (int dim_i = 0; dim_i < numDims; dim_i++) {
     taco_uassert(freeSizeBlock[dim_i] != -1) <<
-        "Each dimmension requires at least one free-size block.";
+        "Each dimension requires at least one free-size block.";
   }
   return modeFormats;
 }
@@ -223,7 +223,7 @@ bool Format::isBlocked() {
   return blocked;
 }
 
-int Format::numberOfBlocks() {
+int Format::numBlockLevels() {
   taco_uassert(isBlocked()) << "ModeFormat does not have fixed size.";
   return numBlocks;
 }
@@ -290,19 +290,7 @@ ModeFormat ModeFormat::operator()(
 }
 
 ModeFormat ModeFormat::operator()(const int size) const {
-  ModeFormat format = defined() ? impl->copy({}) : ModeFormat();
-  format.sizeFixed = true;
-  format.blockSize = size;
-  return format;
-}
-
-bool ModeFormat::hasFixedSize() const {
-  return sizeFixed;
-}
-
-int ModeFormat::size() const {
-  taco_uassert(hasFixedSize()) << "ModeFormat does not have fixed size.";
-  return blockSize;
+  return defined() ? impl->copy({SIZE_FIXED}, size) : ModeFormat();
 }
 
 std::string ModeFormat::getName() const {
@@ -337,6 +325,11 @@ bool ModeFormat::hasProperties(const std::vector<Property>& properties) const {
           return false;
         }
         break;
+      case SIZE_FIXED:
+        if (!hasFixedSize()) {
+          return false;
+        }
+        break;
       case NOT_FULL:
         if (isFull()) {
           return false;
@@ -359,6 +352,11 @@ bool ModeFormat::hasProperties(const std::vector<Property>& properties) const {
         break;
       case NOT_COMPACT:
         if (isCompact()) {
+          return false;
+        }
+        break;
+      case SIZE_NOT_FIXED:
+        if (hasFixedSize()) {
           return false;
         }
         break;
@@ -415,6 +413,17 @@ bool ModeFormat::hasInsert() const {
 bool ModeFormat::hasAppend() const {
   taco_iassert(defined());
   return impl->hasAppend;
+}
+
+bool ModeFormat::hasFixedSize() const {
+  taco_iassert(defined());
+  return impl->hasFixedSize;
+}
+
+int ModeFormat::size() const {
+  taco_iassert(defined());
+  taco_uassert(hasFixedSize()) << "ModeFormat does not have fixed size.";
+  return impl->size;
 }
 
 bool ModeFormat::defined() const {

--- a/src/lower/mode_format_compressed.cpp
+++ b/src/lower/mode_format_compressed.cpp
@@ -14,17 +14,19 @@ CompressedModeFormat::CompressedModeFormat() :
 }
 
 CompressedModeFormat::CompressedModeFormat(bool isFull, bool isOrdered,
-                                       bool isUnique, long long allocSize) :
+                                       bool isUnique, bool hasFixedSize,
+                                       int size, long long allocSize) :
     ModeFormatImpl("compressed", isFull, isOrdered, isUnique, false, true,
-                   false, true, false, false, true), 
+                   false, true, false, false, true, hasFixedSize, size), 
     allocSize(allocSize) {
 }
 
 ModeFormat CompressedModeFormat::copy(
-    vector<ModeFormat::Property> properties) const {
+    vector<ModeFormat::Property> properties, int size) const {
   bool isFull = this->isFull;
   bool isOrdered = this->isOrdered;
   bool isUnique = this->isUnique;
+  bool hasFixedSize = this->hasFixedSize;
   for (const auto property : properties) {
     switch (property) {
       case ModeFormat::FULL:
@@ -45,12 +47,18 @@ ModeFormat CompressedModeFormat::copy(
       case ModeFormat::NOT_UNIQUE:
         isUnique = false;
         break;
+      case ModeFormat::SIZE_FIXED:
+        hasFixedSize = true;
+        break;
+      case ModeFormat::SIZE_NOT_FIXED:
+        hasFixedSize = false;
+        break;
       default:
         break;
     }
   }
   const auto compressedVariant = 
-      std::make_shared<CompressedModeFormat>(isFull, isOrdered, isUnique);
+      std::make_shared<CompressedModeFormat>(isFull, isOrdered, isUnique, hasFixedSize, size);
   return ModeFormat(compressedVariant);
 }
 

--- a/src/lower/mode_format_dense.cpp
+++ b/src/lower/mode_format_dense.cpp
@@ -8,15 +8,17 @@ namespace taco {
 DenseModeFormat::DenseModeFormat() : DenseModeFormat(true, true) {
 }
 
-DenseModeFormat::DenseModeFormat(const bool isOrdered, const bool isUnique) : 
+DenseModeFormat::DenseModeFormat(const bool isOrdered, const bool isUnique,
+                                 const bool hasFixedSize, const int size) :
     ModeFormatImpl("dense", true, isOrdered, isUnique, false, true, false,
-                   false, true, true, false) {
+                   false, true, true, false, hasFixedSize, size) {
 }
 
 ModeFormat DenseModeFormat::copy(
-    std::vector<ModeFormat::Property> properties) const {
+    std::vector<ModeFormat::Property> properties, int size) const {
   bool isOrdered = this->isOrdered;
   bool isUnique = this->isUnique;
+  bool hasFixedSize = this->hasFixedSize;
   for (const auto property : properties) {
     switch (property) {
       case ModeFormat::ORDERED:
@@ -31,11 +33,18 @@ ModeFormat DenseModeFormat::copy(
       case ModeFormat::NOT_UNIQUE:
         isUnique = false;
         break;
+      case ModeFormat::SIZE_FIXED:
+        hasFixedSize = true;
+        break;
+      case ModeFormat::SIZE_NOT_FIXED:
+        hasFixedSize = false;
+        break;
       default:
         break;
     }
   }
-  return ModeFormat(std::make_shared<DenseModeFormat>(isOrdered, isUnique));
+
+  return ModeFormat(std::make_shared<DenseModeFormat>(isOrdered, isUnique, hasFixedSize, size));
 }
 
 ModeFunction DenseModeFormat::locate(ir::Expr parentPos,

--- a/src/lower/mode_format_dense_old.cpp
+++ b/src/lower/mode_format_dense_old.cpp
@@ -9,15 +9,17 @@ namespace old {
 DenseModeFormat::DenseModeFormat() : DenseModeFormat(true, true) {
 }
 
-DenseModeFormat::DenseModeFormat(const bool isOrdered, const bool isUnique) : 
+DenseModeFormat::DenseModeFormat(const bool isOrdered, const bool isUnique,
+                                 const bool hasFixedSize, const int size) :
     ModeFormatImpl("dense", true, isOrdered, isUnique, false, true, true,
-                   false, true, true, false) {
+                   false, true, true, false, hasFixedSize, size) {
 }
 
 ModeFormat DenseModeFormat::copy(
-    std::vector<ModeFormat::Property> properties) const {
+    std::vector<ModeFormat::Property> properties, int size) const {
   bool isOrdered = this->isOrdered;
   bool isUnique = this->isUnique;
+  bool hasFixedSize = this->hasFixedSize;
   for (const auto property : properties) {
     switch (property) {
       case ModeFormat::ORDERED:
@@ -32,11 +34,17 @@ ModeFormat DenseModeFormat::copy(
       case ModeFormat::NOT_UNIQUE:
         isUnique = false;
         break;
+      case ModeFormat::SIZE_FIXED:
+        hasFixedSize = true;
+        break;
+      case ModeFormat::SIZE_NOT_FIXED:
+        hasFixedSize = false;
+        break;
       default:
         break;
     }
   }
-  return ModeFormat(std::make_shared<DenseModeFormat>(isOrdered, isUnique));
+  return ModeFormat(std::make_shared<DenseModeFormat>(isOrdered, isUnique, hasFixedSize, size));
 }
 
 ModeFunction DenseModeFormat::coordIterBounds(vector<Expr> coords, Mode mode) const {

--- a/src/lower/mode_format_impl.cpp
+++ b/src/lower/mode_format_impl.cpp
@@ -58,11 +58,13 @@ ModeFormatImpl::ModeFormatImpl(const std::string name, bool isFull,
                                bool isOrdered, bool isUnique, bool isBranchless, 
                                bool isCompact, bool hasCoordValIter, 
                                bool hasCoordPosIter, bool hasLocate, 
-                               bool hasInsert, bool hasAppend) :
+                               bool hasInsert, bool hasAppend,
+                               bool hasFixedSize, int size) :
     name(name), isFull(isFull), isOrdered(isOrdered), isUnique(isUnique),
     isBranchless(isBranchless), isCompact(isCompact),
     hasCoordValIter(hasCoordValIter), hasCoordPosIter(hasCoordPosIter),
-    hasLocate(hasLocate), hasInsert(hasInsert), hasAppend(hasAppend) {
+    hasLocate(hasLocate), hasInsert(hasInsert), hasAppend(hasAppend),
+    hasFixedSize(hasFixedSize), size(size) {
 }
 
 ModeFormatImpl::~ModeFormatImpl() {
@@ -153,7 +155,9 @@ bool ModeFormatImpl::equals(const ModeFormatImpl& other) const {
           isOrdered == other.isOrdered &&
           isUnique == other.isUnique &&
           isBranchless == other.isBranchless &&
-          isCompact == other.isCompact);
+          isCompact == other.isCompact &&
+          hasFixedSize == other.hasFixedSize &&
+          size == other.size);
 }
 
 bool operator==(const ModeFormatImpl& a, const ModeFormatImpl& b) {

--- a/src/lower/mode_format_singleton.cpp
+++ b/src/lower/mode_format_singleton.cpp
@@ -14,17 +14,19 @@ SingletonModeFormat::SingletonModeFormat() :
 }
 
 SingletonModeFormat::SingletonModeFormat(bool isFull, bool isOrdered,
-                                         bool isUnique, long long allocSize) :
+                                         bool isUnique, bool hasFixedSize,
+                                         int size, long long allocSize) :
     ModeFormatImpl("singleton", isFull, isOrdered, isUnique, true, true,
-                   false, true, false, false, true), 
+                   false, true, false, false, true, hasFixedSize, size),
     allocSize(allocSize) {
 }
 
 ModeFormat SingletonModeFormat::copy(
-    std::vector<ModeFormat::Property> properties) const {
+    std::vector<ModeFormat::Property> properties, int size) const {
   bool isFull = this->isFull;
   bool isOrdered = this->isOrdered;
   bool isUnique = this->isUnique;
+  bool hasFixedSize = this->hasFixedSize;
   for (const auto property : properties) {
     switch (property) {
       case ModeFormat::FULL:
@@ -45,12 +47,18 @@ ModeFormat SingletonModeFormat::copy(
       case ModeFormat::NOT_UNIQUE:
         isUnique = false;
         break;
+      case ModeFormat::SIZE_FIXED:
+        hasFixedSize = true;
+        break;
+      case ModeFormat::SIZE_NOT_FIXED:
+        hasFixedSize = false;
+        break;
       default:
         break;
     }
   }
   const auto singletonVariant = 
-      std::make_shared<SingletonModeFormat>(isFull, isOrdered, isUnique);
+      std::make_shared<SingletonModeFormat>(isFull, isOrdered, isUnique, hasFixedSize, size);
   return ModeFormat(singletonVariant);
 }
 

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -295,7 +295,7 @@ Access Parser::parseAccess() {
     format = content->formats.at(tensorName);
   }
   else {
-    format = Format(std::vector<ModeFormatPack>(order, Dense));
+    format = Format(std::vector<ModeFormat>(order, Dense));
   }
 
   TensorBase tensor;

--- a/test/test_tensors.cpp
+++ b/test/test_tensors.cpp
@@ -5,7 +5,7 @@
 namespace taco {
 namespace test {
 
-std::vector<std::vector<ModeFormatPack>> generateModeTypes(int order) {
+std::vector<std::vector<ModeFormat>> generateModeTypes(int order) {
   taco_iassert(order > 0);
   std::vector<size_t> divisors(order);
 
@@ -18,9 +18,9 @@ std::vector<std::vector<ModeFormatPack>> generateModeTypes(int order) {
   
   const size_t numPermutations = numModeTypes * divisors[order - 1];
 
-  std::vector<std::vector<ModeFormatPack>> levels(numPermutations);
+  std::vector<std::vector<ModeFormat>> levels(numPermutations);
   for (size_t i = 0; i < levels.size(); ++i) {
-    std::vector<ModeFormatPack> level;
+    std::vector<ModeFormat> level;
     for (int j = 0; j < order; ++j) {
       switch ((i / divisors[j]) % numModeTypes) {
         case 0:

--- a/test/test_tensors.h
+++ b/test/test_tensors.h
@@ -15,7 +15,7 @@
 namespace taco {
 namespace test {
 
-std::vector<std::vector<ModeFormatPack>> generateModeTypes(int order);
+std::vector<std::vector<ModeFormat>> generateModeTypes(int order);
 std::vector<std::vector<int>> generateModeOrderings(int order);
 
 template <typename T>

--- a/test/tests-format.cpp
+++ b/test/tests-format.cpp
@@ -85,7 +85,7 @@ TEST(format, block) {
 
   Format format({{Dense(5), Sparse}, {Dense, Dense(5)}});
   ASSERT_TRUE(format.isBlocked());
-  ASSERT_EQ(2, format.numberOfBlocks());
+  ASSERT_EQ(2, format.numBlockLevels());
 
   std::vector<std::vector<int>> expectedBlockSizes({{5,0}, {0,5}});
   std::vector<int> expectedDimensionFreeSizeBlock({1,0});

--- a/test/tests-lower.cpp
+++ b/test/tests-lower.cpp
@@ -27,7 +27,7 @@ using taco::sparse;
 using taco::TensorStorage;
 using taco::Array;
 using taco::TypedIndexVector;
-using taco::ModeFormatPack;
+using taco::ModeFormat;
 using taco::Kernel;
 using taco::ir::Stmt;
 using taco::util::contains;
@@ -37,7 +37,7 @@ using taco::error::expr_transposition;
 
 // Temporary hack until dense in format.h is transition from the old system
 #include "taco/lower/mode_format_dense.h"
-taco::ModeFormat dense(std::make_shared<taco::DenseModeFormat>());
+ModeFormat dense(std::make_shared<taco::DenseModeFormat>());
 
 static const Dimension n, m, o;
 static const Type vectype(Float64, {n});
@@ -213,7 +213,7 @@ map<TensorVar,TensorVar> formatVars(const std::vector<TensorVar>& vars,
     }
     else {
       // Default format is dense in all dimensions
-      format = Format(vector<ModeFormatPack>(var.getOrder(), dense));
+      format = Format(vector<ModeFormat>(var.getOrder(), dense));
     }
     formatted.insert({var, TensorVar(var.getName(), var.getType(), format)});
   }

--- a/test/tests-merge_lattice.cpp
+++ b/test/tests-merge_lattice.cpp
@@ -26,7 +26,7 @@ public:
   HashedModeFormat() : ModeFormatImpl("hashed", false, false, true, false,
                                       false, false, true, true, true, false) {}
 
-  ModeFormat copy(std::vector<ModeFormat::Property> properties) const {
+  ModeFormat copy(std::vector<ModeFormat::Property> properties, int size = 0) const {
     return ModeFormat(std::make_shared<HashedModeFormat>());
   }
 


### PR DESCRIPTION
Added support for creating blocked Format objects.

* Changed the Format API to use curly-brackets to express blocks
* Changed the Format API to use packBounds vector to express packs
* Updated all relevant tests and files
* Pending: deciding what block metadata to collect and expose during Format instantiation.
