### PR TITLE
Parallelize Scheduling Command

### DIFF
--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -13,7 +13,7 @@
 #include "taco/util/intrusive_ptr.h"
 #include "taco/util/comparable.h"
 #include "taco/type.h"
-
+#include "taco/ir/ir.h"
 #include "taco/index_notation/index_notation_nodes_abstract.h"
 
 namespace taco {
@@ -697,6 +697,10 @@ std::vector<IndexVar> getIndexVars(IndexStmt stmt);
 
 /// Get all index variables in the expression
 std::vector<IndexVar> getIndexVars(IndexExpr expr);
+
+/// Convert index notation tensor variables to IR pointer variables.
+std::vector<ir::Expr> createVars(const std::vector<TensorVar>& tensorVars,
+                               std::map<TensorVar, ir::Expr>* vars);
 
 
 /// Simplify an index expression by setting the zeroed Access expressions to

--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -485,19 +485,19 @@ public:
   Forall() = default;
   Forall(const ForallNode*);
   Forall(IndexVar indexVar, IndexStmt stmt);
-  Forall(IndexVar indexVar, IndexStmt stmt, std::vector<TAG> tags);
+  Forall(IndexVar indexVar, IndexStmt stmt, std::set<TAG> tags);
 
   IndexVar getIndexVar() const;
   IndexStmt getStmt() const;
 
-  std::vector<TAG> getTags() const;
+  std::set<TAG> getTags() const;
 
   typedef ForallNode Node;
 };
 
 /// Create a forall index statement.
 Forall forall(IndexVar i, IndexStmt expr);
-Forall forall(IndexVar i, IndexStmt expr, std::vector<Forall::TAG> tags);
+Forall forall(IndexVar i, IndexStmt expr, std::set<Forall::TAG> tags);
 
 
 /// A where statment has a producer statement that binds a tensor variable in

--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -480,18 +480,24 @@ public:
 /// sub-statement for each of these values.
 class Forall : public IndexStmt {
 public:
+  enum TAG {PARALLELIZE};
+
   Forall() = default;
   Forall(const ForallNode*);
   Forall(IndexVar indexVar, IndexStmt stmt);
+  Forall(IndexVar indexVar, IndexStmt stmt, std::vector<TAG> tags);
 
   IndexVar getIndexVar() const;
   IndexStmt getStmt() const;
+
+  std::vector<TAG> getTags() const;
 
   typedef ForallNode Node;
 };
 
 /// Create a forall index statement.
 Forall forall(IndexVar i, IndexStmt expr);
+Forall forall(IndexVar i, IndexStmt expr, std::vector<Forall::TAG> tags);
 
 
 /// A where statment has a producer statement that binds a tensor variable in

--- a/include/taco/index_notation/index_notation_nodes.h
+++ b/include/taco/index_notation/index_notation_nodes.h
@@ -184,7 +184,10 @@ struct YieldNode : public IndexStmtNode {
 
 struct ForallNode : public IndexStmtNode {
   ForallNode(IndexVar indexVar, IndexStmt stmt)
-      : indexVar(indexVar), stmt(stmt) {}
+          : indexVar(indexVar), stmt(stmt), tags({}) {}
+
+  ForallNode(IndexVar indexVar, IndexStmt stmt, std::vector<Forall::TAG> tags)
+      : indexVar(indexVar), stmt(stmt), tags(tags) {}
 
   void accept(IndexStmtVisitorStrict* v) const {
     v->visit(this);
@@ -192,6 +195,7 @@ struct ForallNode : public IndexStmtNode {
 
   IndexVar indexVar;
   IndexStmt stmt;
+  std::vector<Forall::TAG> tags;
 };
 
 struct WhereNode : public IndexStmtNode {

--- a/include/taco/index_notation/index_notation_nodes.h
+++ b/include/taco/index_notation/index_notation_nodes.h
@@ -183,10 +183,7 @@ struct YieldNode : public IndexStmtNode {
 };
 
 struct ForallNode : public IndexStmtNode {
-  ForallNode(IndexVar indexVar, IndexStmt stmt)
-          : indexVar(indexVar), stmt(stmt), tags({}) {}
-
-  ForallNode(IndexVar indexVar, IndexStmt stmt, std::vector<Forall::TAG> tags)
+  ForallNode(IndexVar indexVar, IndexStmt stmt, std::set<Forall::TAG> tags)
       : indexVar(indexVar), stmt(stmt), tags(tags) {}
 
   void accept(IndexStmtVisitorStrict* v) const {
@@ -195,7 +192,7 @@ struct ForallNode : public IndexStmtNode {
 
   IndexVar indexVar;
   IndexStmt stmt;
-  std::vector<Forall::TAG> tags;
+  std::set<Forall::TAG> tags;
 };
 
 struct WhereNode : public IndexStmtNode {

--- a/include/taco/index_notation/transformations.h
+++ b/include/taco/index_notation/transformations.h
@@ -94,5 +94,28 @@ private:
 /// Print a precompute command.
 std::ostream& operator<<(std::ostream&, const Precompute&);
 
+/// The precompute optimizaton rewrites an index expression to precompute `expr`
+/// and store it to the given workspace.
+class Parallelize : public TransformationInterface {
+public:
+  Parallelize();
+  Parallelize(IndexExpr expr, IndexVar i);
+
+  IndexExpr getExpr() const;
+  IndexVar geti() const;
+
+  /// Apply the precompute optimization to a concrete index statement.
+  IndexStmt apply(IndexStmt stmt, std::string* reason=nullptr) const;
+
+  void print(std::ostream& os) const;
+
+private:
+  struct Content;
+  std::shared_ptr<Content> content;
+};
+
+/// Print a precompute command.
+std::ostream& operator<<(std::ostream&, const Parallelize&);
+
 }
 #endif

--- a/include/taco/index_notation/transformations.h
+++ b/include/taco/index_notation/transformations.h
@@ -99,9 +99,8 @@ std::ostream& operator<<(std::ostream&, const Precompute&);
 class Parallelize : public TransformationInterface {
 public:
   Parallelize();
-  Parallelize(IndexExpr expr, IndexVar i);
+  Parallelize(IndexVar i);
 
-  IndexExpr getExpr() const;
   IndexVar geti() const;
 
   /// Apply the precompute optimization to a concrete index statement.
@@ -116,6 +115,8 @@ private:
 
 /// Print a precompute command.
 std::ostream& operator<<(std::ostream&, const Parallelize&);
+
+IndexStmt parallelizeOuterLoop(IndexStmt stmt);
 
 }
 #endif

--- a/include/taco/index_notation/transformations.h
+++ b/include/taco/index_notation/transformations.h
@@ -15,6 +15,7 @@ class IndexStmt;
 class TransformationInterface;
 class Reorder;
 class Precompute;
+class Parallelize;
 
 /// A transformation is an optimization that transforms a statement in the
 /// concrete index notation into a new statement that computes the same result
@@ -24,6 +25,7 @@ class Transformation {
 public:
   Transformation(Reorder);
   Transformation(Precompute);
+  Transformation(Parallelize);
 
   IndexStmt apply(IndexStmt stmt, std::string* reason=nullptr) const;
 

--- a/include/taco/lower/iterator.h
+++ b/include/taco/lower/iterator.h
@@ -201,6 +201,10 @@ public:
                         const std::map<TensorVar, ir::Expr>& tensorVars,
                         std::map<Iterator, IndexVar>* indexVars);
 
+  // Create iterators just from IndexStmt
+  static Iterators make(IndexStmt stmt,
+                        std::map<Iterator, IndexVar>* indexVars);
+
   /**
    * Retrieve the coordinate hierarchy level iterator corresponding to the
    * given mode access.

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -732,5 +732,14 @@ Tensor<CType> iterate(const TensorBase& tensor) {
   return Tensor<CType>(tensor);
 }
 
+/// Gets Taco's global number of threads to use for parallelism
+/// This will be replaced by a scheduling language in the future
+int get_taco_num_threads();
+
+/// Sets Taco's global number of threads to use for parallelism
+/// This will be replaced by a scheduling language in the future
+/// Returns true if successful (ie num_threads > 0)
+bool set_taco_num_threads(int num_threads);
+
 }
 #endif

--- a/src/codegen/codegen_c.cpp
+++ b/src/codegen/codegen_c.cpp
@@ -329,7 +329,7 @@ string printContextDeclAndInit(map<Expr, string, ExprCompare> varMap,
   ret << "  }" << endl;
 
   return ret.str();
-};
+}
 
 int countYields(const Function *func) {
   struct CountYields : public IRVisitor {

--- a/src/codegen/codegen_c.cpp
+++ b/src/codegen/codegen_c.cpp
@@ -3,6 +3,7 @@
 #include <dlfcn.h>
 #include <algorithm>
 #include <unordered_set>
+#include <taco.h>
 
 #include "taco/ir/ir_visitor.h"
 #include "codegen_c.h"
@@ -685,6 +686,10 @@ static string getParallelizePragma(LoopKind kind) {
   ret << "#pragma omp parallel for";
   if (kind == LoopKind::Dynamic) {
     ret << " schedule(dynamic, 16)";
+  }
+  int num_threads = get_taco_num_threads();
+  if (num_threads != -1) {
+    ret << " num_threads(" << num_threads << ")";
   }
   return ret.str();
 }

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -12,6 +12,7 @@
 #include "taco/index_notation/index_notation_nodes.h"
 #include "taco/index_notation/index_notation_rewriter.h"
 #include "taco/index_notation/index_notation_printer.h"
+#include "taco/ir/ir.h"
 
 #include "taco/util/name_generator.h"
 #include "taco/util/scopedmap.h"
@@ -1545,6 +1546,19 @@ vector<IndexVar> getIndexVars(IndexStmt stmt) {
   return visitor.indexVars;
 }
 
+vector<ir::Expr> createVars(const vector<TensorVar>& tensorVars,
+                        map<TensorVar, ir::Expr>* vars) {
+  taco_iassert(vars != nullptr);
+  vector<ir::Expr> irVars;
+  for (auto& var : tensorVars) {
+    ir::Expr irVar = ir::Var::make(var.getName(),
+                           var.getType().getDataType(),
+                           true, true);
+    irVars.push_back(irVar);
+    vars->insert({var, irVar});
+  }
+  return irVars;
+}
 
 struct Zero : public IndexNotationRewriterStrict {
 public:

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -834,7 +834,11 @@ Forall::Forall(const ForallNode* n) : IndexStmt(n) {
 }
 
 Forall::Forall(IndexVar indexVar, IndexStmt stmt)
-    : Forall(new ForallNode(indexVar, stmt)) {
+    : Forall(new ForallNode(indexVar, stmt, {})) {
+}
+
+Forall::Forall(IndexVar indexVar, IndexStmt stmt, std::vector<TAG> tags)
+        : Forall(new ForallNode(indexVar, stmt, tags)) {
 }
 
 IndexVar Forall::getIndexVar() const {
@@ -845,8 +849,14 @@ IndexStmt Forall::getStmt() const {
   return getNode(*this)->stmt;
 }
 
+
+
 Forall forall(IndexVar i, IndexStmt expr) {
   return Forall(i, expr);
+}
+
+Forall forall(IndexVar i, IndexStmt expr, std::vector<Forall::TAG> tags) {
+  return Forall(i, expr, tags);
 }
 
 template <> bool isa<Forall>(IndexStmt s) {

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -258,7 +258,8 @@ struct Equals : public IndexNotationVisitorStrict {
     }
     auto bnode = to<ForallNode>(bStmt.ptr);
     if (anode->indexVar != bnode->indexVar ||
-        !equals(anode->stmt, bnode->stmt)) {
+        !equals(anode->stmt, bnode->stmt) ||
+        anode->tags != bnode->tags) {
       eq = false;
       return;
     }
@@ -837,7 +838,7 @@ Forall::Forall(IndexVar indexVar, IndexStmt stmt)
     : Forall(new ForallNode(indexVar, stmt, {})) {
 }
 
-Forall::Forall(IndexVar indexVar, IndexStmt stmt, std::vector<TAG> tags)
+Forall::Forall(IndexVar indexVar, IndexStmt stmt, std::set<TAG> tags)
         : Forall(new ForallNode(indexVar, stmt, tags)) {
 }
 
@@ -849,13 +850,17 @@ IndexStmt Forall::getStmt() const {
   return getNode(*this)->stmt;
 }
 
+std::set<Forall::TAG> Forall::getTags() const {
+  return getNode(*this)->tags;
+}
+
 
 
 Forall forall(IndexVar i, IndexStmt expr) {
   return Forall(i, expr);
 }
 
-Forall forall(IndexVar i, IndexStmt expr, std::vector<Forall::TAG> tags) {
+Forall forall(IndexVar i, IndexStmt expr, std::set<Forall::TAG> tags) {
   return Forall(i, expr, tags);
 }
 
@@ -1697,7 +1702,7 @@ private:
       stmt = op;
     }
     else {
-      stmt = new ForallNode(op->indexVar, body);
+      stmt = new ForallNode(op->indexVar, body, op->tags);
     }
   }
 

--- a/src/index_notation/index_notation_printer.cpp
+++ b/src/index_notation/index_notation_printer.cpp
@@ -186,6 +186,15 @@ void IndexNotationPrinter::visit(const YieldNode* op) {
 void IndexNotationPrinter::visit(const ForallNode* op) {
   os << "forall(" << op->indexVar << ", ";
   op->stmt.accept(this);
+  for (auto iter = op->tags.begin(); iter != op->tags.end(); ++iter) {
+    switch (*iter) {
+      case Forall::PARALLELIZE:
+        os << ", PARALLELIZE";
+        break;
+      default:
+        taco_ierror;
+    }
+  }
   os << ")";
 }
 

--- a/src/index_notation/index_notation_rewriter.cpp
+++ b/src/index_notation/index_notation_rewriter.cpp
@@ -131,7 +131,7 @@ void IndexNotationRewriter::visit(const ForallNode* op) {
     stmt = op;
   }
   else {
-    stmt = new ForallNode(op->indexVar, s);
+    stmt = new ForallNode(op->indexVar, s, op->tags);
   }
 }
 

--- a/src/index_notation/kernel.cpp
+++ b/src/index_notation/kernel.cpp
@@ -9,6 +9,9 @@
 #include "taco/storage/index.h"
 #include "taco/storage/array.h"
 #include "taco/taco_tensor_t.h"
+#include <taco/index_notation/transformations.h>
+#include "taco/index_notation/index_notation_nodes.h"
+
 
 using namespace std;
 
@@ -110,6 +113,7 @@ Kernel compile(IndexStmt stmt) {
       << reason << endl << stmt;
 
   shared_ptr<ir::Module> module(new ir::Module);
+  stmt = parallelizeOuterLoop(stmt);
   module->addFunction(lower(stmt, "compute",  false, true));
   module->addFunction(lower(stmt, "assemble", true, false));
   module->addFunction(lower(stmt, "evaluate", true, true));

--- a/src/index_notation/transformations.cpp
+++ b/src/index_notation/transformations.cpp
@@ -289,7 +289,7 @@ std::ostream& operator<<(std::ostream& os, const Precompute& precompute) {
           stmt = forall(i, rewrite(foralli.getStmt()), {Forall::PARALLELIZE});
           return;
         }
-        ParallelizeRewriter::visit(node);
+        IndexNotationRewriter::visit(node);
       }
 
     };

--- a/src/lower/iterator.cpp
+++ b/src/lower/iterator.cpp
@@ -448,6 +448,26 @@ Iterators Iterators::make(IndexStmt stmt,
   return Iterators(levelIterators, modeIterators);
 }
 
+Iterators Iterators::make(IndexStmt stmt, std::map<Iterator, IndexVar>* indexVars)
+{
+  std::map<TensorVar, ir::Expr> tensorVars;
+
+  // Create result and parameter variables
+  vector<TensorVar> results = getResultTensorVars(stmt);
+  vector<TensorVar> arguments = getInputTensorVars(stmt);
+  vector<TensorVar> temporaries = getTemporaryTensorVars(stmt);
+
+  // Convert tensor results, arguments and temporaries to IR variables
+  map<TensorVar, Expr> resultVars;
+  vector<Expr> resultsIR = createVars(results, &resultVars);
+  tensorVars.insert(resultVars.begin(), resultVars.end());
+  vector<Expr> argumentsIR = createVars(arguments, &tensorVars);
+  vector<Expr> temporariesIR = createVars(temporaries, &tensorVars);
+
+  // Create iterators
+  return Iterators::make(stmt, tensorVars, indexVars);
+}
+
 Iterator Iterators::levelIterator(ModeAccess modeAccess) const
 {
   taco_iassert(content != nullptr);

--- a/src/lower/lowerer_impl.cpp
+++ b/src/lower/lowerer_impl.cpp
@@ -59,21 +59,6 @@ LowererImpl::LowererImpl() : visitor(new Visitor(this)) {
 }
 
 
-/// Convert index notation tensor variables to IR pointer variables.
-static vector<Expr> createVars(const vector<TensorVar>& tensorVars,
-                               map<TensorVar, Expr>* vars) {
-  taco_iassert(vars != nullptr);
-  vector<Expr> irVars;
-  for (auto& var : tensorVars) {
-    Expr irVar = Var::make(var.getName(),
-                           var.getType().getDataType(),
-                           true, true);
-    irVars.push_back(irVar);
-    vars->insert({var, irVar});
-  }
-  return irVars;
-}
-
 static void createCapacityVars(const map<TensorVar, Expr>& tensorVars,
                                map<Expr, Expr>* capacityVars) {
   for (auto& tensorVar : tensorVars) {

--- a/src/lower/lowerer_impl.cpp
+++ b/src/lower/lowerer_impl.cpp
@@ -419,7 +419,7 @@ Stmt LowererImpl::lowerForallDimension(Forall forall,
   // Emit loop with preamble and postamble
   Expr dimension = getDimension(forall.getIndexVar());
   return Block::blanks(For::make(coordinate, 0, dimension, 1, body,
-                                 LoopKind::Serial, false),
+                                 forall.getTags().count(Forall::PARALLELIZE) ? LoopKind::Static : LoopKind::Serial, false),
                        posAppend);
 }
 
@@ -475,7 +475,7 @@ Stmt LowererImpl::lowerForallPosition(Forall forall, Iterator iterator,
   return Block::blanks(boundsCompute,
                        For::make(iterator.getPosVar(), startBound, endBound, 1,
                                  Block::make(declareCoordinate, body),
-                                 LoopKind::Serial, false),
+                                 forall.getTags().count(Forall::PARALLELIZE) ? LoopKind::Static : LoopKind::Serial, false),
                        posAppend);
 
 }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -8,6 +8,7 @@
 #include <climits>
 #include <chrono>
 #include <vector>
+#include <taco/index_notation/transformations.h>
 
 #include "taco/format.h"
 #include "taco/index_notation/index_notation.h"
@@ -445,7 +446,7 @@ void TensorBase::compile(bool assembleWhileCompute) {
   if (std::getenv("NEW_LOWER") && 
       std::string(std::getenv("NEW_LOWER")) == "1") {
     IndexStmt stmt = makeConcrete(assignment);
-
+    stmt = parallelizeOuterLoop(stmt);
     content->assembleFunc = lower(stmt, "assemble", true, false);
     content->computeFunc = lower(stmt, "compute",  assembleWhileCompute, true);
   } else {
@@ -1010,6 +1011,21 @@ void packOperands(const TensorBase& tensor) {
   for (TensorBase operand : operands) {
     operand.pack();
   }
+}
+
+
+static int taco_num_threads = -1;
+
+int get_taco_num_threads() {
+  return taco_num_threads;
+}
+
+bool set_taco_num_threads(int num_threads) {
+  if (num_threads > 0) {
+    taco_num_threads = num_threads;
+    return true;
+  }
+  return false;
 }
 
 }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -445,7 +445,7 @@ void TensorBase::compile(bool assembleWhileCompute) {
   if (std::getenv("NEW_LOWER") && 
       std::string(std::getenv("NEW_LOWER")) == "1") {
     IndexStmt stmt = makeConcrete(assignment);
-    
+
     content->assembleFunc = lower(stmt, "assemble", true, false);
     content->computeFunc = lower(stmt, "compute",  assembleWhileCompute, true);
   } else {

--- a/tools/taco.cpp
+++ b/tools/taco.cpp
@@ -30,6 +30,7 @@
 #include "taco/util/env.h"
 #include "taco/util/collections.h"
 #include "taco/cuda.h"
+#include <taco/index_notation/transformations.h>
 
 // TODO remove
 #include "taco/index_notation/index_notation_rewriter.h"
@@ -737,7 +738,7 @@ int main(int argc, char* argv[]) {
   else {
     if (newLower) {
       IndexStmt stmt = makeConcrete(tensor.getAssignment());
-
+      stmt = parallelizeOuterLoop(stmt);
       compute = lower(stmt, "compute",  false, true);
       assemble = lower(stmt, "assemble", true, false);
       evaluate = lower(stmt, "evaluate", true, true);


### PR DESCRIPTION
Adds the parallelize scheduling command to allow for parallelizing loops that fit the preconditions specified in the original taco paper.

Instead of exposing the full scheduling language yet, this transformation is automatically applied before lowering. This allows taco v2 (#201) to produce the same type of parallel code that taco v1 could. In the future this command will be extended to allow some of the existing preconditions to be broken. #127 is out of date, but should track this progress going forward. 