### PR TITLE
Topologically Reorder Concrete Index Notation

### DIFF
--- a/include/taco/index_notation/transformations.h
+++ b/include/taco/index_notation/transformations.h
@@ -125,6 +125,9 @@ IndexStmt parallelizeOuterLoop(IndexStmt stmt);
 /// The TopoReorder transformation topologically reorders
 /// the ForAlls so that all tensors are iterated in order
 /// Only reorders first contiguous section of ForAlls
+/// iterators form constraints on other dimensions
+/// for example a {dense, dense, sparse, dense, dense} tensor
+/// has constraints i -> k, j -> k, k -> l, k -> m
 class TopoReorder : public TransformationInterface {
 public:
   TopoReorder();

--- a/include/taco/index_notation/transformations.h
+++ b/include/taco/index_notation/transformations.h
@@ -16,6 +16,7 @@ class TransformationInterface;
 class Reorder;
 class Precompute;
 class Parallelize;
+class TopoReorder;
 
 /// A transformation is an optimization that transforms a statement in the
 /// concrete index notation into a new statement that computes the same result
@@ -26,6 +27,7 @@ public:
   Transformation(Reorder);
   Transformation(Precompute);
   Transformation(Parallelize);
+  Transformation(TopoReorder);
 
   IndexStmt apply(IndexStmt stmt, std::string* reason=nullptr) const;
 
@@ -96,8 +98,8 @@ private:
 /// Print a precompute command.
 std::ostream& operator<<(std::ostream&, const Precompute&);
 
-/// The precompute optimizaton rewrites an index expression to precompute `expr`
-/// and store it to the given workspace.
+/// The parallelize optimization tags a Forall as parallelized
+/// after checking for preconditions
 class Parallelize : public TransformationInterface {
 public:
   Parallelize();
@@ -105,7 +107,7 @@ public:
 
   IndexVar geti() const;
 
-  /// Apply the precompute optimization to a concrete index statement.
+  /// Apply the parallelize optimization to a concrete index statement.
   IndexStmt apply(IndexStmt stmt, std::string* reason=nullptr) const;
 
   void print(std::ostream& os) const;
@@ -115,10 +117,27 @@ private:
   std::shared_ptr<Content> content;
 };
 
-/// Print a precompute command.
+/// Print a parallelize command.
 std::ostream& operator<<(std::ostream&, const Parallelize&);
 
 IndexStmt parallelizeOuterLoop(IndexStmt stmt);
+
+/// The TopoReorder transformation topologically reorders
+/// the ForAlls so that all tensors are iterated in order
+/// Only reorders first contiguous section of ForAlls
+class TopoReorder : public TransformationInterface {
+public:
+  TopoReorder();
+
+  /// Apply topological reordering on a concrete index statement.
+  IndexStmt apply(IndexStmt stmt, std::string* reason=nullptr) const;
+
+  void print(std::ostream& os) const;
+};
+
+/// Print a parallelize command.
+std::ostream& operator<<(std::ostream&, const TopoReorder&);
+
 
 }
 #endif

--- a/src/lower/iterator.cpp
+++ b/src/lower/iterator.cpp
@@ -465,7 +465,8 @@ Iterators Iterators::make(IndexStmt stmt, std::map<Iterator, IndexVar>* indexVar
   vector<Expr> temporariesIR = createVars(temporaries, &tensorVars);
 
   // Create iterators
-  return Iterators::make(stmt, tensorVars, indexVars);
+  Iterators iterators = Iterators::make(stmt, tensorVars, indexVars);
+  return iterators;
 }
 
 Iterator Iterators::levelIterator(ModeAccess modeAccess) const

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -446,6 +446,9 @@ void TensorBase::compile(bool assembleWhileCompute) {
   if (std::getenv("NEW_LOWER") && 
       std::string(std::getenv("NEW_LOWER")) == "1") {
     IndexStmt stmt = makeConcrete(assignment);
+    string reason;
+    stmt = TopoReorder().apply(stmt, &reason);
+    taco_uassert(stmt != IndexStmt()) << reason;
     stmt = parallelizeOuterLoop(stmt);
     content->assembleFunc = lower(stmt, "assemble", true, false);
     content->computeFunc = lower(stmt, "compute",  assembleWhileCompute, true);

--- a/test/tests-transformation.cpp
+++ b/test/tests-transformation.cpp
@@ -221,6 +221,32 @@ INSTANTIATE_TEST_CASE_P(parallelize, apply,
                         )
 );
 
+
+INSTANTIATE_TEST_CASE_P(topo_reorder, apply,
+                        Values(
+                                TransformationTest(TopoReorder(),
+                                                   forall(i, w(i) = b(i)),
+                                                   forall(i, w(i) = b(i))
+                                ),
+                                TransformationTest(TopoReorder(),
+                                                   forall(i, w(i) = b(i), {Forall::PARALLELIZE}),
+                                                   forall(i, w(i) = b(i), {Forall::PARALLELIZE})
+                                ),
+                                TransformationTest(TopoReorder(),
+                                                   forall(i, forall(j, W(i,j) = A(i,j))),
+                                                   forall(i, forall(j, W(i,j) = A(i,j)))
+                                ),
+                                TransformationTest(TopoReorder(),
+                                                   forall(j, forall(i, W(i,j) = A(i,j))),
+                                                   forall(i, forall(j, W(i,j) = A(i,j)))
+                                ),
+                                TransformationTest(TopoReorder(),
+                                                   forall(j, forall(i, W(i,j) = D(i,j))),
+                                                   forall(j, forall(i, W(i,j) = D(i,j)))
+                                )
+                        )
+);
+
 /*
 TEST(schedule, workspace_spmspm) {
   TensorBase A("A", Float(64), {3,3}, Format({Dense,Sparse}));

--- a/test/tests-transformation.cpp
+++ b/test/tests-transformation.cpp
@@ -266,7 +266,7 @@ INSTANTIATE_TEST_CASE_P(topo_reorder, apply,
                                 ),
                                 TransformationTest(TopoReorder(),
                                                    forall(k, forall(j, forall(i, X(i,j,k) = Y(i,j,k)))),
-                                                   forall(i, forall(j, forall(k, X(i,j,k) = Y(i,j,k))))
+                                                   forall(i, forall(k, forall(j, X(i,j,k) = Y(i,j,k))))
                                 ),
                                 TransformationTest(TopoReorder(),
                                                    forall(k, forall(j, forall(i, X(i,j,k) = Z(i,j,k)))),

--- a/test/tests-transformation.cpp
+++ b/test/tests-transformation.cpp
@@ -229,6 +229,17 @@ INSTANTIATE_TEST_CASE_P(parallelize, apply,
                         )
 );
 
+// Detect cycles
+INSTANTIATE_TEST_CASE_P(topo_reorder, precondition,
+                        Values(
+                                PreconditionTest(TopoReorder(),
+                                        forall(i, forall(j, A(j, i) = B(i, j)))),
+                                PreconditionTest(TopoReorder(),
+                                                 forall(i, forall(j, W(i, j) = A(j, i) + B(i, j)))),
+                                PreconditionTest(TopoReorder(),
+                                                 forall(i, forall(j, W(i, j) = A(j, i) * B(i, j))))
+                        )
+);
 
 INSTANTIATE_TEST_CASE_P(topo_reorder, apply,
                         Values(
@@ -251,6 +262,10 @@ INSTANTIATE_TEST_CASE_P(topo_reorder, apply,
                                 TransformationTest(TopoReorder(),
                                                    forall(j, forall(i, W(i,j) = D(i,j))),
                                                    forall(j, forall(i, W(i,j) = D(i,j)))
+                                ),
+                                TransformationTest(TopoReorder(),
+                                                   forall(i, forall(j, W(j,i) = D(i,j))),
+                                                   forall(i, forall(j, W(j,i) = D(i,j)))
                                 ),
                                 TransformationTest(TopoReorder(),
                                                    forall(j, forall(i, A(i,j) = D(i,j))),

--- a/tools/taco.cpp
+++ b/tools/taco.cpp
@@ -738,6 +738,9 @@ int main(int argc, char* argv[]) {
   else {
     if (newLower) {
       IndexStmt stmt = makeConcrete(tensor.getAssignment());
+      string reason;
+      stmt = TopoReorder().apply(stmt, &reason);
+      taco_uassert(stmt != IndexStmt()) << reason;
       stmt = parallelizeOuterLoop(stmt);
       compute = lower(stmt, "compute",  false, true);
       assemble = lower(stmt, "assemble", true, false);


### PR DESCRIPTION
Topologically reorders Concrete Index Notation so as to access tensors in order. This allows for TACO to generate efficient and correct code for expressions where the default iteration order is not correct. For example a {dense, dense, sparse, dense, dense} tensor has constraints i -> k, j -> k, k -> l, k -> m, but the pairs (i, j) and (l, m) can be reordered depending on other constraints. This code also checks for cycles in the dependencies and prints an error message to inform users that they must transpose one of the tensors (#197 tracks progress on a faster transpose implementation). In the future this transformation will be exposed in a scheduling language (#127).