### PR TITLE
Python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(CUDA)
 endif(CUDA)
 
 if(PYTHON)
-  message("-- Building Python Extension")
+  message("-- Will Build Python Extension")
   add_definitions(-DPYTHON)
 endif(PYTHON)
 

--- a/include/taco/parser/einsum_parser.h
+++ b/include/taco/parser/einsum_parser.h
@@ -23,10 +23,10 @@ public:
   EinsumParser(const std::string &expression, const std::vector<TensorBase> &tensors);
 
   /// Parses the einsum string and gets the result tensor
-  void parse();
+//  void parse();
 
   /// Gets the result of the einsum expression after it has been parsed
-  TensorBase getResultTensor();
+//  TensorBase getResultTensor();
 
   /// Returns num_unused_symbols valid numpy einsum symbols that are not in used_symbols
   static std::vector<std::string> genUnusedSymbols(std::set<std::string> &usedSymbols, int numUnusedSymbolsNeeded);

--- a/include/taco/parser/einsum_parser.h
+++ b/include/taco/parser/einsum_parser.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <set>
 
+#include "taco/tensor.h"
 #include "taco/util/uncopyable.h"
 #include "taco/type.h"
 
@@ -16,41 +17,48 @@ namespace parser {
 
 class EinsumParser : public util::Uncopyable {
 
-
 public:
+
   /// Create a parser object from einsum notation
   /// @throws ParserError is there is an error with parsing the einsum string
-  EinsumParser(const std::string &expression, const std::vector<TensorBase> &tensors);
-
-  /// Parses the einsum string and gets the result tensor
-//  void parse();
-
-  /// Gets the result of the einsum expression after it has been parsed
-//  TensorBase getResultTensor();
-
-  /// Returns num_unused_symbols valid numpy einsum symbols that are not in used_symbols
-  static std::vector<std::string> genUnusedSymbols(std::set<std::string> &usedSymbols, int numUnusedSymbolsNeeded);
-
-  /// Returns the output string for a given einsum expression in implicit notation
-  static std::string findOutputString(const std::string &subscripts);
+  EinsumParser(const std::string &expression, std::vector<TensorBase> &tensors,
+               Format &format, Datatype outType);
 
   /// Returns true if the expression passed in has an output specified and false otherwise
   /// @throws ParserError if output is not specified correctly
-  static bool exprHasOutput(const std::string &subscripts);
+  bool exprHasOutput(const std::string& subscripts);
 
-  /// Converts an operand to taco notation
-  /// @throws ParserError if ellipses incorrectly specified.
-  static std::string convertToIndexExpr(const std::string &subscripts, const std::vector<std::string> &ellipsisReplacement,
-                                        const std::string &tensorName);
-
-  /// Replaces ellipsis in string with valid indices and returns a vector with the result tensor expression last
-  /// and the input tensors preceding the result tensor in a vector.
+  /// Parses the einsum expression and sets the result tensor to the result of that expression
   /// @throws ParserError is there is an error with parsing the einsum stirng
-  static std::vector<std::string> parseToTaco(const std::string &subscripts, const std::vector<TensorBase>& tensors);
+  void parse();
+
+  /// Gets the result tensor after parsing is complete.
+  TensorBase& getResultTensor();
 
 private:
-  // TensorBase resultTensor;
-  std::string tensorExpressions;
+  std::string einsumSymbols;
+  std::set<char> einSumSymbolsSet;
+  std::string einsumPunctuation;
+  Datatype outType;
+  Format format;
+
+
+  std::string subscripts;
+  TensorBase resultTensor;
+  std::vector<TensorBase> &tensors;
+
+  /// Replaces the ellipses in an expression
+  std::string replaceEllipse(std::string inp, std::string &newString);
+
+  /// Returns a sorted string of unique elements for a given einsum expression in implicit notation
+  std::string findUniqueIndices(const std::string &subscripts);
+
+  /// Builds the result tensor given the explicit input and output substrings
+  void buildResult(std::vector<std::string> inputAndOutput);
+
+  /// splits a string by , but keeps the empty string
+  std::vector<std::string> splitSubscriptInput(std::string &inp);
+
 };
 
 

--- a/include/taco/parser/einsum_parser.h
+++ b/include/taco/parser/einsum_parser.h
@@ -11,7 +11,7 @@
 #include "taco/type.h"
 
 namespace taco {
-class TensorVar;
+class TensorBase;
 namespace parser {
 
 class EinsumParser : public util::Uncopyable {
@@ -20,10 +20,16 @@ class EinsumParser : public util::Uncopyable {
 public:
   /// Create a parser object from einsum notation
   /// @throws ParserError is there is an error with parsing the einsum string
-  EinsumParser(const std::string &expression, const std::vector<TensorVar> &tensors);
+  EinsumParser(const std::string &expression, const std::vector<TensorBase> &tensors);
+
+  /// Parses the einsum string and gets the result tensor
+  void parse();
+
+  /// Gets the result of the einsum expression after it has been parsed
+  TensorBase getResultTensor();
 
   /// Returns num_unused_symbols valid numpy einsum symbols that are not in used_symbols
-  static std::vector<std::string> genUnusedSymbols(const std::set<char> &usedSymbols, int numUnusedSymbolsNeeded);
+  static std::vector<std::string> genUnusedSymbols(std::set<std::string> &usedSymbols, int numUnusedSymbolsNeeded);
 
   /// Returns the output string for a given einsum expression in implicit notation
   static std::string findOutputString(const std::string &subscripts);
@@ -34,14 +40,17 @@ public:
 
   /// Converts an operand to taco notation
   /// @throws ParserError if ellipses incorrectly specified.
-  static std::string convertToIndexExpr(const std::string &subscripts, const std::string &ellipsisReplacement,
+  static std::string convertToIndexExpr(const std::string &subscripts, const std::vector<std::string> &ellipsisReplacement,
                                         const std::string &tensorName);
 
   /// Replaces ellipsis in string with valid indices and returns a vector with the result tensor expression last
   /// and the input tensors preceding the result tensor in a vector.
   /// @throws ParserError is there is an error with parsing the einsum stirng
-  static std::vector<std::string> parseToTaco(const std::string &subscripts, const std::vector<TensorVar>& tensors);
+  static std::vector<std::string> parseToTaco(const std::string &subscripts, const std::vector<TensorBase>& tensors);
 
+private:
+  // TensorBase resultTensor;
+  std::string tensorExpressions;
 };
 
 

--- a/include/taco/parser/parser.h
+++ b/include/taco/parser/parser.h
@@ -54,9 +54,13 @@ public:
   /// Retrieve a map from tensor names to tensors.
   const std::map<std::string,TensorBase>& getTensors() const;
 
+  /// Retrieve a list of names in the order they occurred in the expression
+  const std::vector<std::string> getNames() const;
+
 private:
   struct Content;
   std::shared_ptr<Content> content;
+  std::vector<std::string> names;
 
   /// assign ::= access '=' expr
   ///          | access '+=' expr

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -679,13 +679,14 @@ void write(std::ofstream& file, FileType filetype, const TensorBase& tensor);
 
 template<typename CType>
 TensorBase makeCSR(const std::string& name, const std::vector<int>& dimensions,
-                   int* rowptr, int* colidx, CType* vals) {
+                   int* rowptr, int* colidx, CType* vals, Array::Policy policy = Array::UserOwns) {
   taco_uassert(dimensions.size() == 2) << error::requires_matrix;
   Tensor<CType> tensor(name, dimensions, CSR);
   auto storage = tensor.getStorage();
   auto index = makeCSRIndex(dimensions[0], rowptr, colidx);
   storage.setIndex(index);
-  storage.setValues(makeArray(vals, index.getSize(), Array::UserOwns));
+  storage.setValues(makeArray(vals, index.getSize(), policy));
+  tensor.setStorage(storage);
   return tensor;
 }
 
@@ -700,6 +701,7 @@ TensorBase makeCSR(const std::string& name, const std::vector<int>& dimensions,
   auto storage = tensor.getStorage();
   storage.setIndex(makeCSRIndex(rowptr, colidx));
   storage.setValues(makeArray(vals));
+  tensor.setStorage(storage);
   return std::move(tensor);
 }
 
@@ -726,13 +728,14 @@ void getCSRArrays(const TensorBase& tensor,
 /// arrays remain owned by the user and will not be freed by taco.
 template<typename T>
 TensorBase makeCSC(const std::string& name, const std::vector<int>& dimensions,
-                   int* colptr, int* rowidx, T* vals) {
+                   int* colptr, int* rowidx, T* vals, Array::Policy policy = Array::UserOwns) {
   taco_uassert(dimensions.size() == 2) << error::requires_matrix;
   Tensor<T> tensor(name, dimensions, CSC);
   auto storage = tensor.getStorage();
   auto index = makeCSCIndex(dimensions[1], colptr, rowidx);
   storage.setIndex(index);
-  storage.setValues(makeArray(vals, index.getSize(), Array::UserOwns));
+  storage.setValues(makeArray(vals, index.getSize(), policy));
+  tensor.setStorage(storage);
   return tensor;
 }
 
@@ -747,6 +750,7 @@ TensorBase makeCSC(const std::string& name, const std::vector<int>& dimensions,
   auto storage = tensor.getStorage();
   storage.setIndex(makeCSCIndex(colptr, rowidx));
   storage.setValues(makeArray(vals));
+  tensor.setStorage(storage);
   return std::move(tensor);
 }
 
@@ -903,7 +907,7 @@ Tensor<CType>::Tensor(CType value) : TensorBase(value) {}
 
 template <typename CType>
 Tensor<CType>::Tensor(std::vector<int> dimensions, ModeFormat modeType) 
-    : TensorBase(type<CType>(), dimensions) {}
+    : TensorBase(type<CType>(), dimensions, modeType) {}
 
 template <typename CType>
 Tensor<CType>::Tensor(std::vector<int> dimensions, Format format)

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -1,15 +1,19 @@
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto -fvisibility=hidden -Wno-gnu-zero-variadic-macro-arguments")
 
-
 add_subdirectory(pybind11)
 
 include_directories(${PYTHON_INCLUDE_DIRS})
 include_directories(${TACO_INCLUDE_DIR})
 include_directories(${TACO_PROJECT_DIR}/python_bindings/include)
 
+set(PY_SRC_DIRS src)
 
-pybind11_add_module(core_modules src/pytaco.cpp src/pyFormat.cpp src/pyDatatypes.cpp src/pyTensor.cpp
-                    src/pyIndexNotation.cpp src/pyTensorIO.cpp src/pyParsers.cpp)
+foreach(dir ${PY_SRC_DIRS})
+    file(GLOB PY_SOURCES ${PY_SOURCES} ${dir}/*.cpp)
+endforeach()
+
+set(PY_SOURCES ${PY_SOURCES})
+pybind11_add_module(core_modules ${PY_SOURCES} ${TACO_SOURCES})
 
 set_target_properties(core_modules PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${TACO_PROJECT_DIR}/python_bindings/pytaco/core)
 target_link_libraries(core_modules LINK_PRIVATE taco)

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto -fvisibility=hidden")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto -fvisibility=hidden -Wno-gnu-zero-variadic-macro-arguments")
 
 
 add_subdirectory(pybind11)
@@ -8,8 +8,9 @@ include_directories(${TACO_INCLUDE_DIR})
 include_directories(${TACO_PROJECT_DIR}/python_bindings/include)
 
 
-pybind11_add_module(pytaco src/pytaco.cpp src/pyFormat.cpp src/pyDatatypes.cpp src/pyTensor.cpp
-                    src/pyIndexNotation.cpp src/pyTensorIO.cpp)
-set_target_properties(pytaco PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${TACO_PROJECT_DIR}/python_bindings/libs)
-target_link_libraries(pytaco LINK_PRIVATE taco)
+pybind11_add_module(core_modules src/pytaco.cpp src/pyFormat.cpp src/pyDatatypes.cpp src/pyTensor.cpp
+                    src/pyIndexNotation.cpp src/pyTensorIO.cpp src/pyParsers.cpp)
+
+set_target_properties(core_modules PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${TACO_PROJECT_DIR}/python_bindings/pytaco/core)
+target_link_libraries(core_modules LINK_PRIVATE taco)
 

--- a/python_bindings/include/pyParsers.h
+++ b/python_bindings/include/pyParsers.h
@@ -1,0 +1,17 @@
+#ifndef TACO_PYPARSERS_H
+#define TACO_PYPARSERS_H
+
+#include "taco/parser/parser.h"
+#include "taco/parser/einsum_parser.h"
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace taco{
+namespace pythonBindings{
+
+void defineParser(py::module& m);
+
+}}
+
+#endif //TACO_PYPARSERS_H

--- a/python_bindings/pytaco/__init__.py
+++ b/python_bindings/pytaco/__init__.py
@@ -1,0 +1,2 @@
+from .core.core_modules import *
+from .pytensor import *

--- a/python_bindings/pytaco/numpy_license.txt
+++ b/python_bindings/pytaco/numpy_license.txt
@@ -1,0 +1,30 @@
+Copyright (c) 2005-2019, NumPy Developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following
+       disclaimer in the documentation and/or other materials provided
+       with the distribution.
+
+    * Neither the name of the NumPy Developers nor the names of any
+       contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/python_bindings/pytaco/pytensor/__init__.py
+++ b/python_bindings/pytaco/pytensor/__init__.py
@@ -1,0 +1,3 @@
+from .taco_tensor import *
+from .tensorIO import *
+from .funcs import *

--- a/python_bindings/pytaco/pytensor/funcs.py
+++ b/python_bindings/pytaco/pytensor/funcs.py
@@ -1,0 +1,299 @@
+from ..pytensor.taco_tensor import tensor
+from ..core import core_modules as cm
+import operator
+
+
+def _is_broadcastable(shape1, shape2):
+    for a, b in zip(shape1[::-1], shape2[::-1]):
+        if a != b:  # for singleton dimension we would need && a != 1 and b != 1 but this isn't current supported
+            return False
+    return True
+
+
+def _compute_elt_wise_out_shape(shape1, shape2):
+    if not _is_broadcastable(shape1, shape2):
+        raise ValueError("Shapes {} and {} cannot be added together".format(shape1, shape2))
+
+    return shape1 if len(shape1) >= len(shape2) else shape2
+
+
+def _get_indices_for_operands(result_indices, order1, order2):
+    # This returns a tuple of the index variables that should be used from
+    # result_indices to access shapeA and shapeB
+    start_a = len(result_indices) - order1
+    start_b = len(result_indices) - order2
+    return result_indices[start_a:], result_indices[start_b:]
+
+
+def _compute_elt_wise_op(op, t1, t2, out_format, dtype=None):
+
+    out_dtype = cm.max_type(t1.dtype, t2.dtype) if dtype is None else dtype
+    out_shape = _compute_elt_wise_out_shape(t1.shape, t2.shape)
+
+    if out_shape:
+        result = tensor(out_shape, out_format, dtype=out_dtype)
+        index_var_list = cm.get_index_vars(len(out_shape))
+        index_var1, index_var2 = _get_indices_for_operands(index_var_list, t1.order, t2.order)
+        result[index_var_list] = op(t1[index_var1], t2[index_var2])
+        return result
+    else:
+        result = tensor(dtype=out_dtype)
+        result[None] = op(t1[None], t2[None])
+        return result
+
+
+def add(t1, t2, out_format, dtype=None):
+    return _compute_elt_wise_op(operator.add, t1, t2, out_format, dtype)
+
+
+def multiply(t1, t2, out_format, dtype=None):
+    return _compute_elt_wise_op(operator.mul, t1, t2, out_format, dtype)
+
+
+def subtract(t1, t2, out_format, dtype=None):
+    return _compute_elt_wise_op(operator.sub, t1, t2, out_format, dtype)
+
+
+def divide(t1, t2, out_format, dtype=None):
+    return _compute_elt_wise_op(operator.truediv, t1, t2, out_format, dtype)
+
+
+def floordiv(t1, t2, out_format, dtype=cm.int64):
+    if not dtype.is_int() or not dtype.is_uint():
+        raise ValueError("Floor divide must have int data type as output")
+    return _compute_elt_wise_op(operator.floordiv, t1, t2, out_format, dtype)
+
+
+def _remove_elts_at_index(inp, elts_to_remove):
+    result = inp[:]
+    for elt in elts_to_remove:
+        if elt >= len(inp) or elt < 0:
+            raise ValueError("Axis {} too large for tensor of order {}".format(elt, len(inp)))
+        result[elt] = None
+
+    return list(filter(lambda x: x is not None, result))
+
+
+def _as_list(x):
+    if type(x) is list:
+        return x
+    else:
+        return [x]
+
+
+def reduce_sum(t1, axis=None, out_format=cm.dense, dtype=None):
+
+    out_dtype = t1.dtype if dtype is None else dtype
+    res_shape = [] if axis is None else _remove_elts_at_index(t1.shape, _as_list(axis))
+
+    inp_index_vars = cm.get_index_vars(t1.order)
+    out_index_vars = [] if axis is None else _remove_elts_at_index(inp_index_vars, _as_list(axis))
+
+    result_tensor = tensor(res_shape, format_type=out_format, dtype=out_dtype)
+    result_tensor[out_index_vars] = t1[inp_index_vars]
+    return result_tensor
+
+
+def _matrix_out_shape(shape1, shape2):
+    if len(shape1) < 2 or len(shape2) < 2:
+        raise ValueError("Invalid tensor order for matrix multiply. Must be at least order 2 but operand1 has "
+                         "order {} while operand 2 has order {}.".format(len(shape1), len(shape2)))
+
+    if shape1[-1] != shape2[-2]:
+        raise ValueError("Input operand1 has value {} in dimension 0 while operand2 has value {} in dimension 1. "
+                         "These two dimensions must be equal".format(shape1[-1], shape2[-2]))
+
+    if not _is_broadcastable(shape1[:-2], shape2[:-2]):
+        raise ValueError("Cannot broadcast outer tensor elements. All the leading dimensions must be equal.")
+
+    result_shape = shape1[:-2] if len(shape1) >= len(shape2) else shape2[:-2]
+    result_shape.extend([shape1[-2], shape2[-1]])
+    return result_shape
+
+
+def matmul(t1, t2, out_format=cm.dense, dtype=None):
+
+    out_dtype = cm.max_type(t1.dtype, t2.dtype) if dtype is None else dtype
+    out_shape = _matrix_out_shape(t1.shape, t2.shape)
+    result_tensor = tensor(out_shape, format_type=out_format, dtype=out_dtype)
+
+    reduction_var = cm.index_var()
+    leading_vars = cm.get_index_vars(max(t1.order, t2.order))
+    t1_vars, t2_vars = leading_vars[-t1.order:], leading_vars[-t2.order:]
+    t1_vars[-1] = reduction_var
+    t2_vars[-2] = reduction_var
+    result_tensor[leading_vars] = t1[t1_vars] * t2[t2_vars]
+    return result_tensor
+
+
+def inner(t1, t2, out_format=cm.dense, dtype=None):
+
+    if t1.order == 0 or t2.order == 0:
+        return multiply(t1, t2, out_format, dtype)
+
+    if t1.order != 0 and t2.order != 0 and t1.shape[-1] != t2.shape[-1]:
+        raise ValueError("Last dimensions of t1 and t2 must be equal but t1 has dimension {} while "
+                         "t2 has dimension %".format(t1.shape[-1], t2.shape[-1]))
+
+    out_dtype = cm.max_type(t1.dtype, t2.dtype) if dtype is None else dtype
+    out_shape = t1.shape[:-1] + t2.shape[:-1]
+
+    reduction_var = cm.index_var()
+    t1_vars, t2_vars = cm.get_index_vars(len(t1.shape[:-1])), cm.get_index_vars(len(t2.shape[:-1]))
+    result_vars = t1_vars + t2_vars
+
+    t1_vars.append(reduction_var)
+    t2_vars.append(reduction_var)
+
+    result_tensor = tensor(out_shape, out_format, dtype=out_dtype)
+    result_tensor[result_vars] = t1[t1_vars] * t2[t2_vars]
+    return result_tensor
+
+
+def _dot_output_shape(shape1, shape2):
+
+    if shape1[-1] != shape2[-2]:
+        raise ValueError("Input operand1 has value {} in dimension 0 while operand2 has value {} in dimension 1."
+                         " These two dimensions must be equal".format(shape1[-1], shape2[-2]))
+
+    return shape1[:-1] + shape2[:-2] + shape2[-1:]
+
+
+def dot(t1, t2, out_format=cm.dense, dtype=None):
+
+    if t1.order == 0 or t2.order <= 1:
+        return inner(t1, t2, out_format, dtype)
+
+    # Here we know that a is a non-scalar and b has order at least 2
+    out_shape = _dot_output_shape(t1.shape, t2.shape)
+    out_dtype = cm.max_type(t1.dtype, t2.dtype) if dtype is None else dtype
+
+    t1_vars = cm.get_index_vars(t1.order - 1)
+    t2_vars = cm.get_index_vars(t2.order - 1)
+    res_vars = t1_vars + t2_vars
+
+    reduction_var = cm.index_var()
+    t1_vars.append(reduction_var)
+    t2_vars = t2_vars[:-1] + [reduction_var] + t2_vars[-1:]
+    result_tensor = tensor(out_shape, format_type=out_format, dtype=out_dtype)
+    result_tensor[res_vars] = t1[t1_vars] * t2[t2_vars]
+    return result_tensor
+
+
+def outer(t1, t2, out_format=cm.dense, dtype=None):
+
+    t1_order = t1.order
+    t2_order = t2.order
+    if t1_order == 0 or t2_order == 0:
+        return multiply(t1, t2, out_format, dtype)
+
+    if t1_order != 1:
+        raise ValueError("Can only perform outer product with vectors and scalars but first "
+                         "operand has {} dimensions.".format(t1.order))
+
+    if t2_order != 1:
+        raise ValueError("Can only perform outer product with vectors and scalars but second "
+                         "operand has {} dimensions.".format(t2.order))
+
+    out_shape = t1.shape + t2.shape
+    out_dtype = cm.max_type(t1.dtype, t2.dtype) if dtype is None else dtype
+    out_vars = cm.get_index_vars(2)
+
+    result_tensor = tensor(out_shape, format_type=out_format, dtype=out_dtype)
+    result_tensor[out_vars] = t1[out_vars[0]] * t2[out_vars[1]]
+    return result_tensor
+
+
+def tensordot(t1, t2, axes=2, out_format=cm.dense, dtype = None):
+
+    # This is largely adapted from numpy's tensordot source code
+
+    try:
+        iter(axes)
+    except Exception:
+        axes_t1 = list(range(-axes, 0))
+        axes_t2 = list(range(0, axes))
+    else:
+        axes_t1, axes_t2 = axes
+
+    try:
+        nt1 = len(axes_t1)
+        axes_t1 = list(axes_t1)
+    except TypeError:
+        axes_t1 = [axes_t1]
+        nt1 = 1
+
+    try:
+        nt2 = len(axes_t2)
+        axes_t2 = list(axes_t2)
+    except TypeError:
+        axes_t2 = [axes_t2]
+        nt2 = 1
+
+    t1_shape = t1.shape
+    t1_order = t1.order
+    t2_shape = t2.shape
+    t2_order = t2.order
+
+    equal = True
+
+    if nt1 != nt2:
+        equal = False
+    else:
+        for k in range(nt1):
+            if t1_shape[axes_t1[k]] != t2_shape[axes_t2[k]]:
+                equal = False
+                break
+            if axes_t1[k] < 0:
+                axes_t1[k] += t1_order
+            if axes_t2[k] < 0:
+                axes_t2[k] += t2_order
+    if not equal:
+        raise ValueError("shape-mismatch for sum")
+
+    notin_t1 = [k for k in range(t1_order) if k not in axes_t1]
+    out_shape_t1 = [t1_shape[axis] for axis in notin_t1]
+
+    notin_t2 = [k for k in range(t2_order) if k not in axes_t2]
+    out_shape_t2 = [t2_shape[axis] for axis in notin_t2]
+
+    static_vars_t1 = cm.get_index_vars(len(notin_t1))
+    static_vars_t2 = cm.get_index_vars(len(notin_t2))
+    reduction_vars = cm.get_index_vars(nt1)
+
+    t1_vars = [None] * t1_order
+    t2_vars = [None] * t2_order
+    for k in range(len(reduction_vars)):
+        t1_vars[axes_t1[k]] = reduction_vars[k]
+        t2_vars[axes_t2[k]] = reduction_vars[k]
+
+    for k in range(len(static_vars_t1)):
+        t1_vars[notin_t1[k]] = static_vars_t1[k]
+
+    for k in range(len(static_vars_t2)):
+        t2_vars[notin_t2[k]] = static_vars_t2[k]
+
+    out_vars = static_vars_t1 + static_vars_t2
+
+    out_shape = out_shape_t1 + out_shape_t2
+    out_dtype = cm.max_type(t1.dtype, t2.dtype) if dtype is None else dtype
+    result_tensor = tensor(out_shape, format_type=out_format, dtype=out_dtype)
+    result_tensor[out_vars] = t1[t1_vars] * t2[t2_vars]
+    return result_tensor
+
+
+def parse(expr, *args, out_format=None, dtype=None):
+    if len(args) < 2:
+        raise ValueError("Expression must have at least one operand on the LHS and one on the RHS.")
+
+    out_dtype = args[0].dtype if dtype is None else dtype
+    if dtype is None:
+        for i in range(1, len(args)):
+            out_dtype = cm.max_type(out_dtype, args[i].dtype)
+
+    tensor_base = cm._parse(expr, [t._tensor for t in args], out_format, out_dtype)
+    return tensor.from_tensor_base(tensor_base)
+
+
+# def einsum(expr, *args, out_format=None, dtype=None):
+#     cm._einsum(expr, [t._tensor for t in args], out_format, cm.float32)

--- a/python_bindings/pytaco/pytensor/funcs.py
+++ b/python_bindings/pytaco/pytensor/funcs.py
@@ -295,5 +295,11 @@ def parse(expr, *args, out_format=None, dtype=None):
     return tensor.from_tensor_base(tensor_base)
 
 
-# def einsum(expr, *args, out_format=None, dtype=None):
-#     cm._einsum(expr, [t._tensor for t in args], out_format, cm.float32)
+def einsum(expr, *args, out_format=None, dtype=None):
+    out_dtype = args[0].dtype if dtype is None else dtype
+    if dtype is None:
+        for i in range(1, len(args)):
+            out_dtype = cm.max_type(out_dtype, args[i].dtype)
+
+    ein = cm._einsum(expr, [t._tensor for t in args], out_format, out_dtype)
+    return tensor.from_tensor_base(ein)

--- a/python_bindings/pytaco/pytensor/taco_tensor.py
+++ b/python_bindings/pytaco/pytensor/taco_tensor.py
@@ -139,6 +139,12 @@ class tensor:
         a.setflags(write=False)  # forbid user from changing array via numpy if they request a copy.
         return a
 
+    def to_dense(self):
+        new_t = tensor(self.shape, _cm.dense, dtype=self.dtype)
+        vars = _cm.get_index_vars(self.order)
+        new_t[vars] = self[vars]
+        return new_t
+
     def insert(self, coords, vals):
         self._tensor.insert(coords, vals)
 

--- a/python_bindings/pytaco/pytensor/taco_tensor.py
+++ b/python_bindings/pytaco/pytensor/taco_tensor.py
@@ -1,0 +1,207 @@
+from ..core import core_modules as _cm
+import numpy as np
+
+"""
+    This is a class used to hide the different tensor types and export a numpy-style interface.
+    
+    This is a light wrapper that creates the correct C++ tensor given the dtype. This wrapper class
+    needs to stay in sync with the underlying bindings. 
+"""
+
+
+class tensor:
+
+    def __init__(self, arg1=None, format_type=_cm.compressed, dtype=_cm.float32, name=None):
+
+        if name is None:
+            name = _cm.unique_name('A')
+
+        if isinstance(arg1, int) or isinstance(arg1, float) or not arg1:
+            if dtype == _cm.float32:
+                self._tensor = _cm.TensorFloat(name)
+            elif dtype == _cm.float64:
+                self._tensor = _cm.TensorDouble(name)
+            elif dtype == _cm.int8:
+                self._tensor = _cm.TensorInt8(name)
+            elif dtype == _cm.int16:
+                self._tensor = _cm.TensorInt16(name)
+            elif dtype == _cm.int32:
+                self._tensor = _cm.TensorInt32(name)
+            elif dtype == _cm.int64:
+                self._tensor = _cm.TensorInt64(name)
+            elif dtype == _cm.uint8:
+                self._tensor = _cm.TensorUInt8(name)
+            elif dtype == _cm.uint16:
+                self._tensor = _cm.TensorUInt16(name)
+            elif dtype == _cm.uint32:
+                self._tensor = _cm.TensorUInt32(name)
+            elif dtype == _cm.uint64:
+                self._tensor = _cm.TensorUInt64(name)
+            else:
+                raise ValueError("Invalid datatype. Must be float32/64, (u)int8, (u)int16, (u)int32 or (u)int64")
+
+            if arg1 is not None:
+                self._tensor[None] = arg1
+                self._tensor.pack()
+
+        elif isinstance(arg1, tuple) or isinstance(arg1, list):
+            shape = arg1
+            if dtype == _cm.float32:
+                self._tensor = _cm.TensorFloat(name, shape, format_type)
+            elif dtype == _cm.float64:
+                self._tensor = _cm.TensorDouble(name, shape, format_type)
+            elif dtype == _cm.int8:
+                self._tensor = _cm.TensorInt8(name, shape, format_type)
+            elif dtype == _cm.int16:
+                self._tensor = _cm.TensorInt16(name, shape, format_type)
+            elif dtype == _cm.int32:
+                self._tensor = _cm.TensorInt32(name, shape, format_type)
+            elif dtype == _cm.int64:
+                self._tensor = _cm.TensorInt64(name, shape, format_type)
+            elif dtype == _cm.uint8:
+                self._tensor = _cm.TensorUInt8(name, shape, format_type)
+            elif dtype == _cm.uint16:
+                self._tensor = _cm.TensorUInt16(name, shape, format_type)
+            elif dtype == _cm.uint32:
+                self._tensor = _cm.TensorUInt32(name, shape, format_type)
+            elif dtype == _cm.uint64:
+                self._tensor = _cm.TensorUInt64(name, shape, format_type)
+            else:
+                raise ValueError("Invalid datatype. Must be float32/64, (u)int8, (u)int16, (u)int32 or (u)int64")
+
+        else:
+
+            raise ValueError("Invalid argument for first argument. Must be a tuple or list if a shape or a single value"
+                             "if initializing a scalar.")
+
+    @classmethod
+    def _fromCppTensor(cls, cppTensor):
+        pytensor = cls()
+        pytensor._tensor = cppTensor
+        return pytensor
+
+    @classmethod
+    def _from_x(cls, x, dtype):
+        if dtype == _cm.float32:
+            return cls._fromCppTensor(_cm.TensorFloat(x))
+        elif dtype == _cm.float64:
+            return cls._fromCppTensor(_cm.TensorDouble(x))
+        elif dtype == _cm.int8:
+            return cls._fromCppTensor(_cm.TensorInt8(x))
+        elif dtype == _cm.int16:
+            return cls._fromCppTensor(_cm.TensorInt16(x))
+        elif dtype == _cm.int32:
+            return cls._fromCppTensor(_cm.TensorInt32(x))
+        elif dtype == _cm.int64:
+            return cls._fromCppTensor(_cm.TensorInt64(x))
+        elif dtype == _cm.uint8:
+            return cls._fromCppTensor(_cm.TensorUInt8(x))
+        elif dtype == _cm.uint16:
+            return cls._fromCppTensor(_cm.TensorUInt16(x))
+        elif dtype == _cm.uint32:
+            return cls._fromCppTensor(_cm.TensorUInt32(x))
+        elif dtype == _cm.uint64:
+            return cls._fromCppTensor(_cm.TensorUInt64(x))
+        else:
+            raise ValueError("Invalid datatype ({}). Must be float32/64, (u)int8, (u)int16, "
+                             "(u)int32 or (u)int64".format(dtype))
+
+    @classmethod
+    def from_tensor_base(cls, tensor_base):
+        return cls._from_x(tensor_base, tensor_base.dtype())
+
+    @property
+    def order(self):
+        return self._tensor.order()
+
+    @property
+    def name(self):
+        return self._tensor.get_name()
+
+    @name.setter
+    def name(self, name):
+        self._tensor.set_name(name)
+
+    @property
+    def shape(self):
+        return self._tensor.get_dimensions()
+
+    @property
+    def dtype(self):
+        return self._tensor.dtype()
+
+    @property
+    def format(self):
+        return self._tensor.format()
+
+    @property
+    def T(self):
+        new_ordering = list(range(self.order))[::-1]
+        return self.transpose(new_ordering)
+
+    def transpose(self, new_ordering, new_format=None, name=None):
+        if name is None:
+            name = _cm.unique_name('A')
+
+        if new_format is None:
+            new_format = self.format
+
+        new_t = self._tensor.transpose(new_ordering, new_format, name)
+        return tensor._fromCppTensor(new_t)
+
+    def pack(self):
+        self._tensor.pack()
+
+    def compile(self):
+        self._tensor.compile()
+
+    def assemble(self):
+        self._tensor.assemble()
+
+    def evaluate(self):
+        self._tensor.evaluate()
+
+    def compute(self):
+        self._tensor.compile()
+
+    def __getitem__(self, index):
+        return self._tensor[index]
+
+    def __setitem__(self, key, value):
+        self._tensor[key] = value
+
+    def __repr__(self):
+        return self._tensor.__repr__()
+
+    def __array__(self):
+        if not _cm.is_dense(self.format):
+            raise ValueError("Cannot export a compressed tensor. Make sure all dimensions are dense "
+                             "using to_dense() before attempting this conversion.")
+        a = np.array(self._tensor, copy=False)
+        a.setflags(write=False)  # forbid user from changing array via numpy if they request a copy.
+        return a
+
+
+def from_numpy_array(array, copy=False):
+    # For some reason disabling conversion in pybind11 still copies C and F style arrays unnecessarily.
+    # Disabling the force convert parameter also seems to not work. This explicity calls the different functions
+    # to get this working for now
+    col_major = array.flags["F_CONTIGUOUS"]
+    t = _cm.fromNpF(array, copy) if col_major else _cm.fromNpC(array, copy)
+    return tensor._fromCppTensor(t)
+
+
+def _from_matrix(matrix, copy, csr):
+    indptr, indices, data = matrix.indptr, matrix.indices, matrix.data
+    shape = matrix.shape
+    return tensor._fromCppTensor(_cm.fromSpMatrix(indptr, indices, data, shape, copy, csr))
+
+
+def from_sp_csr(matrix, copy=True):
+    return _from_matrix(matrix, copy, True)
+
+
+def from_sp_csc(matrix, copy=True):
+    return _from_matrix(matrix, copy, False)
+
+

--- a/python_bindings/pytaco/pytensor/taco_tensor.py
+++ b/python_bindings/pytaco/pytensor/taco_tensor.py
@@ -181,6 +181,9 @@ class tensor:
         a.setflags(write=False)  # forbid user from changing array via numpy if they request a copy.
         return a
 
+    def insert(self, coords, vals):
+        self._tensor.insert(coords, vals)
+
 
 def from_numpy_array(array, copy=False):
     # For some reason disabling conversion in pybind11 still copies C and F style arrays unnecessarily.

--- a/python_bindings/pytaco/pytensor/tensorIO.py
+++ b/python_bindings/pytaco/pytensor/tensorIO.py
@@ -1,0 +1,11 @@
+from ..core import core_modules as _cm
+from ..pytensor.taco_tensor import tensor
+
+
+def write(filename, t):
+    _cm._write(filename, t._tensor)
+
+
+def read(filename, fmt, pack=True):
+    cppTensor = _cm._read(filename, fmt, pack)
+    return tensor._fromCppTensor(cppTensor)

--- a/python_bindings/src/pyDatatypes.cpp
+++ b/python_bindings/src/pyDatatypes.cpp
@@ -24,6 +24,7 @@ py::object asNpDtype(const taco::Datatype &dtype){
 void defineTacoTypes(py::module &m){
 
   m.def("as_np_dtype", &asNpDtype, "Convert taco datatype to its numpy equivalent.");
+  m.def("max_type", &max_type, "Get the max datatype");
 
   py::class_<taco::Datatype> dtype(m, "dtype");
 

--- a/python_bindings/src/pyIndexNotation.cpp
+++ b/python_bindings/src/pyIndexNotation.cpp
@@ -150,27 +150,33 @@ static void addIndexExprBinaryOps(PyClass &class_instance){
           }, py::is_operator())
 
           .def("__div__", [](const IndexExpr &self, const other_t other) -> IndexExpr{
-              return new DivNode(self, IndexExpr(other));
+              IndexExpr cast = new CastNode(self, Float64);
+              return new DivNode(cast, IndexExpr(other));
           }, py::is_operator())
 
           .def("__rdiv__", [](const IndexExpr &self, const other_t other) -> IndexExpr{
-              return new DivNode(IndexExpr(other), self);
+              IndexExpr cast = new CastNode(self, Float64);
+              return new DivNode(IndexExpr(other), cast);
           }, py::is_operator())
 
           .def("__truediv__", [](const IndexExpr &self, const other_t other) -> IndexExpr{
-              return new DivNode(self, IndexExpr(other));
+              IndexExpr cast = new CastNode(self, Float64);
+              return new DivNode(cast, IndexExpr(other));
           }, py::is_operator())
 
           .def("__rtruediv__", [](const IndexExpr &self, const other_t other) -> IndexExpr{
-              return new DivNode(IndexExpr(other), self);
+              IndexExpr cast = new CastNode(self, Float64);
+              return new DivNode(IndexExpr(other), cast);
           }, py::is_operator())
 
           .def("__floordiv__", [](const IndexExpr &self, const other_t other) -> IndexExpr{
-              return new DivNode(self, IndexExpr(other));
+              IndexExpr div = new DivNode(self, IndexExpr(other));
+              return new CastNode(div, Int64);
           }, py::is_operator())
 
           .def("__rfloordiv__", [](const IndexExpr &self, const other_t other) -> IndexExpr{
-              return new DivNode(IndexExpr(other), self);
+              IndexExpr div = new DivNode(IndexExpr(other), self);
+              return new CastNode(div, Int64);
           }, py::is_operator());
 
 }

--- a/python_bindings/src/pyIndexNotation.cpp
+++ b/python_bindings/src/pyIndexNotation.cpp
@@ -29,7 +29,7 @@ public:
 };
 
 static void defineIndexVar(py::module &m){
-  py::class_<taco::IndexVar>(m, "indexVar")
+  py::class_<taco::IndexVar>(m, "indexvar")
           .def(py::init<>())
           .def(py::init<const std::string&>())
           .def("name", &taco::IndexVar::getName)
@@ -111,6 +111,14 @@ static void defineReduction(py::module &m){
               o << "IndexExpr(" << expr << ")";
               return o.str();
           }, py::is_operator());
+}
+
+static std::vector<IndexVar> getIndexVars(int n){
+  std::vector<IndexVar> vars;
+  for(int i = 0; i < n; ++i){
+    vars.emplace_back(IndexVar());
+  }
+  return vars;
 }
 
 template<typename other_t, typename PyClass>
@@ -220,6 +228,7 @@ static void defineAccess(py::module &m){
 }
 
 void defineIndexNotation(py::module &m){
+  m.def("get_index_vars", &getIndexVars);
   defineIndexVar(m);
   defineIndexExpr(m);
   defineAccess(m);

--- a/python_bindings/src/pyIndexNotation.cpp
+++ b/python_bindings/src/pyIndexNotation.cpp
@@ -173,8 +173,6 @@ static void addIndexExprBinaryOps(PyClass &class_instance){
               return new DivNode(IndexExpr(other), self);
           }, py::is_operator());
 
-
-
 }
 
 static void defineIndexExpr(py::module &m){

--- a/python_bindings/src/pyParsers.cpp
+++ b/python_bindings/src/pyParsers.cpp
@@ -1,0 +1,103 @@
+#include <taco.h>
+#include <taco/parser/lexer.h>
+#include "pyParsers.h"
+#include "pybind11/stl.h"
+
+namespace py = pybind11;
+
+namespace taco{
+namespace pythonBindings{
+
+static std::vector<std::string> extractNames(std::string& expr){
+
+  parser::Parser nameGetter(expr, {}, {}, {}, {});
+  try {
+    nameGetter.parse();
+  } catch(parser::ParseError & e) {
+    throw py::value_error(e.getMessage());
+  }
+  return nameGetter.getNames();
+}
+
+static void resetNames(std::vector<std::string> oldNames, py::list &tensors){
+  for(size_t i = 0; i < tensors.size(); ++i) {
+    auto cpptensor = tensors[i];
+    auto tensor = cpptensor.cast<TensorBase&>();
+    tensor.setName(oldNames[i]);
+  }
+}
+
+static TensorBase parseString(std::string& expr, py::list &tensors, py::object& fmt, Datatype dtype){
+
+  auto tensorNames = extractNames(expr);
+
+  std::map<std::string, Format> nameFormat;
+  std::map<std::string, Datatype> nameDtype;
+  std::map<std::string, std::vector<int>> nameDims;
+  std::map<std::string, TensorBase> nameTensor;
+
+  if(tensorNames.size() - 1 == tensors.size()){
+    if(!fmt.is_none()) {
+      nameFormat.insert({tensorNames[0], fmt.cast<Format>()});
+    }
+    nameDtype.insert({tensorNames[0], dtype});
+    tensorNames = std::vector<std::string>(tensorNames.begin() + 1, tensorNames.end());
+  }
+
+  if(tensorNames.size() != tensors.size()) {
+    throw py::value_error("The number of tensors in the expression and the number of tensors given mismatch.");
+  }
+
+  for(size_t i = 0; i < tensors.size(); ++i) {
+    auto cpptensor = tensors[i];
+    auto tensor = cpptensor.cast<TensorBase&>();
+    std::string temp = tensor.getName();
+    tensor.setName(tensorNames[i]);
+    tensorNames[i] = temp;
+
+    nameFormat.insert({tensor.getName(), tensor.getFormat()});
+    nameDtype.insert({tensor.getName(), tensor.getComponentType()});
+    nameDims.insert({tensor.getName(), tensor.getDimensions()});
+    nameTensor.insert({tensor.getName(), tensor});
+  }
+
+  parser::Parser tensor_parser(expr, nameFormat, nameDtype, nameDims, nameTensor);
+  try {
+    tensor_parser.parse();
+  } catch (const parser::ParseError& e){
+    resetNames(tensorNames, tensors);
+    throw py::value_error(e.getMessage());
+  }
+
+  resetNames(tensorNames, tensors);
+
+  // TODO :: Currently the parser will not work with current API. This is a hack to force the assignment through the new API.
+  // The issue is that the parser directly calls set assignment on a tensor but this keeps the compile flag to false. Attenpting
+  // to force the compile fails because the needsCompile flag is set to false even though the tensor has to be compiled.
+  TensorBase result_tensor = tensor_parser.getResultTensor();
+  std::vector<IndexVar> vars = result_tensor.getAssignment().getLhs().getIndexVars();
+  IndexExpr rhs = result_tensor.getAssignment().getRhs();
+  result_tensor(vars) = rhs;
+  return result_tensor;
+}
+
+static void einsumParse(std::string& expr, py::list &tensors, py::object& fmt, Datatype dtype) {
+  std::vector<TensorBase> cppTensors;
+  for(auto &tensor: tensors){
+    cppTensors.push_back(tensor.cast<TensorBase>());
+  }
+
+  try {
+    parser::EinsumParser::parseToTaco(expr, cppTensors);
+  } catch (const parser::ParseError& e){
+    throw py::value_error(e.getMessage());
+  }
+
+}
+
+void defineParser(py::module& m) {
+  m.def("_parse", &parseString);
+  m.def("_einsum", &einsumParse);
+}
+
+}}

--- a/python_bindings/src/pyParsers.cpp
+++ b/python_bindings/src/pyParsers.cpp
@@ -81,18 +81,22 @@ static TensorBase parseString(std::string& expr, py::list &tensors, py::object& 
   return result_tensor;
 }
 
-static void einsumParse(std::string& expr, py::list &tensors, py::object& fmt, Datatype dtype) {
+static TensorBase einsumParse(std::string& expr, py::list &tensors, py::object& fmt, Datatype dtype) {
   std::vector<TensorBase> cppTensors;
   for(auto &tensor: tensors){
     cppTensors.push_back(tensor.cast<TensorBase>());
   }
 
+  Format format = fmt.is_none()? Format() : fmt.cast<Format>();
+  parser::EinsumParser einsumParser(expr, cppTensors, format, dtype);
   try {
-    parser::EinsumParser::parseToTaco(expr, cppTensors);
+    einsumParser.parse();
   } catch (const parser::ParseError& e){
     throw py::value_error(e.getMessage());
   }
 
+  TensorBase result = einsumParser.getResultTensor();
+  return result;
 }
 
 void defineParser(py::module& m) {

--- a/python_bindings/src/pyTensor.cpp
+++ b/python_bindings/src/pyTensor.cpp
@@ -3,6 +3,7 @@
 #include "pybind11/operators.h"
 #include "taco/type.h"
 #include "pybind11/stl.h"
+#include "pybind11/numpy.h"
 
 // Add Python dictionary initializer with {tuple(coordinate) : data} pairs
 
@@ -11,6 +12,12 @@ namespace taco{
 namespace pythonBindings{
 
 static void checkBounds(const std::vector<int>& dims, const std::vector<int>& indices){
+
+  // Check for potential scalar access. Don't throw error if syntax valid
+  if(dims.empty() && (indices.empty() || (indices[0] == 0 && indices.size() == 1))){
+    return;
+  }
+
   if(dims.size() != indices.size()){
     std::ostringstream o;
     o << "Incorrect number of dimensions when indexing. Tensor is order " << dims.size() << " but got index of "
@@ -30,46 +37,215 @@ static void checkBounds(const std::vector<int>& dims, const std::vector<int>& in
   }
 }
 
-template<typename CType>
-static void declareTensor(py::module &m, std::string typestr) {
+template<typename T>
+static Tensor<T> fromNumpy(py::array_t<T, py::array::f_style> array, bool copy) {
+  py::buffer_info array_buffer = array.request();
+  std::vector<ssize_t> buf_shape = array_buffer.shape;
+  std::vector<int> shape(buf_shape.begin(), buf_shape.end());
+  const ssize_t size = array.size();
+  const ssize_t dims = array_buffer.ndim;
 
+  // Creat col-major dense tensor
+  std::vector<int> ordering;
+  for(int i = dims-1; i >= 0; --i){
+    ordering.push_back(i);
+  }
+
+  Format fmt(std::vector<ModeFormatPack>(dims, dense), ordering);
+  Tensor<T> tensor(shape, fmt);
+
+  TensorStorage& storage = tensor.getStorage();
+  void *buf_data = array_buffer.ptr;
+  Array::Policy policy = Array::Policy::UserOwns;
+  if(copy){
+    buf_data = new T[size];
+    memcpy(buf_data, array_buffer.ptr, size*array_buffer.itemsize);
+    policy = Array::Policy::Delete;
+  }
+
+  storage.setValues(makeArray(static_cast<T*>(buf_data), size, policy));
+  tensor.setStorage(storage);
+  return tensor;
+}
+
+
+template<typename T>
+static Tensor<T> fromNumpy(py::array_t<T, py::array::c_style | py::array::forcecast>  array, bool copy) {
+
+  py::buffer_info array_buffer = array.request();
+  std::vector<ssize_t> buf_shape = array_buffer.shape;
+  std::vector<int> shape(buf_shape.begin(), buf_shape.end());
+  const ssize_t size = array.size();
+
+  // Creat row-major dense tensor
+  Tensor<T> tensor(shape, dense);
+  TensorStorage& storage = tensor.getStorage();
+  void *buf_data = array_buffer.ptr;
+  Array::Policy policy = Array::Policy::UserOwns;
+  if(copy){
+    buf_data = new T[size];
+    memcpy(buf_data, array_buffer.ptr, size*array_buffer.itemsize);
+    policy = Array::Policy::Delete;
+  }
+
+  storage.setValues(makeArray(static_cast<T*>(buf_data), size, policy));
+  tensor.setStorage(storage);
+  return tensor;
+}
+
+template<typename IdxType, typename T>
+static Tensor<T> fromSpMatrix(py::array_t<IdxType> ind_ptr, py::array_t<IdxType> inds, py::array_t<T> data,
+                               const std::vector<int> &dims, bool copy, bool CSR){
+
+  py::buffer_info ind_ptr_buf = ind_ptr.request();
+  py::buffer_info inds_buf = inds.request();
+  py::buffer_info data_buf = data.request();
+
+  if(ind_ptr_buf.ndim != 1 || inds_buf.ndim != 1 || data_buf.ndim != 1) {
+    throw py::value_error("Data arrays must be 1D.");
+  }
+
+  IdxType *mat_ptr  = static_cast<IdxType *>(ind_ptr_buf.ptr);
+  IdxType *mat_ind  = static_cast<IdxType *>(inds_buf.ptr);
+  T *mat_data = static_cast<T *>(data_buf.ptr);
+  Array::Policy policy = Array::Policy::UserOwns;
+
+  if(copy){
+    mat_ptr = new IdxType[ind_ptr_buf.size];
+    mat_ind = new IdxType[inds_buf.size];
+    mat_data = new T[data_buf.size];
+    memcpy(mat_ptr, ind_ptr_buf.ptr, ind_ptr_buf.size*ind_ptr_buf.itemsize);
+    memcpy(mat_ind, inds_buf.ptr, inds_buf.size * inds_buf.itemsize);
+    memcpy(mat_data, data_buf.ptr, data_buf.size * data_buf.itemsize);
+    policy = Array::Policy::Delete;
+  }
+
+  // Create CSR Matrix
+  Tensor<T> tensor;
+  if(CSR){
+    tensor = makeCSR(util::uniqueName("csr"), dims, mat_ptr, mat_ind, mat_data, policy);
+  } else{
+    tensor = makeCSC(util::uniqueName("csc"), dims, mat_ptr, mat_ind, mat_data, policy);
+  }
+
+  return tensor;
+}
+
+template<typename CType, typename idxVar>
+static inline Access accessGetter(Tensor<CType>& tensor, idxVar& var) {
+  return tensor(var);
+}
+
+template<typename CType>
+static inline CType elementGetter(Tensor<CType>& tensor, std::vector<int> coords) {
+  checkBounds(tensor.getDimensions(), coords);
+  if(tensor.getOrder() == 0) {
+    return tensor.at({});
+  }
+  return tensor.at(coords);
+}
+
+template<typename CType, typename pyType>
+static inline void elementSetter(Tensor<CType> &tensor, std::vector<int> coords, pyType value) {
+  checkBounds(tensor.getDimensions(), coords);
+  if(tensor.getOrder() == 0) {
+    tensor = static_cast<CType>(value);
+  }
+  tensor.insert(coords, static_cast<CType>(value));
+}
+
+template<typename CType, typename pyType>
+static inline void singleElementSetter(Tensor<CType> &tensor, int coord, pyType value) {
+  elementSetter<CType, pyType>(tensor, {coord}, value);
+}
+
+template<typename CType, typename VarType, typename ExprType>
+static inline void exprSetter(Tensor<CType> &tensor, VarType idx, ExprType expr) {
+  tensor(idx) = expr;
+}
+
+template<typename CType>
+static void declareTensor(py::module &m, const std::string typestr) {
   using typedTensor = Tensor<CType>;
 
+  m.def("fromNpF", (typedTensor (*)(py::array_t<CType, py::array::f_style> array, bool copy))
+                             &fromNumpy<CType>, py::arg("array").noconvert(), py::arg("copy"));
+  m.def("fromNpC", (typedTensor (*)(py::array_t<CType, py::array::c_style |
+                                              py::array::forcecast> array, bool copy)) &fromNumpy<CType>);
+
+  m.def("fromSpMatrix", &fromSpMatrix<int, CType>);
+
   std::string pyClassName = std::string("Tensor") + typestr;
-  py::class_<typedTensor, TensorBase>(m, pyClassName.c_str())
+  py::class_<typedTensor, TensorBase>(m, pyClassName.c_str(), py::buffer_protocol())
 
           .def(py::init<>())
+
+          .def(py::init<TensorBase>())
 
           .def(py::init<std::string>(), py::arg("name"))
 
           .def(py::init<CType>(), py::arg("value"))
 
-          .def(py::init<std::vector<int>, ModeFormat>(), py::arg("shape"),
-               py::arg("mode_type") = ModeFormat::compressed)
-
-          .def(py::init<std::vector<int>, Format>(), py::arg("shape"), py::arg("format"))
-
           .def(py::init<std::string, std::vector<int>, ModeFormat>(), py::arg("name"), py::arg("shape"),
-               py::arg("mode_type") = ModeFormat::compressed)
+               py::arg("format") = ModeFormat::compressed)
 
           .def(py::init<std::string, std::vector<int>, Format>(), py::arg("name"), py::arg("shape"),
                py::arg("format"))
+
+          .def_buffer([](typedTensor &t) -> py::buffer_info {
+
+              if(!isDense(t.getFormat())){
+                throw py::value_error("Cannot export a compressed tensor. Make sure all dimensions are dense "
+                                      "using to_dense() before attempting this conversion.");
+              }
+
+              // Force computation of the tensor
+              t.pack();
+              if(t.needsCompute()){
+                t.evaluate();
+              }
+
+              void *ptr = t.getStorage().getValues().getData();
+
+              std::vector<ssize_t> shape (t.getDimensions().begin(), t.getDimensions().end());
+              std::vector<ssize_t> row_major_strides;
+
+              for(size_t i = 0; i < shape.size(); ++i) {
+                ssize_t currentStride = sizeof(CType);
+                for(size_t j = i + 1; j < shape.size(); ++j){
+                  currentStride *= shape[j];
+                }
+                row_major_strides.push_back(currentStride);
+              }
+
+              std::vector<ssize_t> strides;
+              for(const int &permutation : t.getFormat().getModeOrdering()){
+                strides.push_back(row_major_strides[permutation]);
+              }
+
+              return py::buffer_info(
+                      ptr,                                         /* Pointer to buffer */
+                      sizeof(CType),                               /* Size of one scalar */
+                      py::format_descriptor<CType>::format(),      /* Python struct-style format descriptor */
+                      t.getOrder(),                                /* Number of dimensions */
+                      shape,                                       /* Buffer dimensions */
+                      strides                                      /* Strides (in bytes) for each index */
+              );
+          })
 
           .def("set_name", &TensorBase::setName)
 
           .def("get_name", &TensorBase::getName)
 
-          .def_property_readonly("order", &TensorBase::getOrder)
-
-          .def_property("name", &TensorBase::getName, &TensorBase::setName)
+          .def("order", &TensorBase::getOrder)
 
           .def("get_shape", &TensorBase::getDimension, py::arg("axis"))
 
-          .def_property_readonly("shape", &TensorBase::getDimensions)
+          .def("dtype", &TensorBase::getComponentType)
 
-          .def_property_readonly("dtype", &TensorBase::getComponentType)
+          .def("get_dimensions", &TensorBase::getDimensions)
 
-          .def_property_readonly("format", &TensorBase::getFormat)
+          .def("format", &TensorBase::getFormat)
 
           .def("pack", &typedTensor::pack)
 
@@ -81,103 +257,99 @@ static void declareTensor(py::module &m, std::string typestr) {
 
           .def("compute", &typedTensor::compute)
 
+          .def("transpose", [](typedTensor &self, std::vector<int> dims, Format format, std::string name) -> void{
+              self.transpose(name, dims, format);
+          }, py::is_operator())
+
           .def("__getitem__", [](typedTensor& self, const int &index) -> CType {
-              checkBounds(self.getDimensions(), {index});
-              return self.at({index});
+               return elementGetter<CType>(self, {index});
             }, py::is_operator())
 
           .def("__getitem__", [](typedTensor& self, const std::vector<int> &indices) -> CType {
-              checkBounds(self.getDimensions(), indices);
-              return self.at(indices);
+               return elementGetter<CType>(self, indices);
             }, py::is_operator())
 
-          .def("__getitem__", [](typedTensor& self, py::none) -> Access {
-              if(self.getOrder() != 0){
-                throw py::index_error("Can only use None with scalar tensors");
+          .def("__getitem__", [](typedTensor& self, nullptr_t ptr) -> Access{
+            if(self.getOrder() != 0) {
+              throw py::index_error("Can only index scalar tensors with None.");
+            }
+            return self();
+          }, py::is_operator())
+
+          .def("__getitem__", &accessGetter<CType, IndexVar&>, py::is_operator())
+
+          .def("__getitem__", &accessGetter<CType, std::vector<IndexVar>&>, py::is_operator())
+
+          .def("__setitem__", &singleElementSetter<CType, int64_t>, py::is_operator())
+
+          .def("__setitem__", &singleElementSetter<CType, double>, py::is_operator())
+
+          .def("__setitem__", &elementSetter<CType, int64_t>, py::is_operator())
+
+          .def("__setitem__", &elementSetter<CType, double>, py::is_operator())
+
+          .def("__setitem__", [](typedTensor& self, nullptr_t ptr, int64_t value) -> void {
+              if(self.getOrder() != 0) {
+                throw py::index_error("Can only index scalar tensors with None.");
               }
-              return self();
+              self = static_cast<CType>(value);
           }, py::is_operator())
 
-          .def("__getitem__", [](typedTensor& self, const IndexVar indexVars) -> Access {
-              return self(indexVars);
+          .def("__setitem__", [](typedTensor& self, nullptr_t ptr, double value) -> void {
+              if(self.getOrder() != 0) {
+                throw py::index_error("Can only index scalar tensors with None.");
+              }
+              self = static_cast<CType>(value);
           }, py::is_operator())
 
-          .def("__getitem__", [](typedTensor& self, const std::vector<IndexVar> indexVars) -> Access {
-              return self(indexVars);
-          }, py::is_operator())
-
-          .def("__setitem__", [](typedTensor& self, const int &index, py::object value) -> void {
-              checkBounds(self.getDimensions(), {index});
-              self.insert({index}, static_cast<CType>(value.cast<double>()));
-          }, py::is_operator())
-
-          .def("__setitem__", [](typedTensor& self, const std::vector<int> &indices, py::object value) -> void {
-              checkBounds(self.getDimensions(), indices);
-              self.insert(indices, static_cast<CType>(value.cast<double>()));
-          }, py::is_operator())
-
-          .def("__setitem__", [](typedTensor& self, py::none, py::object value) -> void {
-              self = static_cast<CType>(value.cast<double>());
-          }, py::is_operator())
-
-          .def("__setitem__", [](typedTensor& self, py::none, const IndexExpr expr) -> void {
+          //  Set scalars to expression using none
+          .def("__setitem__", [](typedTensor& self, nullptr_t ptr, const IndexExpr expr) -> void {
               self = expr;
           }, py::is_operator())
 
-          .def("__setitem__", [](typedTensor& self, py::none, const Access access) -> void {
+          .def("__setitem__", [](typedTensor& self, nullptr_t ptr, const Access access) -> void {
               self = access;
           }, py::is_operator())
 
-          .def("__setitem__", [](typedTensor& self, py::none, const TensorVar tensorVar) -> void {
+          .def("__setitem__", [](typedTensor& self, nullptr_t ptr, const TensorVar tensorVar) -> void {
               self = tensorVar;
           }, py::is_operator())
 
-          .def("__setitem__", [](typedTensor& self, const IndexVar indexVar, const IndexExpr expr) -> void {
-              self(indexVar) = expr;
+          // Set expressions with varying types
+          .def("__setitem__", &exprSetter<CType, IndexVar, IndexExpr>, py::is_operator())
+
+          .def("__setitem__", &exprSetter<CType, IndexVar, Access>, py::is_operator())
+
+          .def("__setitem__", &exprSetter<CType, IndexVar, TensorVar>, py::is_operator())
+
+          .def("__setitem__", &exprSetter<CType, std::vector<IndexVar>, IndexExpr>, py::is_operator())
+
+          .def("__setitem__", &exprSetter<CType, std::vector<IndexVar>, Access>, py::is_operator())
+
+          .def("__setitem__", &exprSetter<CType, std::vector<IndexVar>, TensorVar>, py::is_operator())
+
+          // This is a hack that exploits pybind11's resolution order. If we get here all other methods to resolve the
+          // function failed and we throw an error. There may be better was to handle this in pybind.
+          .def("__getitem__", [](typedTensor& self, const py::object &indices) -> void {
+              throw py::index_error("Indices must be an iterable of integers or IndexVars");
           }, py::is_operator())
 
-          .def("__setitem__", [](typedTensor& self, const IndexVar indexVar, const Access access) -> void {
-              self(indexVar) = access;
-          }, py::is_operator())
-
-          .def("__setitem__", [](typedTensor& self, const IndexVar indexVar, const TensorVar tensorVar) -> void {
-              self(indexVar) = tensorVar;
-          }, py::is_operator())
-
-          .def("__setitem__", [](typedTensor& self, const std::vector<IndexVar> indexVars, const IndexExpr expr) -> void {
-              self(indexVars) = expr;
-          }, py::is_operator())
-
-          .def("__setitem__", [](typedTensor& self, const std::vector<IndexVar> indexVars, const Access access) -> void {
-              self(indexVars) = access;
-          }, py::is_operator())
-
-          .def("__setitem__", [](typedTensor& self, const std::vector<IndexVar> indexVars, const TensorVar tensorVar) -> void {
-              self(indexVars) = tensorVar;
+          .def("__setitem__", [](typedTensor& self, const py::object &indices, py::object value) -> void {
+              throw py::index_error("Indices must be an iterable of integers or IndexVars");
           }, py::is_operator())
 
           .def("__repr__",   [](typedTensor& self) -> std::string{
               std::ostringstream o;
               o << self;
               return o.str();
-          }, py::is_operator())
-
-
-          // This is a hack that exploits pybind11's resolution order. If we get here all other methods to resolve the
-          // function failed on both passes and we throw an error. There may be better was to handle this in pybind.
-          .def("__getitem__", [](typedTensor& self, const py::object &indices) -> void {
-            throw py::index_error("Indices must be an iterable of integers or IndexVars");
-          }, py::is_operator())
-
-          .def("__setitem__", [](typedTensor& self, const py::object &indices, py::object value) -> void {
-             throw py::index_error("Indices must be an iterable of integers or IndexVars");
           }, py::is_operator());
+
 }
 
-void defineTensor(py::module &m){
+void defineTensor(py::module &m) {
 
   py::class_<TensorBase>(m, "TensorBase")
-          .def(py::init<>());
+          .def("dtype", &TensorBase::getComponentType);
 
   declareTensor<int8_t>(m, "Int8");
   declareTensor<int16_t>(m, "Int16");

--- a/python_bindings/src/pyTensor.cpp
+++ b/python_bindings/src/pyTensor.cpp
@@ -362,6 +362,7 @@ void defineTensor(py::module &m) {
   py::class_<TensorBase>(m, "TensorBase")
           .def("dtype", &TensorBase::getComponentType);
 
+  declareTensor<bool>(m, "Bool");
   declareTensor<int8_t>(m, "Int8");
   declareTensor<int16_t>(m, "Int16");
   declareTensor<int32_t>(m, "Int32");

--- a/python_bindings/src/pyTensor.cpp
+++ b/python_bindings/src/pyTensor.cpp
@@ -154,6 +154,15 @@ static inline void elementSetter(Tensor<CType> &tensor, std::vector<int> coords,
   tensor.insert(coords, static_cast<CType>(value));
 }
 
+template<typename CType>
+static void insert(Tensor<CType> &tensor, std::vector<int> coords, double value) {
+  checkBounds(tensor.getDimensions(), coords);
+  if(tensor.getOrder() == 0) {
+    tensor = static_cast<CType>(value);
+  }
+  tensor.insert(coords, static_cast<CType>(value));
+}
+
 template<typename CType, typename pyType>
 static inline void singleElementSetter(Tensor<CType> &tensor, int coord, pyType value) {
   elementSetter<CType, pyType>(tensor, {coord}, value);
@@ -257,6 +266,8 @@ static void declareTensor(py::module &m, const std::string typestr) {
 
           .def("compute", &typedTensor::compute)
 
+          .def("insert", &insert<CType>)
+
           .def("transpose", [](typedTensor &self, std::vector<int> dims, Format format, std::string name) -> void{
               self.transpose(name, dims, format);
           }, py::is_operator())
@@ -280,13 +291,13 @@ static void declareTensor(py::module &m, const std::string typestr) {
 
           .def("__getitem__", &accessGetter<CType, std::vector<IndexVar>&>, py::is_operator())
 
-          .def("__setitem__", &singleElementSetter<CType, int64_t>, py::is_operator())
-
-          .def("__setitem__", &singleElementSetter<CType, double>, py::is_operator())
-
           .def("__setitem__", &elementSetter<CType, int64_t>, py::is_operator())
 
           .def("__setitem__", &elementSetter<CType, double>, py::is_operator())
+
+          .def("__setitem__", &singleElementSetter<CType, int64_t>, py::is_operator())
+
+          .def("__setitem__", &singleElementSetter<CType, double>, py::is_operator())
 
           .def("__setitem__", [](typedTensor& self, nullptr_t ptr, int64_t value) -> void {
               if(self.getOrder() != 0) {

--- a/python_bindings/src/pyTensorIO.cpp
+++ b/python_bindings/src/pyTensorIO.cpp
@@ -10,9 +10,13 @@ static Tensor<double> tensorRead(std::string filename, T modeType, bool pack = t
 }
 
 void defineIOFuncs(py::module &m){
-  m.def("read", tensorRead<Format>, py::arg("filename"), py::arg("format").noconvert(), py::arg("pack")=true);
-  m.def("read", tensorRead<ModeFormat>, py::arg("filename"), py::arg("modeType").noconvert(), py::arg("pack")=true);
-  m.def("write",(void (*)(std::string, const TensorBase&)) &taco::write, py::arg("filename"),
+  m.def("_read", tensorRead<Format>, py::arg("filename"), py::arg("format").noconvert(),
+          py::arg("pack")=true);
+
+  m.def("_read", tensorRead<ModeFormat>, py::arg("filename"), py::arg("modeType").noconvert(),
+          py::arg("pack")=true);
+
+  m.def("_write",(void (*)(std::string, const TensorBase&)) &taco::write, py::arg("filename"),
           py::arg("tensor").noconvert());
 }
 

--- a/python_bindings/src/pytaco.cpp
+++ b/python_bindings/src/pytaco.cpp
@@ -1,17 +1,24 @@
-#include <python3.6/Python.h>
+#include <Python.h>
 #include <pybind11/pybind11.h>
 #include "pyFormat.h"
 #include "pyDatatypes.h"
 #include "pyIndexNotation.h"
 #include "pyTensor.h"
 #include "pyTensorIO.h"
+#include "pyParsers.h"
 
-PYBIND11_MODULE(pytaco, m){
+
+void addHelpers(py::module &m) {
+  m.def("get_taco_num_threads", &taco::get_taco_num_threads);
+  m.def("set_taco_num_threads", &taco::set_taco_num_threads, py::arg("num_threads"));
+  m.def("unique_name", (std::string(*)(char)) &taco::util::uniqueName);
+}
+
+PYBIND11_MODULE(core_modules, m){
 
   m.doc() = "A Python module for operating on Sparse Tensors.";
   using namespace taco::pythonBindings;
-  m.def("get_taco_num_threads", &taco::get_taco_num_threads);
-  m.def("set_taco_num_threads", &taco::set_taco_num_threads, py::arg("num_threads"));
+  addHelpers(m);
   defineTacoTypes(m);
   defineModeFormats(m);
   defineModeFormatPack(m);
@@ -19,5 +26,7 @@ PYBIND11_MODULE(pytaco, m){
   defineIndexNotation(m);
   defineTensor(m);
   defineIOFuncs(m);
+  defineParser(m);
 
 }
+

--- a/src/parser/einsum_parser.cpp
+++ b/src/parser/einsum_parser.cpp
@@ -22,13 +22,13 @@ EinsumParser::EinsumParser(const std::string &expression, const std::vector<Tens
 //  tensorExpressions = parseToTaco(expression, tensors);
 }
 
-void EinsumParser::parse(){
-
-}
-
-TensorBase EinsumParser::getResultTensor(){
-  //return resultTensor
-}
+//void EinsumParser::parse(){
+//
+//}
+//
+//TensorBase EinsumParser::getResultTensor(){
+//  return resultTensor;
+//}
 
 std::vector<std::string> EinsumParser::genUnusedSymbols(std::set<std::string> &usedSymbols, int numUnusedSymbolsNeeded) {
   const std::string baseEinsumChars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");

--- a/src/parser/einsum_parser.cpp
+++ b/src/parser/einsum_parser.cpp
@@ -4,62 +4,39 @@
 #include "taco/util/strings.h"
 #include "taco/tensor.h"
 
-
 #include <algorithm>
 
 namespace taco{
 namespace parser{
 
-EinsumParser::EinsumParser(const std::string &expression, const std::vector<TensorBase> &tensors) {
+EinsumParser::EinsumParser(const std::string &expression,
+                           std::vector<TensorBase> &tensors,
+                           Format &format,
+                           Datatype outType) : outType(outType), format(format), tensors(tensors) {
+
+  einsumSymbols = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  einSumSymbolsSet = std::set<char>(einsumSymbols.begin(), einsumSymbols.end());
+  einsumPunctuation = ".,->";
 
   if(expression.empty()){
     throw ParseError("No input operands");
   }
 
   // Remove spaces from expression
-  std::string subscripts;
   std::remove_copy(expression.begin(), expression.end(), std::back_inserter(subscripts), ' ');
-//  tensorExpressions = parseToTaco(expression, tensors);
-}
 
-//void EinsumParser::parse(){
-//
-//}
-//
-//TensorBase EinsumParser::getResultTensor(){
-//  return resultTensor;
-//}
-
-std::vector<std::string> EinsumParser::genUnusedSymbols(std::set<std::string> &usedSymbols, int numUnusedSymbolsNeeded) {
-  const std::string baseEinsumChars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
-
-  // Base index name to use if we run out of einsum characters.
-  const std::string baseName("ein");
-
-  int unusedSymbolsFound = 0, currentIdx = 0;
-  std::vector<std::string> unusedSymbols;
-  taco::util::NameGenerator nameGenerator({baseName});
-
-  // First consume einsum characters
-  while(unusedSymbolsFound < numUnusedSymbolsNeeded && currentIdx < (int)baseEinsumChars.length()){
-
-    std::string currentSymbol(1, baseEinsumChars[currentIdx++]);
-    if(usedSymbols.count(currentSymbol) == 0){
-      unusedSymbols.emplace_back(currentSymbol);
-      unusedSymbolsFound++;
+  // Check that all elements are valid and throw error otherwise
+  for(const auto& s: subscripts) {
+    if(einSumSymbolsSet.count(s) == 0 && einsumPunctuation.find(s) == std::string::npos) {
+      std::ostringstream o;
+      o << "Character " << s << " is not a valid symbol.";
+      throw ParseError(o.str());
     }
   }
-
-  // If we run out of einsum variables, create new variables as placeholders.
-  while(unusedSymbolsFound < numUnusedSymbolsNeeded){
-    unusedSymbols.push_back(nameGenerator.getUniqueName(baseName));
-    unusedSymbolsFound++;
-  }
-
-  return unusedSymbols;
 }
 
-std::string EinsumParser::findOutputString(const std::string &subscripts){
+std::string EinsumParser::findUniqueIndices(const std::string &subscripts) {
+
   std::string tempString;
   std::remove_copy_if(subscripts.begin(), subscripts.end(), std::back_inserter(tempString),
                       [](char chr){ return chr == '.' || chr == ',';});
@@ -91,8 +68,8 @@ bool EinsumParser::exprHasOutput(const std::string &subscripts){
   // Go through subscripts and check for ->
   int dash_count = 0, gt_count = 0;
   for(int i = 0; i < (int)subscripts.size(); i++){
-    dash_count = subscripts[i] == '-'? dash_count + 1: dash_count;
-    gt_count = subscripts[i] == '>'? gt_count + 1: gt_count;
+    dash_count += (subscripts[i] == '-');
+    gt_count   += (subscripts[i] == '>');
 
     if(subscripts[i] == '-' && (i + 1) < (int)subscripts.size() && subscripts[i+1] != '>'){
       throw ParseError("Subscripts must contain '->' instead of '-'.");
@@ -106,128 +83,220 @@ bool EinsumParser::exprHasOutput(const std::string &subscripts){
   return dash_count == 1;
 }
 
-std::string EinsumParser::convertToIndexExpr(const std::string &subscripts, const std::vector<std::string> &ellipsisReplacement,
-                                             const std::string &tensorName) {
 
-  std::string tensorString(tensorName + "(");
+std::string EinsumParser::replaceEllipse(std::string inp, std::string &newString){
+  const std::string ellipse("...");
+  size_t firstCharLoc = inp.find(ellipse);
+  if(firstCharLoc == std::string::npos) {
+    return inp;
+  }
 
-  int ellipseCount = 0;
+  std::string replaced(inp.begin(), inp.begin() + firstCharLoc);
+  replaced += newString;
+  replaced += std::string(inp.begin() + firstCharLoc + ellipse.size(), inp.end());
+  return replaced;
+}
 
-  for(int i = 0; i < (int)subscripts.length(); ++i){
-    const char subscript = subscripts[i];
-    if(subscript == '.'){
-      ellipseCount++;
-      if(ellipseCount == 3){
-        if(subscripts[i - 2] != '.' || subscripts[i-1] != '.'){
-          throw ParseError("Ellipses must be consecutive");
-        }
-        for(const auto& replacement: ellipsisReplacement){
-          tensorString.append(replacement);
-          tensorString.push_back(',');
-        }
+std::vector<std::string> EinsumParser::splitSubscriptInput(std::string &input) {
+  std::vector<std::string> splitInput;
+
+  std::string betweenDelim;
+  for(auto &sub : input) {
+    if(sub == ',') {
+      splitInput.push_back(betweenDelim);
+      betweenDelim.clear();
+    } else {
+      betweenDelim += sub;
+    }
+  }
+  splitInput.push_back(betweenDelim);
+  return splitInput;
+}
+
+TensorBase& EinsumParser::getResultTensor() {
+  return resultTensor;
+}
+
+void EinsumParser::buildResult(std::vector<std::string> subs){
+
+  std::vector<std::string> inputSubs = splitSubscriptInput(subs[0]);
+  std::string outputSubs = subs[1];
+
+  std::map<char, IndexVar> subscriptToIndex;
+  std::map<char, int> subscriptToShape;
+
+
+  for(int currentInput = 0; currentInput < static_cast<int>(inputSubs.size()); ++currentInput){
+    std::string &subscript = inputSubs[currentInput];
+    if(static_cast<int>(subscript.size()) != tensors[currentInput].getOrder()) {
+      std::ostringstream o;
+      o << "Dimension mismatch for input " << currentInput << ".";
+      throw ParseError(o.str());
+    }
+
+    const auto &tensorDims = tensors[currentInput].getDimensions();
+    for(int i = 0; i < static_cast<int>(subscript.size()); ++i) {
+      if(subscriptToIndex.count(i) == 0){
+        subscriptToIndex.insert({subscript[i], IndexVar()});
       }
-    }else{
-      tensorString.push_back(subscript);
-      tensorString.push_back(',');
+
+      // This is fine since we don't broadcast singleton dimensions meaning all indices must access the same var
+      if(subscriptToShape.count(i) == 0) {
+        subscriptToShape.insert({subscript[i], tensorDims[i]});
+      } else if (subscriptToShape.at(subscript[i]) != tensorDims[i]) {
+        throw ParseError("Dimensions mismatch.");
+      }
     }
   }
 
-  if(ellipseCount != 0 && ellipseCount != 3){
-    throw ParseError("Incorrect number of ellipses present in index expression.");
+  std::vector<IndexVar> vars;
+  for(auto &sub : inputSubs[0]) {
+    vars.push_back(subscriptToIndex.at(sub));
   }
 
-  if(tensorString[tensorString.length() - 1] == ','){
-    tensorString[tensorString.length() - 1] = ')';
-  }else{
-    tensorString.push_back(')');
+  IndexExpr expr = tensors[0](vars);
+  vars.clear();
+  for(int i = 1; i < static_cast<int>(tensors.size()); ++i) {
+    TensorBase& tensor = tensors[i];
+    for(auto &sub : inputSubs[i]) {
+      vars.push_back(subscriptToIndex.at(sub));
+    }
+    expr = expr * tensor(vars);
+    vars.clear();
   }
 
-  // Need to check if we actually need a scalar
-  if(tensorString[tensorString.length() - 2] == '(' && tensorString[tensorString.length() - 1] == ')'){
-    return tensorName;
+  // Build output - first var list then tensor
+  std::vector<int> outShape;
+  for(auto &sub : outputSubs) {
+    vars.push_back(subscriptToIndex.at(sub));
+    outShape.push_back(subscriptToShape.at(sub));
   }
 
-  return tensorString;
+  if(format.getOrder() != 0 && format.getOrder() != static_cast<int>(outShape.size())) {
+    std::ostringstream o;
+    o << "Number of dimensions in format (" << format.getOrder() << ") does not match dimensions of output tensor("
+                                                                 <<  outShape.size() << "),";
+    throw ParseError(o.str());
+  }
+
+  if(format.getOrder() == 0 && format.getOrder() != static_cast<int>(outShape.size())) {
+    format = Format(std::vector<ModeFormatPack>(outShape.size(), dense));
+  }
+
+  resultTensor = TensorBase(outType, outShape, format);
+  resultTensor(vars) = expr;
 }
 
-std::vector<std::string> EinsumParser::parseToTaco(const std::string &subscripts,
-                                                   const std::vector<TensorBase> &tensors) {
 
-  // Split operands list and get output operand
+void EinsumParser::parse() {
+
   bool hasOutput = exprHasOutput(subscripts);
+
+  // Split tensor if output exists
   std::vector<std::string> inputTensorSubscripts;
-  std::string outputSubscripts, unsplitInputs;
+  std::string outputSubscripts;
   if(hasOutput) {
     std::vector<std::string> temp = taco::util::split(subscripts, "->");
     outputSubscripts = temp.size() == 2? temp[1]: outputSubscripts;
-    unsplitInputs = temp[0];
-    inputTensorSubscripts = taco::util::split(unsplitInputs, ",");
+    inputTensorSubscripts = splitSubscriptInput(temp[0]);
   }else {
-    inputTensorSubscripts = taco::util::split(subscripts, ",");
-    unsplitInputs = subscripts;
-    outputSubscripts = "..." + findOutputString(subscripts);
+    inputTensorSubscripts = splitSubscriptInput(subscripts);
   }
 
-  // Check that all output subscripts are in the input
-  for(const char &sub : outputSubscripts){
-    if(sub != '.' && unsplitInputs.find(sub) == std::string::npos){
-      throw ParseError("Output contains an index not in the input.");
-    }
+  if(inputTensorSubscripts.size() != tensors.size()) {
+    throw ParseError("There needs to be one tensor for each input string.");
   }
 
-  // Compute set of used characters
-  std::set<std::string> usedSymbols;
-  for(const char &subscript : subscripts){
-    if(isalpha(subscript)){
-      usedSymbols.emplace(1, subscript);
-    }
-  }
+  if(subscripts.find('.') != std::string::npos) {
+    std::string usedSymbols, unusedSymbols;
 
-  // Compute the max size of the tensor
-  int maxTensorOrder = 0;
-  for(const auto &tensor : tensors){
-    maxTensorOrder = std::max(maxTensorOrder, tensor.getOrder());
-  }
-
-  // Create a list of unused index names
-  std::vector<std::string> unusedSymbols = genUnusedSymbols(usedSymbols, maxTensorOrder);
-
-  int longestOmittedDimSize = 0;
-  std::vector<std::string> tensorsExprs;
-
-  for(int currentTensor = 0; currentTensor < (int)tensors.size(); ++currentTensor){
-    std::string &tensorSubscript = inputTensorSubscripts[currentTensor];
-
-    if(tensorSubscript.find('.') != std::string::npos){
-
-      int dimsRemaining = tensors[currentTensor].getOrder() - (int)(tensorSubscript.length() - 3);
-      longestOmittedDimSize = std::max(longestOmittedDimSize, dimsRemaining);
-
-      if(dimsRemaining < 0){
-        throw ParseError("Ellipses lengths do not match.");
-      }else{
-        std::vector<std::string> tacoIndices(unusedSymbols.end() - dimsRemaining, unusedSymbols.end());
-        tensorsExprs.push_back(convertToIndexExpr(tensorSubscript, tacoIndices, tensors[currentTensor].getName()));
+    for(auto& elt : subscripts) {
+      if(einsumPunctuation.find(elt) == std::string::npos) {
+        usedSymbols += elt;
       }
+    }
 
-    }else{
-      tensorsExprs.push_back(convertToIndexExpr(tensorSubscript, {""}, tensors[currentTensor].getName()));
+    for(auto& elt : einsumSymbols) {
+      if (usedSymbols.find(elt) == std::string::npos) {
+        unusedSymbols += elt;
+      }
+    }
+
+    int longest = 0;
+
+    for(size_t i = 0; i < inputTensorSubscripts.size(); ++i) {
+      std::string subscript = inputTensorSubscripts[i];
+
+      if(subscript.find('.') != std::string::npos) {
+        if(std::count(subscript.begin(), subscript.end(), '.') != 3 || subscript.find("...") == std::string::npos) {
+          throw ParseError("Invalid Ellipses.");
+        }
+
+        int ellipseCount = 0;
+        if(tensors[i].getOrder() > 0){
+          ellipseCount = std::max(tensors[i].getOrder(), 1);
+          ellipseCount -= (subscript.size() - 3);
+        }
+
+        longest = std::max(longest, ellipseCount);
+
+        if(ellipseCount < 0) {
+          throw ParseError("Ellipses lengths do not match.");
+        } else if (ellipseCount == 0) {
+          std::string noEllipseSub;
+          std::remove_copy(subscript.begin(), subscript.end(), std::back_inserter(noEllipseSub), '.');
+          inputTensorSubscripts[i] = noEllipseSub;
+        } else {
+          std::string replace_ind(unusedSymbols.end() - ellipseCount, unusedSymbols.end());
+          inputTensorSubscripts[i] = replaceEllipse(subscript, replace_ind);
+        }
+      }
+    }
+
+    subscripts = util::join(inputTensorSubscripts.begin(), inputTensorSubscripts.end(), ",");
+    std::string outEllipse;
+    if(longest > 0){
+      outEllipse = std::string(unusedSymbols.end() - longest, unusedSymbols.end());
+    }
+
+    if(hasOutput) {
+      subscripts += ("->" + replaceEllipse(outputSubscripts, outEllipse));
+    } else {
+      std::string sortedOutput = findUniqueIndices(subscripts);
+      std::string normalInds;
+      std::remove_copy_if(sortedOutput.begin(), sortedOutput.end(), std::back_inserter(normalInds),
+                         [outEllipse](char chr){ return outEllipse.find(chr) != std::string::npos; });
+
+      std::sort(normalInds.begin(), normalInds.end());
+      subscripts += ("->" + outEllipse + normalInds);
     }
   }
 
-  std::string tacoOutput;
-
-  // Index vars to replace ellipses in output if any
-  std::vector<std::string> outEllipseIndices(unusedSymbols.end() - longestOmittedDimSize, unusedSymbols.end());
-  tacoOutput = convertToIndexExpr(outputSubscripts, outEllipseIndices, "out");
-
-  // Ensure number of tensors equals the number of terms
-  if(tensorsExprs.size() != tensors.size()){
-    throw ParseError("Number of subscripts must be equal to the number of terms.");
+  std::string inputSubs;
+  if(subscripts.find("->") != std::string::npos){
+    std::vector<std::string> temp = taco::util::split(subscripts, "->");
+    outputSubscripts = temp.size() == 2? temp[1]: outputSubscripts;
+    inputSubs = temp[0];
+  } else {
+    inputSubs = subscripts;
+    outputSubscripts = findUniqueIndices(inputSubs);
+    subscripts += ("->" + outputSubscripts);
   }
 
-  tensorsExprs.push_back(tacoOutput);
-  return tensorsExprs;
-}
 
+  for(auto &sub : outputSubscripts) {
+    if(inputSubs.find(sub) == std::string::npos) {
+      std::ostringstream o;
+      o << "Output character " << sub << " did not appear in the input";
+      throw ParseError(o.str());
+    }
+  }
+
+  size_t num_inputs = splitSubscriptInput(inputSubs).size();
+  if(num_inputs != tensors.size()) {
+    throw ParseError("Number of einsum subscripts must be equal to the number of operands.");
+  }
+
+  buildResult({inputSubs, outputSubscripts});
+}
 }}

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -262,12 +262,17 @@ IndexExpr Parser::parseFinal() {
   }
 }
 
+const std::vector<std::string> Parser::getNames() const{
+  return names;
+}
+
 Access Parser::parseAccess() {
   if(content->currentToken != Token::identifier) {
     throw ParseError("Expected tensor name");
   }
   string tensorName = content->lexer.getIdentifier();
   consume(Token::identifier);
+  names.push_back(tensorName);
 
   vector<IndexVar> varlist;
   if (content->currentToken == Token::underscore) {


### PR DESCRIPTION
Exposes parsers to Python and hides different tensor classes.

Implements a functional API for the python interface.

Exposes dense tensors as buffer objects so they can be transformed to numpy arrays.

Allows initialization of tensors from numpy arrays and scipy sparse matrices.