### PR TITLE
Added docs folder

### DIFF
--- a/python_bindings/docs/make.bat
+++ b/python_bindings/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+
+:end
+popd

--- a/python_bindings/docs/source/conf.py
+++ b/python_bindings/docs/source/conf.py
@@ -1,0 +1,75 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# http://www.sphinx-doc.org/en/master/config
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../..'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'PyTaco'
+copyright = '2019, MIT COMMIT GROUP'
+author = 'MIT COMMIT GROUP'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.ifconfig',
+    'numpydoc',
+
+]
+
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+
+# -- Extension configuration -------------------------------------------------
+
+
+numpydoc_attributes_as_param_list = True
+numpydoc_class_members_toctree = False
+numpydoc_show_class_members = False
+
+
+# -- Options for intersphinx extension ---------------------------------------
+
+# Example configuration for intersphinx: refer to the Python standard library.
+intersphinx_mapping = {'https://docs.python.org/': None}

--- a/python_bindings/docs/source/index.rst
+++ b/python_bindings/docs/source/index.rst
@@ -1,0 +1,23 @@
+.. PyTaco documentation master file, created by
+   sphinx-quickstart on Sat May 25 19:06:12 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to PyTaco's documentation
+==================================
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Home:
+
+   rst_files/tensor
+   rst_files/datatype
+   rst_files/format
+   rst_files/file_io
+   rst_files/sched
+
+
+
+
+
+

--- a/python_bindings/docs/source/rst_files/as_np_dt.rst
+++ b/python_bindings/docs/source/rst_files/as_np_dt.rst
@@ -1,0 +1,4 @@
+Converting PyTaco Datatype to Numpy
+======================================
+
+.. autofunction:: pytaco.as_np_dtype

--- a/python_bindings/docs/source/rst_files/datatype.rst
+++ b/python_bindings/docs/source/rst_files/datatype.rst
@@ -1,0 +1,15 @@
+Datatypes
+========================
+
+.. toctree::
+   :maxdepth: 2
+
+   dtype_object
+   as_np_dt
+
+
+
+
+
+
+

--- a/python_bindings/docs/source/rst_files/dtype_object.rst
+++ b/python_bindings/docs/source/rst_files/dtype_object.rst
@@ -1,0 +1,4 @@
+PyTaco Datatype Object
+=================================
+
+.. autoclass:: pytaco.dtype

--- a/python_bindings/docs/source/rst_files/file_io.rst
+++ b/python_bindings/docs/source/rst_files/file_io.rst
@@ -1,0 +1,17 @@
+Tensor IO
+=================================
+
+PyTaco can read and write tensors natively from four different file formats. The formats PyTaco supports are:
+
+`Matrix Market (Coordinate) Format <https://math.nist.gov/MatrixMarket/formats.html>`_ - .mtx
+
+`Rutherford-Boeing Format <https://www.cise.ufl.edu/research/sparse/matrices/DOC/rb.pdf>`_ - .rb
+
+`FROSTT Format <http://frostt.io/tensors/file-formats.html>`_ - .tns
+
+For both the read and write functions, the file format is inferred from the file extension. This means that the
+extension must be given when specifying a file name.
+
+
+.. autofunction:: pytaco.read
+.. autofunction:: pytaco.write

--- a/python_bindings/docs/source/rst_files/format.rst
+++ b/python_bindings/docs/source/rst_files/format.rst
@@ -1,0 +1,11 @@
+Formats
+=======================
+.. toctree::
+   :maxdepth: 3
+   :caption: Home:
+
+   mode_format
+   format_class
+   format_funcs
+
+

--- a/python_bindings/docs/source/rst_files/format_class.rst
+++ b/python_bindings/docs/source/rst_files/format_class.rst
@@ -1,0 +1,3 @@
+PyTaco Format Object
+=======================
+.. autoclass:: pytaco.format

--- a/python_bindings/docs/source/rst_files/format_funcs.rst
+++ b/python_bindings/docs/source/rst_files/format_funcs.rst
@@ -1,0 +1,4 @@
+Format Functions
+===================
+
+.. autofunction:: pytaco.is_dense

--- a/python_bindings/docs/source/rst_files/mode_format.rst
+++ b/python_bindings/docs/source/rst_files/mode_format.rst
@@ -1,0 +1,3 @@
+Mode Formats
+=======================
+.. autoclass:: pytaco.mode_format

--- a/python_bindings/docs/source/rst_files/sched.rst
+++ b/python_bindings/docs/source/rst_files/sched.rst
@@ -1,0 +1,7 @@
+Scheduling Commands
+======================
+
+.. autofunction:: pytaco.get_num_threads
+.. autofunction:: pytaco.set_num_threads
+.. autofunction:: pytaco.set_parallel_schedule
+.. autofunction:: pytaco.get_parallel_schedule

--- a/python_bindings/docs/source/rst_files/tensor.rst
+++ b/python_bindings/docs/source/rst_files/tensor.rst
@@ -1,0 +1,4 @@
+Tensor Class
+=================
+.. autoclass:: pytaco.tensor
+


### PR DESCRIPTION
Added docs folder. Needs sphinx, numpydocs and sphinx_rtd_theme.

Install Sphinx using:
apt-get install python3-sphinx

Install numpydoc using:
pip3 install numpydoc

Install Read the docs theme using:
pip3 install sphinx_rtd_theme

To build, cd into the docs directory and type:
make html

There are some premade docs in the html folder.