### PR TITLE
Fix clang compilation errors.

### DIFF
--- a/include/taco/ir/ir_printer.h
+++ b/include/taco/ir/ir_printer.h
@@ -4,6 +4,7 @@
 #include <ostream>
 #include <map>
 #include <string>
+#include "taco/ir/ir.h"
 #include "taco/ir/ir_visitor.h"
 #include "taco/util/scopedmap.h"
 #include "taco/util/name_generator.h"

--- a/include/taco/util/scopedmap.h
+++ b/include/taco/util/scopedmap.h
@@ -1,6 +1,7 @@
 #ifndef TACO_UTIL_SCOPEDMAP_H
 #define TACO_UTIL_SCOPEDMAP_H
 
+#include <iostream>
 #include <list>
 #include <map>
 #include <ostream>

--- a/include/taco/util/timers.h
+++ b/include/taco/util/timers.h
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <iostream>
 #include <numeric>
-#include <ostream>
 #include <vector>
 #include <cmath>
 #include "taco/error.h"

--- a/include/taco/util/timers.h
+++ b/include/taco/util/timers.h
@@ -3,8 +3,12 @@
 
 #include <chrono>
 #include <algorithm>
+#include <iostream>
 #include <numeric>
+#include <ostream>
+#include <vector>
 #include <cmath>
+#include "taco/error.h"
 
 using namespace std;
 

--- a/include/taco/util/variadic.h
+++ b/include/taco/util/variadic.h
@@ -2,6 +2,7 @@
 #define TACO_UTIL_VARIADIC_H
 
 #include <type_traits>
+#include <vector>
 
 namespace taco {
 namespace util {

--- a/src/lower/lowerer_impl.cpp
+++ b/src/lower/lowerer_impl.cpp
@@ -610,7 +610,7 @@ Stmt LowererImpl::lowerMergeCases(ir::Expr coordinate, IndexStmt stmt,
       Stmt body = lowerForallBody(coordinate, zeroedStmt, {},
                                   inserters, appenders, reducedAccesses);
 
-      cases.push_back({conjunction(coordComparisons), body});
+      cases.push_back({taco::ir::conjunction(coordComparisons), body});
     }
     result.push_back(Case::make(cases, lattice.exact()));
   }
@@ -1539,7 +1539,7 @@ Expr LowererImpl::checkThatNoneAreExhausted(std::vector<Iterator> iterators)
   }
 
   return (!result.empty())
-         ? conjunction(result)
+         ? taco::ir::conjunction(result)
          : Lt::make(iterators[0].getIteratorVar(), iterators[0].getEndVar());
 }
 


### PR DESCRIPTION
Fix compilation errors when compiling taco with clang.
- Explicitly include headers that are used implicitly. 
- Call taco::ir::conjunction in lower_impl.cpp with its full name to avoid ambiguity with std::conjunction.