### PR TITLE
Cuda error codes vary with cuda version; don't hardcode numbers.

### DIFF
--- a/src/cuda.cpp
+++ b/src/cuda.cpp
@@ -44,7 +44,7 @@ string get_default_CUDA_compiler_flags() {
   #define gpuErrchk(ans) { gpuAssert((ans), __FILE__, __LINE__); }
   inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=true)
   {
-    if (code != cudaSuccess && code != 29) // 29 is driver is shutting down which is normal behavior 
+    if (code != cudaSuccess && code != cudaErrorCudartUnloading) // cudart unloading is normal behavior
     {
       taco_ierror << "GPUassert: " << code << " " << cudaGetErrorString(code) << " " << file << " " << line;
     }


### PR DESCRIPTION
I get the following after running the tests:

```
[----------] Global test environment tear-down
[==========] 805 tests from 271 test cases ran. (1075533 ms total)
[  PASSED  ] 805 tests.

  YOU HAVE 10 DISABLED TESTS

Compiler bug at /home/infinoid/workspace/taco/taco/src/cuda.cpp:49 in gpuAssert
Please report it to developers
 GPUassert: 4 driver shutting down /home/infinoid/workspace/taco/taco/src/cuda.cpp 68
Aborted
```

In cuda 9.0, cudaErrorCudartUnloading = 29.
In cuda 10.2, cudaErrorCudartUnloading = 4.
Using the enum name should work in both cases.


With the fix, I get:

```
[----------] Global test environment tear-down
[==========] 805 tests from 271 test cases ran. (1037539 ms total)
[  PASSED  ] 805 tests.

  YOU HAVE 10 DISABLED TESTS

```

My cmake command was:
`cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCUDA=ON ../taco`