### PR TITLE
Fix a couple of index expression equality tests

### DIFF
--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -134,7 +134,7 @@ struct Equals : public IndexNotationVisitorStrict {
       eq = false;
       return;
     }
-    if (anode->indexVars.size() != anode->indexVars.size()) {
+    if (anode->indexVars.size() != bnode->indexVars.size()) {
       eq = false;
       return;
     }
@@ -279,7 +279,7 @@ struct Equals : public IndexNotationVisitorStrict {
       return;
     }
     auto bnode = to<YieldNode>(bStmt.ptr);
-    if (anode->indexVars.size() != anode->indexVars.size()) {
+    if (anode->indexVars.size() != bnode->indexVars.size()) {
       eq = false;
       return;
     }


### PR DESCRIPTION
These look like bugs to me.

The code compares vector sizes before comparing vector contents; but comparing side A with itself is ineffective.

The `Isomorphic` class in the `second-taco` branch has the same issues.  I will fix that separately.