### PR TITLE
Fix index expression equality/isomorphism classes

### DIFF
--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -172,7 +172,7 @@ struct Isomorphic : public IndexNotationVisitorStrict {
       eq = false;
       return;
     }
-    if (anode->indexVars.size() != anode->indexVars.size()) {
+    if (anode->indexVars.size() != bnode->indexVars.size()) {
       eq = false;
       return;
     }
@@ -320,7 +320,7 @@ struct Isomorphic : public IndexNotationVisitorStrict {
       return;
     }
     auto bnode = to<YieldNode>(bStmt.ptr);
-    if (anode->indexVars.size() != anode->indexVars.size()) {
+    if (anode->indexVars.size() != bnode->indexVars.size()) {
       eq = false;
       return;
     }
@@ -444,7 +444,7 @@ struct Equals : public IndexNotationVisitorStrict {
       eq = false;
       return;
     }
-    if (anode->indexVars.size() != anode->indexVars.size()) {
+    if (anode->indexVars.size() != bnode->indexVars.size()) {
       eq = false;
       return;
     }
@@ -591,7 +591,7 @@ struct Equals : public IndexNotationVisitorStrict {
       return;
     }
     auto bnode = to<YieldNode>(bStmt.ptr);
-    if (anode->indexVars.size() != anode->indexVars.size()) {
+    if (anode->indexVars.size() != bnode->indexVars.size()) {
       eq = false;
       return;
     }


### PR DESCRIPTION
Same as #294, but for the `second-taco` branch.  In this branch, the `Isomorphic` class has the same issues as the `Equals` class.

(I am working toward a merge, but wanted to track this separately.)