### PR TITLE
Fix scheduling tests to catch exceptions properly for Python builds

### DIFF
--- a/test/tests-scheduling.cpp
+++ b/test/tests-scheduling.cpp
@@ -725,7 +725,11 @@ TEST(scheduling, dense_pos_error) {
   y(i) = x(i);
 
   IndexStmt stmt = y.getAssignment().concretize();
+#ifdef PYTHON
+  ASSERT_THROW(stmt.pos(i, ipos, x(i)), taco::TacoException);
+#else
   ASSERT_DEATH(stmt.pos(i, ipos, x(i)), "Pos transformation is not valid for dense formats, the coordinate space should be transformed instead");
+#endif
 }
 
 TEST(scheduling, pos_var_not_in_access) {
@@ -735,7 +739,11 @@ TEST(scheduling, pos_var_not_in_access) {
   y(i) = x(i);
 
   IndexStmt stmt = y.getAssignment().concretize();
+#ifdef PYTHON
+  ASSERT_THROW(stmt.pos(j, ipos, x(i)), taco::TacoException);
+#else
   ASSERT_DEATH(stmt.pos(j, ipos, x(i)), "Index variable j does not appear in access: x[(]i[)]");
+#endif
 }
 
 TEST(scheduling, pos_wrong_access) {
@@ -745,8 +753,13 @@ TEST(scheduling, pos_wrong_access) {
   y(i) = x(i);
 
   IndexStmt stmt = y.getAssignment().concretize();
+#ifdef PYTHON
+  ASSERT_THROW(stmt.pos(i, ipos, x(j)), taco::TacoException);
+  ASSERT_THROW(stmt.pos(i, ipos, y(i)), taco::TacoException);
+#else
   ASSERT_DEATH(stmt.pos(i, ipos, x(j)), "Access: x[(]j[)] does not appear in index statement as an argument");
   ASSERT_DEATH(stmt.pos(i, ipos, y(i)), "Access: y[(]i[)] does not appear in index statement as an argument");
+#endif
 }
 
 TEST(scheduling_eval_test, spmv_fuse) {


### PR DESCRIPTION
The Python build changes the way errors are reported; failed assertions become thrown exceptions.
The gtest framework has different macros to expect assertions vs exceptions, so tests which expect assertions are broken for Python builds.

When you try to run this:
```
cmake -DPYTHON=ON ../taco
make
bin/taco-test
```

Three tests fail.  The failures look like:

```
[ RUN      ] scheduling.dense_pos_error
Death test: stmt.pos(i, ipos, x(i))
    Result: threw an exception.
 Error msg:
[  DEATH   ] 
[  DEATH   ] /home/infinoid/workspace/taco/taco/test/tests-scheduling.cpp:728:: Caught std::exception-derived exception escaping the death test statement. Exception message: Error at /home/infinoid/workspace/taco/taco/src/index_notation/index_notation.cpp:1458 in pos:
[  DEATH   ]  Pos transformation is not valid for dense formats, the coordinate space should be transformed instead
[  DEATH   ] 
[  FAILED  ] scheduling.dense_pos_error (1 ms)
[ RUN      ] scheduling.pos_var_not_in_access
Death test: stmt.pos(j, ipos, x(i))
    Result: threw an exception.
 Error msg:
[  DEATH   ] 
[  DEATH   ] /home/infinoid/workspace/taco/taco/test/tests-scheduling.cpp:738:: Caught std::exception-derived exception escaping the death test statement. Exception message: Error at /home/infinoid/workspace/taco/taco/src/index_notation/index_notation.cpp:1453 in pos:
[  DEATH   ]  Index variable j does not appear in access: x(i)
[  DEATH   ] 
[  FAILED  ] scheduling.pos_var_not_in_access (2 ms)
[ RUN      ] scheduling.pos_wrong_access
Death test: stmt.pos(i, ipos, x(j))
    Result: threw an exception.
 Error msg:
[  DEATH   ] 
[  DEATH   ] /home/infinoid/workspace/taco/taco/test/tests-scheduling.cpp:748:: Caught std::exception-derived exception escaping the death test statement. Exception message: Error at /home/infinoid/workspace/taco/taco/src/index_notation/index_notation.cpp:1435 in pos:
[  DEATH   ]  Access: x(j) does not appear in index statement as an argument
[  DEATH   ] 
[  FAILED  ] scheduling.pos_wrong_access (2 ms)
```

This patch fixes the scheduling death tests to expect the right kind of failure based on whether PYTHON is defined.  With this, the test suite passes for me, for both python and non-python builds.