### PR TITLE
Teach cmake how to install python bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 build/
 bin/
 lib/
-python_bindings/libs/
-python_bindings/pytaco/core/
 *__pycache__*
 *.swp
 *.swo

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -12,9 +12,17 @@ foreach(dir ${PY_SRC_DIRS})
     file(GLOB PY_SOURCES ${PY_SOURCES} ${dir}/*.cpp)
 endforeach()
 
+file(GLOB PYTACO_FILES ${CMAKE_CURRENT_SOURCE_DIR}/pytaco/*.py)
+file(GLOB PYTENSOR_FILES ${CMAKE_CURRENT_SOURCE_DIR}/pytaco/pytensor/*.py)
+
 set(PY_SOURCES ${PY_SOURCES})
 pybind11_add_module(core_modules ${PY_SOURCES} ${TACO_SOURCES})
 
-set_target_properties(core_modules PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${TACO_PROJECT_DIR}/python_bindings/pytaco/core)
+set_target_properties(core_modules PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/pytaco/core)
 target_link_libraries(core_modules LINK_PRIVATE taco)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/pytaco DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 
+set(PY_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/lib/pytaco)
+install(FILES ${PYTACO_FILES} DESTINATION ${PY_INSTALL_PATH})
+install(FILES ${PYTENSOR_FILES} DESTINATION ${PY_INSTALL_PATH}/pytensor)
+install(TARGETS core_modules DESTINATION ${PY_INSTALL_PATH}/core)


### PR DESCRIPTION
Currently, cmake's `make install` rule ignores the python bindings.  CMake puts the built shared object directly into the pytaco source folder.

This patch stages the `.py` files and `.so` file in the build folder, and installs them during `make install`.  The results look like this:

```
/usr/local/lib
/usr/local/lib/libtaco.so
/usr/local/lib/pytaco
/usr/local/lib/pytaco/__init__.py
/usr/local/lib/pytaco/pytensor
/usr/local/lib/pytaco/pytensor/__init__.py
/usr/local/lib/pytaco/pytensor/taco_tensor.py
/usr/local/lib/pytaco/pytensor/tensorIO.py
/usr/local/lib/pytaco/core
/usr/local/lib/pytaco/core/core_modules.cpython-36m-x86_64-linux-gnu.so
```

The staging of `.py` and `.so` files in the build folder will be useful for fixing `make test`, which is next on my list.