### PR TITLE
Bump cmake requirement to cover features taco uses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 project(taco)
 option(CUDA "Build for NVIDIA GPU (CUDA must be preinstalled)" OFF)
 option(PYTHON "Build TACO for python environment" OFF)


### PR DESCRIPTION
Taco requires a minimum cmake version of 2.8.3.  But while I was testing #300, I found that taco doesn't actually build with cmake 2.8.3.  The libtaco library fails to link:

```
Linking CXX shared library ../lib/libtaco.so
/usr/bin/ld: cannot find -lPRIVATE
collect2: error: ld returned 1 exit status
src/CMakeFiles/taco.dir/build.make:1669: recipe for target 'lib/libtaco.so' failed
make[2]: *** [lib/libtaco.so] Error 1
CMakeFiles/Makefile2:103: recipe for target 'src/CMakeFiles/taco.dir/all' failed
make[1]: *** [src/CMakeFiles/taco.dir/all] Error 2
Makefile:110: recipe for target 'all' failed
make: *** [all] Error 2
```

Taco's build scripts use the "PRIVATE" library type.  This feature was introduced in cmake 2.8.12.

So, bump the requirement to 2.8.12.  (Note that 2.8.12 is still quite old, it was released 2013-10-11.)

Here is where Taco uses it: https://github.com/tensor-compiler/taco/blob/master/src/CMakeLists.txt#L30

Here are some docs on what PRIVATE means: https://cmake.org/cmake/help/v3.18/command/target_link_libraries.html#libraries-for-a-target-and-or-its-dependents

Here is the cmake changelog when they added it: "target_link_libraries: Add PUBLIC/PRIVATE/INTERFACE keyword signature" -- https://cmake.org/files/v2.8/CMakeChangeLog-2.8.12
