### PR TITLE
Add TACO_NVCC var to complement TACO_NVCCFLAGS

### DIFF
--- a/src/codegen/module.cpp
+++ b/src/codegen/module.cpp
@@ -122,7 +122,7 @@ string Module::compile() {
   string file_ending;
   string shims_file;
   if (should_use_CUDA_codegen()) {
-    cc = "nvcc";
+    cc = util::getFromEnv("TACO_NVCC", "nvcc");
     cflags = util::getFromEnv("TACO_NVCCFLAGS",
     get_default_CUDA_compiler_flags());
     file_ending = ".cu";


### PR DESCRIPTION
This is useful for passing additional arguments to nvcc.

I did this because I wanted to force nvcc to use a specific version of g++.
Example: `TACO_NVCC="nvcc -ccbin g++-8"`