### PR TITLE
Fix taco_tensor_t.h to be compatible with C99.

### DIFF
--- a/include/taco/taco_tensor_t.h
+++ b/include/taco/taco_tensor_t.h
@@ -6,7 +6,7 @@
 #ifndef TACO_TENSOR_T_DEFINED
 #define TACO_TENSOR_T_DEFINED
 
-#include <cstdint>
+#include <stdint.h>
 
 typedef enum { taco_mode_dense, taco_mode_sparse } taco_mode_t;
 


### PR DESCRIPTION
The [comment at the top of `taco_tensor_t.h`](https://github.com/tensor-compiler/taco/blob/master/include/taco/taco_tensor_t.h#L2)  says it should be C99, not C++.  However, it includes a C++-only system header.

Update it to include the C99 equivalent, instead.  This allows C programs to call Taco-generated compute functions.