### PR TITLE
Add Tensor name collision detection

### DIFF
--- a/include/taco/error/error_messages.h
+++ b/include/taco/error/error_messages.h
@@ -18,6 +18,7 @@ extern const std::string expr_einsum_missformed;
 
 // compile error messages
 extern const std::string compile_without_expr;
+extern const std::string compile_tensor_name_collision;
 
 // assemble error messages
 extern const std::string assemble_without_compile;

--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -851,6 +851,10 @@ public:
   TensorVar(const std::string& name, const Type& type);
   TensorVar(const Type& type, const Format& format);
   TensorVar(const std::string& name, const Type& type, const Format& format);
+  TensorVar(const int &id, const std::string& name, const Type& type, const Format& format);
+
+  /// Returns the ID of the tensor variable.
+  int getId() const;
 
   /// Returns the name of the tensor variable.
   std::string getName() const;

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -864,12 +864,15 @@ struct TensorBase::Content {
   bool               needsAssemble;
   bool               needsCompute;
   std::vector<std::weak_ptr<TensorBase::Content>> dependentTensors;
+  unsigned int       uniqueId;
 
   Content(std::string name, Datatype dataType, const std::vector<int>& dimensions,
           Format format)
       : dataType(dataType), dimensions(dimensions),
         storage(TensorStorage(dataType, dimensions, format)),
-        tensorVar(TensorVar(name, Type(dataType,convert(dimensions)),format)) {}
+        tensorVar(TensorVar(util::getUniqueId(), name, Type(dataType,convert(dimensions)),format)) {
+          uniqueId = tensorVar.getId();
+        }
 };
 
 // ------------------------------------------------------------

--- a/include/taco/util/name_generator.h
+++ b/include/taco/util/name_generator.h
@@ -11,6 +11,8 @@ namespace util {
 std::string uniqueName(char prefix);
 std::string uniqueName(const std::string& prefix);
 
+int getUniqueId();
+
 class NameGenerator {
 public:
   NameGenerator();

--- a/src/error/error_messages.cpp
+++ b/src/error/error_messages.cpp
@@ -28,6 +28,9 @@ const std::string expr_einsum_missformed =
 const std::string compile_without_expr =
   "The tensor must be assigned to before compile is called.";
 
+const std::string compile_tensor_name_collision =
+  "Tensor name collision.";
+
 const std::string assemble_without_compile =
   "The compile method must be called before assemble.";
 

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -1815,6 +1815,7 @@ std::ostream& operator<<(std::ostream& os, const IndexVar& var) {
 
 // class TensorVar
 struct TensorVar::Content {
+  int id;
   string name;
   Type type;
   Format format;
@@ -1833,18 +1834,27 @@ TensorVar::TensorVar(const Type& type)
 }
 
 TensorVar::TensorVar(const std::string& name, const Type& type)
-: TensorVar(name, type, createDenseFormat(type)) {
+: TensorVar(-1, name, type, createDenseFormat(type)) {
 }
 
 TensorVar::TensorVar(const Type& type, const Format& format)
-    : TensorVar(util::uniqueName('A'), type, format) {
+    : TensorVar(-1, util::uniqueName('A'), type, format) {
 }
 
 TensorVar::TensorVar(const string& name, const Type& type, const Format& format)
+    : TensorVar(-1, name, type, format) {
+}
+
+TensorVar::TensorVar(const int& id, const string& name, const Type& type, const Format& format)
     : content(new Content) {
+  content->id = id;
   content->name = name;
   content->type = type;
   content->format = format;
+}
+
+int TensorVar::getId() const {
+  return content->id;
 }
 
 std::string TensorVar::getName() const {

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -540,6 +540,33 @@ void TensorBase::compile() {
   taco_uassert(assignment.defined())
       << error::compile_without_expr;
 
+  struct CollisionFinder : public IndexNotationVisitor {
+    using IndexNotationVisitor::visit;
+
+    std::map<std::string,const TensorVar> tensorvars;
+
+    CollisionFinder() :tensorvars() {}
+
+    void visit(const AccessNode* node) {
+      Access access(node);
+      const TensorVar new_tensorvar = access.getTensorVar();
+      const std::string new_name = new_tensorvar.getName();
+      if(new_tensorvar.getId() != -1) {
+        auto found = tensorvars.find(new_name);
+        if(found != tensorvars.end() && found->second.getId() != -1) {
+          const TensorVar found_tensorvar = found->second;
+          taco_uassert(new_tensorvar.getId() == found_tensorvar.getId())
+              << error::compile_tensor_name_collision << " " << new_name;
+        } else {
+          tensorvars.insert(std::pair<std::string,const TensorVar>(new_name, new_tensorvar));
+        }
+      }
+    }
+  };
+  CollisionFinder dupes = CollisionFinder();
+  assignment.getLhs().accept(&dupes);
+  assignment.accept(&dupes);
+
   IndexStmt stmt = makeConcreteNotation(makeReductionNotation(assignment));
   stmt = reorderLoopsTopologically(stmt);
   stmt = insertTemporaries(stmt);

--- a/src/util/name_generator.cpp
+++ b/src/util/name_generator.cpp
@@ -22,6 +22,10 @@ string uniqueName(const string& prefix) {
   return prefix + to_string(uniqueCount());
 }
 
+int getUniqueId() {
+  return uniqueCount();
+}
+
 
 // class NameGenerator
 NameGenerator::NameGenerator() {

--- a/test/tests-error.cpp
+++ b/test/tests-error.cpp
@@ -38,6 +38,17 @@ TEST(error, compile_without_expr) {
 #endif
 }
 
+TEST(error, compile_tensor_name_collision) {
+  Tensor<double> a("a", {5}, Sparse);
+  Tensor<double> b("a", {5}, Sparse); // name should be "b"
+  a(i) = b(i);
+#ifdef PYTHON
+  ASSERT_THROW(a.compile(), taco::TacoException);
+#else
+  ASSERT_DEATH(a.compile(), error::compile_tensor_name_collision);
+#endif
+}
+
 TEST(error, assemble_without_compile) {
   Tensor<double> a({5}, Sparse);
   Tensor<double> b({5}, Sparse);


### PR DESCRIPTION
Add a sanity check to catch cases where multiple tensors are used with the same name.
Fixes #324.

Add a check to Tensor.compile() to match up Tensor names with IDs and catch name collisions.
Add "Tensor name collision." error string to error_messages.{cpp,h}.
Add an internal unique ID to `Tensor` and `TensorVar` objects.
Add a test case.