### PR TITLE
Rename CMake "gtest" library to "taco-gtest"

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,14 +1,14 @@
 file(GLOB GTEST_SOURCE gtest/gtest-all.cc)
 file(GLOB GTEST_HEADER gtest/gtest.h)
 include_directories(${TACO_TEST_DIR} ${TACO_SRC_DIR})
-add_library(gtest ${GTEST_HEADER} ${GTEST_SOURCE})
+add_library(taco-gtest ${GTEST_HEADER} ${GTEST_SOURCE})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-declarations -DTACO_TEST_DIR=\"${TACO_TEST_DIR}\"")
 
 file(GLOB TEST_HEADERS *.h)
 file(GLOB TEST_SOURCES *.cpp)
 
 add_executable(taco-test ${TEST_SOURCES} ${TEST_HEADERS})
-target_link_libraries(taco-test gtest)
+target_link_libraries(taco-test taco-gtest)
 target_link_libraries(taco-test pthread)
 target_link_libraries(taco-test taco)
 


### PR DESCRIPTION
This allows application projects to build with Taco using cmake without target name collisions.

Fixes: #271

This allows application projects to include a taco source directory in their CMake build, and have their own copy of the gtest framework without name conflicts.