### PR TITLE
Workspace reuse

### DIFF
--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -949,6 +949,10 @@ std::vector<TensorVar> getArguments(IndexStmt stmt);
 /// Returns the temporaries in the index statement, in the order they appear.
 std::vector<TensorVar> getTemporaries(IndexStmt stmt);
 
+// [Olivia]
+/// Returns the temporaries in the index statement, in the order they appear.
+std::map<Forall, Where> getTemporaryLocations(IndexStmt stmt);
+
 /// Returns the tensors in the index statement.
 std::vector<TensorVar> getTensorVars(IndexStmt stmt);
 

--- a/include/taco/ir/ir.h
+++ b/include/taco/ir/ir.h
@@ -65,7 +65,8 @@ enum class IRNodeType {
   BlankLine,
   Print,
   GetProperty,
-  Break
+  Break,
+  Sort
 };
 
 enum class TensorProperty {
@@ -723,6 +724,13 @@ struct Break : public StmtNode<Break> {
   static Stmt make();
 
   static const IRNodeType _type_info = IRNodeType::Break;
+};
+
+struct Sort : public StmtNode<Sort> {
+  std::vector<Expr> args;
+  static Stmt make(std::vector<Expr> args);
+
+  static const IRNodeType _type_info = IRNodeType::Sort;
 };
 
 /** A print statement.

--- a/include/taco/ir/ir_printer.h
+++ b/include/taco/ir/ir_printer.h
@@ -68,6 +68,7 @@ protected:
   virtual void visit(const Break*);
   virtual void visit(const Print*);
   virtual void visit(const GetProperty*);
+  virtual void visit(const Sort*);
 
   std::ostream &stream;
   int indent;

--- a/include/taco/ir/ir_rewriter.h
+++ b/include/taco/ir/ir_rewriter.h
@@ -68,6 +68,7 @@ protected:
   virtual void visit(const Break* op);
   virtual void visit(const Print* op);
   virtual void visit(const GetProperty* op);
+  virtual void visit(const Sort *op);
 };
 
 }}

--- a/include/taco/ir/ir_visitor.h
+++ b/include/taco/ir/ir_visitor.h
@@ -48,6 +48,7 @@ struct BlankLine;
 struct Break;
 struct Print;
 struct GetProperty;
+struct Sort;
 
 /// Extend this class to visit every node in the IR.
 class IRVisitorStrict {
@@ -98,6 +99,7 @@ public:
   virtual void visit(const Break*) = 0;
   virtual void visit(const Print*) = 0;
   virtual void visit(const GetProperty*) = 0;
+  virtual void visit(const Sort*) = 0;
 };
 
 
@@ -151,6 +153,7 @@ public:
   virtual void visit(const Break* op);
   virtual void visit(const Print* op);
   virtual void visit(const GetProperty* op);
+  virtual void visit(const Sort* op);
 };
 
 }}

--- a/include/taco/lower/lowerer_impl.h
+++ b/include/taco/lower/lowerer_impl.h
@@ -350,8 +350,8 @@ protected:
   /// Initializes a temporary workspace
   std::vector<ir::Stmt> codeToInitializeTemporary(Where where);
 
-  /// Gets the size of a temporary tensorVar
-  ir::Expr getTemporarySize(TensorVar var);
+  /// Gets the size of a temporary tensorVar in the where statement
+  ir::Expr getTemporarySize(Where where);
 
   /// Initializes helper arrays to give dense workspaces sparse acceleration
   std::vector<ir::Stmt> codeToInitializeDenseAcceleratorArrays(Where where);

--- a/include/taco/lower/lowerer_impl.h
+++ b/include/taco/lower/lowerer_impl.h
@@ -333,17 +333,19 @@ protected:
   ir::Stmt codeToInitializeIteratorVars(std::vector<Iterator> iterators, std::vector<Iterator> rangers, std::vector<Iterator> mergers, ir::Expr coord, IndexVar coordinateVar);
   ir::Stmt codeToInitializeIteratorVar(Iterator iterator, std::vector<Iterator> iterators, std::vector<Iterator> rangers, std::vector<Iterator> mergers, ir::Expr coordinate, IndexVar coordinateVar);
 
+  /// Initializes a temporary workspace
+  std::vector<ir::Stmt> codeToInitializeTemporary(Where where);
 
   /// Recovers a derived indexvar from an underived variable.
   ir::Stmt codeToRecoverDerivedIndexVar(IndexVar underived, IndexVar indexVar, bool emitVarDecl);
 
-    /// Conditionally increment iterator position variables.
+  /// Conditionally increment iterator position variables.
   ir::Stmt codeToIncIteratorVars(ir::Expr coordinate, IndexVar coordinateVar,
           std::vector<Iterator> iterators, std::vector<Iterator> mergers);
 
   ir::Stmt codeToLoadCoordinatesFromPosIterators(std::vector<Iterator> iterators, bool declVars);
 
-    /// Create statements to append coordinate to result modes.
+  /// Create statements to append coordinate to result modes.
   ir::Stmt appendCoordinate(std::vector<Iterator> appenders, ir::Expr coord);
 
   /// Create statements to append positions to result modes.
@@ -362,6 +364,9 @@ private:
 
   int markAssignsAtomicDepth = 0;
   ParallelUnit atomicParallelUnit;
+
+  /// Map used to hoist temporary workspace initialization
+  std::map<Forall, Where> temporaryInitialization;
 
   /// Map from tensor variables in index notation to variables in the IR
   std::map<TensorVar, ir::Expr> tensorVars;

--- a/src/codegen/codegen_c.cpp
+++ b/src/codegen/codegen_c.cpp
@@ -182,7 +182,7 @@ protected:
 
   virtual void visit(const Var *op) {
     if (varMap.count(op) == 0) {
-      varMap[op] = codeGen->genUniqueName(op->name);
+      varMap[op] = op->is_ptr? op->name : codeGen->genUniqueName(op->name);
     }
   }
 

--- a/src/codegen/codegen_c.cpp
+++ b/src/codegen/codegen_c.cpp
@@ -190,6 +190,7 @@ protected:
     if (!util::contains(localVars, op->var)) {
       localVars.push_back(op->var);
     }
+    op->var.accept(this);
     op->rhs.accept(this);
   }
 

--- a/src/codegen/codegen_cuda.cpp
+++ b/src/codegen/codegen_cuda.cpp
@@ -240,7 +240,7 @@ protected:
 
   virtual void visit(const Var *op) {
     if (varMap.count(op) == 0 && !inBlock) {
-      varMap[op] = codeGen->genUniqueName(op->name);
+      varMap[op] = op->is_ptr? op->name : codeGen->genUniqueName(op->name);
     }
   }
 

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -2118,8 +2118,23 @@ bool isConcreteNotation(IndexStmt stmt, std::string* reason) {
         return;
       }
 
+      // Handles derived vars on RHS with underived vars on LHS.
+      Assignment assignPtrWrapper = Assignment(op);
+      std::vector<IndexVar> possibleReductionVars = assignPtrWrapper.getReductionVars();
+      std::vector<IndexVar> freeVars = assignPtrWrapper.getFreeVars();
+      std::set<IndexVar> freeVarsSet(freeVars.begin(), freeVars.end());
+
+      int numReductionVars = 0;
+      for(const auto& reductionVar : possibleReductionVars) {
+        std::vector<IndexVar> underivedParents = provGraph.getUnderivedAncestors(reductionVar);
+        for(const auto& parent : underivedParents) {
+          if(!util::contains(freeVarsSet, parent)) {
+            ++numReductionVars;
+          }
+        }
+      }
       // allow introducing precompute loops where we set a temporary to values instead of +=
-      if (Assignment(op).getReductionVars().size() > 0 &&
+      if (numReductionVars > 0 &&
           op->op == IndexExpr() && !inWhereProducer) {
         *reason = "reduction variables in concrete notation must be dominated "
                   "by compound assignments (such as +=)";

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -2332,6 +2332,22 @@ vector<TensorVar> getArguments(IndexStmt stmt) {
   return result;
 }
 
+std::map<Forall, Where> getTemporaryLocations(IndexStmt stmt) {
+  map<Forall, Where> temporaryLocs;
+  Forall f = Forall();
+  match(stmt,
+        function<void(const ForallNode*, Matcher*)>([&](const ForallNode* op, Matcher* ctx) {
+          f = op;
+          ctx->match(op->stmt);
+        }),
+          function<void(const WhereNode*, Matcher*)>([&](const WhereNode* w, Matcher* ctx) {
+            if (!(f == IndexStmt()))
+              temporaryLocs.insert({f, Where(w)});
+          })
+        );
+  return temporaryLocs;
+}
+
 std::vector<TensorVar> getTemporaries(IndexStmt stmt) {
   vector<TensorVar> temporaries;
   bool firstAssignment = true;

--- a/src/index_notation/index_notation_printer.cpp
+++ b/src/index_notation/index_notation_printer.cpp
@@ -81,7 +81,12 @@ void IndexNotationPrinter::visit(const NegNode* op) {
   Precedence precedence = Precedence::NEG;
   bool parenthesize =  precedence > parentPrecedence;
   parentPrecedence = precedence;
-  os << "-";
+  if(op->getDataType().isBool()) {
+    os << "!";
+  } else {
+    os << "-";
+  }
+
   if (parenthesize) {
     os << "(";
   }

--- a/src/index_notation/transformations.cpp
+++ b/src/index_notation/transformations.cpp
@@ -1115,16 +1115,15 @@ static IndexStmt optimizeSpMM(IndexStmt stmt) {
   }
 
   TensorVar B = Baccess.getTensorVar();
-  if (B.getFormat().getModeFormats()[0].getName() != "dense" ||
-      B.getFormat().getModeFormats()[1].getName() != "compressed" ||
-      B.getFormat().getModeOrdering()[0] != 0 ||
+  if (B.getFormat().getModeOrdering()[0] != 0 ||
       B.getFormat().getModeOrdering()[1] != 1) {
     return stmt;
   }
 
+  // We need random access into the first mode or this tensor in order to perform a linear combination of rows
+  // algorithm. (I think?)
   TensorVar C = Caccess.getTensorVar();
-  if (C.getFormat().getModeFormats()[0].getName() != "dense" ||
-      C.getFormat().getModeFormats()[1].getName() != "compressed" ||
+  if (C.getFormat().getModeFormats()[0].getName() == "compressed" ||
       C.getFormat().getModeOrdering()[0] != 0 ||
       C.getFormat().getModeOrdering()[1] != 1) {
     return stmt;

--- a/src/index_notation/transformations.cpp
+++ b/src/index_notation/transformations.cpp
@@ -1123,7 +1123,7 @@ static IndexStmt optimizeSpMM(IndexStmt stmt) {
   // We need random access into the first mode or this tensor in order to perform a linear combination of rows
   // algorithm. (I think?)
   TensorVar C = Caccess.getTensorVar();
-  if (C.getFormat().getModeFormats()[0].getName() == "compressed" ||
+  if (!C.getFormat().getModeFormats()[0].hasLocate() ||
       C.getFormat().getModeOrdering()[0] != 0 ||
       C.getFormat().getModeOrdering()[1] != 1) {
     return stmt;

--- a/src/index_notation/transformations.cpp
+++ b/src/index_notation/transformations.cpp
@@ -1114,16 +1114,19 @@ static IndexStmt optimizeSpMM(IndexStmt stmt) {
     return stmt;
   }
 
+  // I think we can to linear combination of rows as long as there are no permutations in the format and the
+  // level formats are ordered. The i -> k -> j loops should iterate over the data structures without issue.
   TensorVar B = Baccess.getTensorVar();
-  if (B.getFormat().getModeOrdering()[0] != 0 ||
+  if (!B.getFormat().getModeFormats()[0].isOrdered() ||
+      !B.getFormat().getModeFormats()[1].isOrdered() ||
+      B.getFormat().getModeOrdering()[0] != 0 ||
       B.getFormat().getModeOrdering()[1] != 1) {
     return stmt;
   }
 
-  // We need random access into the first mode or this tensor in order to perform a linear combination of rows
-  // algorithm. (I think?)
   TensorVar C = Caccess.getTensorVar();
-  if (!C.getFormat().getModeFormats()[0].hasLocate() ||
+  if (!C.getFormat().getModeFormats()[0].isOrdered() ||
+      !C.getFormat().getModeFormats()[1].isOrdered() ||
       C.getFormat().getModeOrdering()[0] != 0 ||
       C.getFormat().getModeOrdering()[1] != 1) {
     return stmt;

--- a/src/ir/ir.cpp
+++ b/src/ir/ir.cpp
@@ -817,6 +817,13 @@ Expr GetProperty::make(Expr tensor, TensorProperty property, int mode,
   return gp;
 }
 
+// Sort
+Stmt Sort::make(std::vector<Expr> args) {
+  Sort* sort = new Sort;
+  sort->args = args;
+  return sort;
+}
+
 
 // GetProperty
 Expr GetProperty::make(Expr tensor, TensorProperty property, int mode) {
@@ -953,6 +960,8 @@ template<> void StmtNode<Print>::accept(IRVisitorStrict *v)
     const { v->visit((const Print*)this); }
 template<> void ExprNode<GetProperty>::accept(IRVisitorStrict *v)
     const { v->visit((const GetProperty*)this); }
+template<> void StmtNode<Sort>::accept(IRVisitorStrict *v)
+  const { v->visit((const Sort*)this); }
 
 // printing methods
 std::ostream& operator<<(std::ostream& os, const Stmt& stmt) {

--- a/src/ir/ir_printer.cpp
+++ b/src/ir/ir_printer.cpp
@@ -131,7 +131,11 @@ void IRPrinter::visit(const Var* op) {
 }
 
 void IRPrinter::visit(const Neg* op) {
-  stream << "-";
+  if(op->type.isBool()) {
+    stream << "!";
+  } else {
+    stream << "-";
+  }
   parentPrecedence = Precedence::NEG;
   op->a.accept(this);
 }
@@ -574,6 +578,16 @@ void IRPrinter::visit(const Print* op) {
 void IRPrinter::visit(const GetProperty* op) {
   stream << op->name;
 }
+
+void IRPrinter::visit(const Sort* op) {
+  doIndent();
+  stream << "qsort(";
+  parentPrecedence = Precedence::CALL;
+  acceptJoin(this, stream, op->args, ", ");
+  stream << ");";
+  stream << endl;
+}
+
 
 void IRPrinter::resetNameCounters() {
   // seed the unique names with all C99 keywords

--- a/src/ir/ir_rewriter.cpp
+++ b/src/ir/ir_rewriter.cpp
@@ -479,5 +479,23 @@ void IRRewriter::visit(const GetProperty* op) {
   }
 }
 
+void IRRewriter::visit(const Sort* op) {
+  std::vector<Expr> args;
+  bool rewritten = false;
+  for (auto& arg : op->args) {
+    Expr rewrittenArg = rewrite(arg);
+    args.push_back(rewrittenArg);
+    if (rewrittenArg != arg) {
+      rewritten = true;
+    }
+  }
+  if (rewritten) {
+    stmt = Sort::make(args);
+  }
+  else {
+    stmt = op;
+  }
+}
+
 
 }}

--- a/src/ir/ir_visitor.cpp
+++ b/src/ir/ir_visitor.cpp
@@ -236,5 +236,10 @@ void IRVisitor::visit(const Print* op) {
     e.accept(this);
 }
 
+void IRVisitor::visit(const Sort* op) {
+  for (auto e: op->args)
+    e.accept(this);
+}
+
 }  // namespace ir
 }  // namespace taco

--- a/src/lower/lower.cpp
+++ b/src/lower/lower.cpp
@@ -12,6 +12,7 @@
 #include "taco/ir/ir.h"
 #include "taco/ir/simplify.h"
 #include "ir/ir_generators.h"
+#include "taco/ir/ir_printer.h"
 
 #include "taco/lower/lowerer_impl.h"
 #include "taco/lower/iterator.h"

--- a/src/lower/lowerer_impl.cpp
+++ b/src/lower/lowerer_impl.cpp
@@ -939,7 +939,7 @@ Stmt LowererImpl::lowerForallDimension(Forall forall,
 
     Stmt declareVar = VarDecl::make(coordinate, Load::make(indexList, loopVar));
     Stmt body = lowerForallBody(coordinate, forall.getStmt(), locators, inserters, appenders, reducedAccesses);
-    Stmt resetGuard = ir::Store::make(bitGuard, loopVar, ir::Literal::make(false), markAssignsAtomicDepth > 0, atomicParallelUnit);
+    Stmt resetGuard = ir::Store::make(bitGuard, coordinate, ir::Literal::make(false), markAssignsAtomicDepth > 0, atomicParallelUnit);
     body = Block::make(declareVar, body, resetGuard);
 
     if (forall.getParallelUnit() != ParallelUnit::NotParallel && forall.getOutputRaceStrategy() == OutputRaceStrategy::Atomics) {

--- a/src/lower/lowerer_impl.cpp
+++ b/src/lower/lowerer_impl.cpp
@@ -1622,8 +1622,8 @@ Stmt LowererImpl::lowerWhere(Where where) {
   }
 
   // Now that temporary allocations are hoisted, we always need to emit an initialization loop before entering the
-  // producer.
-  if(generateComputeCode() && !isScalar(temporary.getType())) {
+  // producer but only if there is no dense acceleration
+  if(generateComputeCode() && !isScalar(temporary.getType()) && !accelarateDenseWorkSpace) {
     // TODO: We only actually need to do this if:
     //      1) We use the temporary multiple times
     //      2) The PRODUCER RHS is sparse(not full). (Guarantees that old values are overwritten before consuming)

--- a/test/tests-scheduling.cpp
+++ b/test/tests-scheduling.cpp
@@ -84,6 +84,7 @@ TEST(scheduling, lowerDenseMatrixMul) {
     }
   }
 
+  cout << "-------PACKING---------" << endl;
   A.pack();
   B.pack();
 
@@ -96,21 +97,29 @@ TEST(scheduling, lowerDenseMatrixMul) {
              .split(j, j0, j1, 2)
              .split(k, k0, k1, 2)
              .reorder({i0, j0, k0, i1, j1, k1});
+  cout << "-------COMPILING---------" << endl;
 
   C.compile(stmt);
+  cout << "-------ASSEMBLING---------" << endl;
   C.assemble();
+  cout << "-------COMPUTING---------" << endl;
   C.compute();
 
   Tensor<double> expected("expected", {4, 4}, {Dense, Dense});
   expected(i, j) = A(i, k) * B(k, j);
+  IndexStmt expected_stmt = C.getAssignment().concretize();
   expected.compile();
   expected.assemble();
   expected.compute();
   ASSERT_TENSOR_EQ(C, expected);
 
-  //  std::shared_ptr<ir::CodeGen> codegen = ir::CodeGen::init_default(cout, ir::CodeGen::ImplementationGen);
-  //  ir::Stmt compute = lower(stmt, "compute",  false, true);
-  //  codegen->compile(compute, true);
+    cout << stmt << endl;
+
+    std::shared_ptr<ir::CodeGen> codegen = ir::CodeGen::init_default(cout, ir::CodeGen::ImplementationGen);
+    ir::Stmt compute = lower(stmt, "compute",  true, true);
+    codegen->compile(compute, true);
+    ir::Stmt expected_compute = lower(expected_stmt, "compute",  false, true);
+    //codegen->compile(expected_compute, true);
 }
 
 TEST(scheduling, lowerSparseCopy) {

--- a/test/tests-scheduling.cpp
+++ b/test/tests-scheduling.cpp
@@ -84,7 +84,6 @@ TEST(scheduling, lowerDenseMatrixMul) {
     }
   }
 
-  cout << "-------PACKING---------" << endl;
   A.pack();
   B.pack();
 
@@ -97,29 +96,21 @@ TEST(scheduling, lowerDenseMatrixMul) {
              .split(j, j0, j1, 2)
              .split(k, k0, k1, 2)
              .reorder({i0, j0, k0, i1, j1, k1});
-  cout << "-------COMPILING---------" << endl;
 
   C.compile(stmt);
-  cout << "-------ASSEMBLING---------" << endl;
   C.assemble();
-  cout << "-------COMPUTING---------" << endl;
   C.compute();
 
   Tensor<double> expected("expected", {4, 4}, {Dense, Dense});
   expected(i, j) = A(i, k) * B(k, j);
-  IndexStmt expected_stmt = C.getAssignment().concretize();
   expected.compile();
   expected.assemble();
   expected.compute();
   ASSERT_TENSOR_EQ(C, expected);
 
-    cout << stmt << endl;
-
-    std::shared_ptr<ir::CodeGen> codegen = ir::CodeGen::init_default(cout, ir::CodeGen::ImplementationGen);
-    ir::Stmt compute = lower(stmt, "compute",  true, true);
-    codegen->compile(compute, true);
-    ir::Stmt expected_compute = lower(expected_stmt, "compute",  false, true);
-    //codegen->compile(expected_compute, true);
+  //  std::shared_ptr<ir::CodeGen> codegen = ir::CodeGen::init_default(cout, ir::CodeGen::ImplementationGen);
+  //  ir::Stmt compute = lower(stmt, "compute",  false, true);
+  //  codegen->compile(compute, true);
 }
 
 TEST(scheduling, lowerSparseCopy) {

--- a/test/tests-workspaces.cpp
+++ b/test/tests-workspaces.cpp
@@ -1,0 +1,186 @@
+#include <taco/index_notation/transformations.h>
+#include <codegen/codegen_c.h>
+#include <codegen/codegen_cuda.h>
+#include "test.h"
+#include "test_tensors.h"
+#include "taco/tensor.h"
+#include "taco/index_notation/index_notation.h"
+#include "codegen/codegen.h"
+#include "taco/lower/lower.h"
+
+using namespace taco;
+
+TEST(workspaces, tile_vecElemMul_NoTail) {
+  
+  Tensor<double> A("A", {16}, {Dense});
+  Tensor<double> B("B", {16}, {Dense});
+  Tensor<double> C("C", {16}, {Dense});
+
+  for (int i = 0; i < 16; i++) {
+      A.insert({i}, (double) i);
+      B.insert({i}, (double) i);
+  }
+
+  A.pack();
+  B.pack();
+
+  IndexVar i("i");
+  IndexVar i_bounded("i_bounded");
+  IndexVar i0("i0"), i1("i1");
+  IndexExpr precomputedExpr = B(i) * C(i);
+  A(i) = precomputedExpr;
+
+  IndexStmt stmt = A.getAssignment().concretize();
+  TensorVar precomputed("precomputed", Type(Float64, {Dimension(i1)}), taco::dense);
+  stmt = stmt.bound(i, i_bounded, 17, BoundType::MaxExact)
+             .split(i_bounded, i0, i1, 4)
+             .precompute(precomputedExpr, i1, i1, precomputed);
+   
+  A.compile(stmt.concretize());
+  A.assemble();
+  A.compute();
+
+  Tensor<double> expected("expected", {16}, {Dense});
+  expected(i) = B(i) * C(i);
+  expected.compile();
+  expected.assemble();
+  expected.compute();
+  ASSERT_TENSOR_EQ(A, expected);
+}
+
+TEST(workspaces, tile_vecElemMul_Tail1) {
+  
+  Tensor<double> A("A", {16}, {Dense});
+  Tensor<double> B("B", {16}, {Dense});
+  Tensor<double> C("C", {16}, {Dense});
+
+  for (int i = 0; i < 16; i++) {
+      A.insert({i}, (double) i);
+      B.insert({i}, (double) i);
+  }
+
+  A.pack();
+  B.pack();
+
+  IndexVar i("i");
+  IndexVar i_bounded("i_bounded");
+  IndexVar i0("i0"), i1("i1");
+  IndexExpr precomputedExpr = B(i) * C(i);
+  A(i) = precomputedExpr;
+
+  IndexStmt stmt = A.getAssignment().concretize();
+  TensorVar precomputed("precomputed", Type(Float64, {Dimension(i1)}), taco::dense);
+  stmt = stmt.bound(i, i_bounded, 16, BoundType::MaxExact)
+             .split(i_bounded, i0, i1, 5)
+             .precompute(precomputedExpr, i1, i1, precomputed);
+   
+  A.compile(stmt.concretize());
+  A.assemble();
+  A.compute();
+
+  Tensor<double> expected("expected", {16}, {Dense});
+  expected(i) = B(i) * C(i);
+  expected.compile();
+  expected.assemble();
+  expected.compute();
+  ASSERT_TENSOR_EQ(A, expected);
+}
+
+TEST(workspaces, tile_vecElemMul_Tail2) {
+  
+  Tensor<double> A("A", {17}, {Dense});
+  Tensor<double> B("B", {17}, {Dense});
+  Tensor<double> C("C", {17}, {Dense});
+
+  for (int i = 0; i < 17; i++) {
+      A.insert({i}, (double) i);
+      B.insert({i}, (double) i);
+  }
+
+  A.pack();
+  B.pack();
+
+  IndexVar i("i");
+  IndexVar i_bounded("i_bounded");
+  IndexVar i0("i0"), i1("i1");
+  IndexExpr precomputedExpr = B(i) * C(i);
+  A(i) = precomputedExpr;
+
+  IndexStmt stmt = A.getAssignment().concretize();
+  TensorVar precomputed("precomputed", Type(Float64, {Dimension(i1)}), taco::dense);
+  stmt = stmt.bound(i, i_bounded, 17, BoundType::MaxExact)
+             .split(i_bounded, i0, i1, 4)
+             .precompute(precomputedExpr, i1, i1, precomputed);
+   
+  A.compile(stmt.concretize());
+  A.assemble();
+  A.compute();
+
+  Tensor<double> expected("expected", {17}, {Dense});
+  expected(i) = B(i) * C(i);
+  expected.compile();
+  expected.assemble();
+  expected.compute();
+  ASSERT_TENSOR_EQ(A, expected);
+
+//  ir::IRPrinter irp = ir::IRPrinter(cout);
+//    
+//  cout << stmt << endl;
+//
+//  std::shared_ptr<ir::CodeGen> codegen = ir::CodeGen::init_default(cout, ir::CodeGen::ImplementationGen);
+//  ir::Stmt compute = lower(stmt, "compute",  false, true);
+//  
+//  irp.print(compute);
+//  cout << endl;
+//  codegen->compile(compute, false);
+}
+
+TEST(workspaces, tile_denseMatMul) {
+  
+  Tensor<double> A("A", {16}, {Dense});
+  Tensor<double> B("B", {16}, {Dense});
+  Tensor<double> C("C", {16}, {Dense});
+
+  for (int i = 0; i < 16; i++) {
+      A.insert({i}, (double) i);
+      B.insert({i}, (double) i);
+  }
+
+  A.pack();
+  B.pack();
+
+  IndexVar i("i");
+  IndexVar i_bounded("i_bounded");
+  IndexVar i0("i0"), i1("i1");
+  IndexExpr precomputedExpr = B(i) * C(i);
+  A(i) = precomputedExpr;
+
+  IndexStmt stmt = A.getAssignment().concretize();
+  TensorVar precomputed("precomputed", Type(Float64, {Dimension(i1)}), taco::dense);
+  stmt = stmt.bound(i, i_bounded, 16, BoundType::MaxExact)
+             .split(i_bounded, i0, i1, 4)
+             .precompute(precomputedExpr, i1, i1, precomputed);
+   
+  A.compile(stmt.concretize());
+  A.assemble();
+  A.compute();
+
+  Tensor<double> expected("expected", {16}, {Dense});
+  expected(i) = B(i) * C(i);
+  expected.compile();
+  expected.assemble();
+  expected.compute();
+  ASSERT_TENSOR_EQ(A, expected);
+
+//  ir::IRPrinter irp = ir::IRPrinter(cout);
+//    
+//  cout << stmt << endl;
+//
+//  std::shared_ptr<ir::CodeGen> codegen = ir::CodeGen::init_default(cout, ir::CodeGen::ImplementationGen);
+//  ir::Stmt compute = lower(stmt, "compute",  false, true);
+//  
+//  irp.print(compute);
+//  cout << endl;
+//  codegen->compile(compute, false);
+  
+}

--- a/test/tests-workspaces.cpp
+++ b/test/tests-workspaces.cpp
@@ -32,11 +32,13 @@ TEST(workspaces, tile_vecElemMul_NoTail) {
 
   IndexStmt stmt = A.getAssignment().concretize();
   TensorVar precomputed("precomputed", Type(Float64, {Dimension(i1)}), taco::dense);
-  stmt = stmt.bound(i, i_bounded, 17, BoundType::MaxExact)
+  stmt = stmt.bound(i, i_bounded, 16, BoundType::MaxExact)
              .split(i_bounded, i0, i1, 4)
              .precompute(precomputedExpr, i1, i1, precomputed);
    
-  A.compile(stmt.concretize());
+    cout << stmt << endl;
+
+  A.compile(stmt);
   A.assemble();
   A.compute();
 

--- a/test/tests-workspaces.cpp
+++ b/test/tests-workspaces.cpp
@@ -36,7 +36,7 @@ TEST(workspaces, tile_vecElemMul_NoTail) {
              .split(i_bounded, i0, i1, 4)
              .precompute(precomputedExpr, i1, i1, precomputed);
    
-    cout << stmt << endl;
+//    cout << stmt << endl;
 
   A.compile(stmt);
   A.assemble();


### PR DESCRIPTION
This PR is joint work by myself and @weiya711. 

List of new features:

1. Support for hoisting allocation of workspace memory outside of the workspace loop. (Thanks to @weiya711)
2. Allows TACO to 'accelerate' dense workspace with sparse iteration. That is, if a workspace consumer is dense and is being stored in a sparse result TACO will automatically track a list of indices and only append the relevant indices to the result tensor. This is useful for SpGEMM. For now, this is only enabled for serial CPU code.
3. Changes the cuda and c code generators so that unique names are not generated for pointer variables.
4. Adds some tests for workspaces which exposed the bug below. (Thanks to @weiya711).

Addresses the following bugs:

1. Fixes bug causing derived variables on the RHS of an assignment to be incorrectly identified as reduction variables. This caused the check for concrete index notation to fail on valid input.

All tests passed with the GPU and CPU backends. Tests were run on a machine with the following configuration:

OS: Ubuntu 20.04.1 LTS
gcc: 7.5.0
g++ 7.5.0
CUDA: 10.2.89

GPU cmake command:  cmake -DCMAKE_BUILD_TYPE=Release -DCUDA=ON ..
CPU cmake command:  cmake -DCMAKE_BUILD_TYPE=Release ..

