### PR TITLE
Fix build failures on ubuntu 16.04

### DIFF
--- a/src/lower/iterator.cpp
+++ b/src/lower/iterator.cpp
@@ -417,7 +417,7 @@ Iterators::Iterators(IndexStmt stmt, const map<TensorVar, Expr>& tensorVars)
       taco_iassert(util::contains(tensorVars, n->tensorVar));
       Expr tensorIR = tensorVars.at(n->tensorVar);
       Format format = n->tensorVar.getFormat();
-      createAccessIterators(Access(n), format, tensorIR, provGraph);
+      this->createAccessIterators(Access(n), format, tensorIR, provGraph);
     }),
     function<void(const AssignmentNode*, Matcher*)>([&](auto n, auto m) {
       m->match(n->rhs);

--- a/test/tests-scheduling-eval.cpp
+++ b/test/tests-scheduling-eval.cpp
@@ -323,8 +323,8 @@ TEST(scheduling_eval, test_spmvCPU_temp) {
   int NUM_J = 1039/10;
   float SPARSITY = .3;
   Tensor<double> A("A", {NUM_I, NUM_J}, CSR);
-  Tensor<double> x("x", {NUM_J}, {Dense});
-  Tensor<double> y("y", {NUM_I}, {Dense});
+  Tensor<double> x("x", {NUM_J}, Format({Dense}));
+  Tensor<double> y("y", {NUM_I}, Format({Dense}));
 
   srand(4353);
   for (int i = 0; i < NUM_I; i++) {
@@ -362,7 +362,7 @@ TEST(scheduling_eval, test_spmvCPU_temp) {
   y.assemble();
   y.compute();
 
-  Tensor<double> expected("expected", {NUM_I}, {Dense});
+  Tensor<double> expected("expected", {NUM_I}, Format({Dense}));
   expected(i) = A(i, j) * x(j);
   expected.compile();
   expected.assemble();
@@ -379,8 +379,8 @@ TEST(scheduling_eval, example_spmvCPU_splitpos) {
   float SPARSITY = .3;
   int CHUNK_SIZE = 16;
   Tensor<double> A("A", {NUM_I, NUM_J}, CSR);
-  Tensor<double> x("x", {NUM_J}, {Dense});
-  Tensor<double> y("y", {NUM_I}, {Dense});
+  Tensor<double> x("x", {NUM_J}, Format({Dense}));
+  Tensor<double> y("y", {NUM_I}, Format({Dense}));
 
   srand(53535);
   for (int i = 0; i < NUM_I; i++) {
@@ -415,7 +415,7 @@ TEST(scheduling_eval, example_spmvCPU_splitpos) {
   y.assemble();
   y.compute();
 
-  Tensor<double> expected("expected", {NUM_I}, {Dense});
+  Tensor<double> expected("expected", {NUM_I}, Format({Dense}));
   expected(i) = A(i, j) * x(j);
   expected.compile();
   expected.assemble();
@@ -542,8 +542,8 @@ TEST(scheduling_eval, spmvCPU) {
   int NUM_J = 1039/10;
   float SPARSITY = .3;
   Tensor<double> A("A", {NUM_I, NUM_J}, CSR);
-  Tensor<double> x("x", {NUM_J}, {Dense});
-  Tensor<double> y("y", {NUM_I}, {Dense});
+  Tensor<double> x("x", {NUM_J}, Format({Dense}));
+  Tensor<double> y("y", {NUM_I}, Format({Dense}));
 
   srand(120);
   for (int i = 0; i < NUM_I; i++) {
@@ -574,7 +574,7 @@ TEST(scheduling_eval, spmvCPU) {
   y.assemble();
   y.compute();
 
-  Tensor<double> expected("expected", {NUM_I}, {Dense});
+  Tensor<double> expected("expected", {NUM_I}, Format({Dense}));
   expected(i) = A(i, j) * x(j);
   expected.compile();
   expected.assemble();
@@ -592,7 +592,7 @@ TEST(scheduling_eval, ttvCPU) {
   float SPARSITY = .3;
   Tensor<double> A("A", {NUM_I, NUM_J}, {Dense, Dense}); // TODO: change to sparse outputs
   Tensor<double> B("B", {NUM_I, NUM_J, NUM_K}, {Sparse, Sparse, Sparse});
-  Tensor<double> c("c", {NUM_K}, {Dense});
+  Tensor<double> c("c", {NUM_K}, Format({Dense}));
 
   srand(9536);
   for (int i = 0; i < NUM_I; i++) {
@@ -757,8 +757,8 @@ TEST(scheduling_eval, spmvGPU) {
   int NUM_J = 1039/10;
   float SPARSITY = .01;
   Tensor<double> A("A", {NUM_I, NUM_J}, CSR);
-  Tensor<double> x("x", {NUM_J}, {Dense});
-  Tensor<double> y("y", {NUM_I}, {Dense});
+  Tensor<double> x("x", {NUM_J}, Format({Dense}));
+  Tensor<double> y("y", {NUM_I}, Format({Dense}));
 
   srand(94353);
   for (int i = 0; i < NUM_I; i++) {
@@ -789,7 +789,7 @@ TEST(scheduling_eval, spmvGPU) {
   y.assemble();
   y.compute();
 
-  Tensor<double> expected("expected", {NUM_I}, {Dense});
+  Tensor<double> expected("expected", {NUM_I}, Format({Dense}));
   expected(i) = A(i, j) * x(j);
   expected.compile();
   expected.assemble();
@@ -1023,7 +1023,7 @@ TEST(scheduling_eval, ttvGPU) {
   float SPARSITY = .3;
   Tensor<double> A("A", {NUM_I, NUM_J}, {Dense, Dense}); // TODO: change to sparse outputs
   Tensor<double> B("B", {NUM_I, NUM_J, NUM_K}, {Sparse, Sparse, Sparse});
-  Tensor<double> c("c", {NUM_K}, {Dense});
+  Tensor<double> c("c", {NUM_K}, Format({Dense}));
 
   srand(35325);
   for (int i = 0; i < NUM_I; i++) {
@@ -1169,8 +1169,8 @@ TEST(generate_evaluation_files, DISABLED_cpu) {
     stringstream source;
     std::shared_ptr<ir::CodeGen> codegen = ir::CodeGen::init_default(source, ir::CodeGen::ImplementationGen);
     Tensor<double> A("A", {NUM_I, NUM_J}, CSR);
-    Tensor<double> x("x", {NUM_J}, {Dense});
-    Tensor<double> y("y", {NUM_I}, {Dense});
+    Tensor<double> x("x", {NUM_J}, Format({Dense}));
+    Tensor<double> y("y", {NUM_I}, Format({Dense}));
     y(i) = A(i, j) * x(j);
     IndexStmt stmt = y.getAssignment().concretize();
     bool isFirst = true;
@@ -1237,7 +1237,7 @@ TEST(generate_evaluation_files, DISABLED_cpu) {
     std::shared_ptr<ir::CodeGen> codegen = ir::CodeGen::init_default(source, ir::CodeGen::ImplementationGen);
     Tensor<double> A("A", {NUM_I, NUM_J}, {Dense, Dense}); // TODO: change to sparse outputs
     Tensor<double> B("B", {NUM_I, NUM_J, NUM_K}, {Sparse, Sparse, Sparse});
-    Tensor<double> c("c", {NUM_K}, {Dense});
+    Tensor<double> c("c", {NUM_K}, Format({Dense}));
     A(i,j) = B(i,j,k) * c(k);
     IndexStmt stmt = A.getAssignment().concretize();
     bool isFirst = true;
@@ -1481,8 +1481,8 @@ TEST(generate_evaluation_files, DISABLED_gpu) {
     stringstream source;
     std::shared_ptr<ir::CodeGen> codegen = ir::CodeGen::init_default(source, ir::CodeGen::ImplementationGen);
     Tensor<double> A("A", {NUM_I, NUM_J}, CSR);
-    Tensor<double> x("x", {NUM_J}, {Dense});
-    Tensor<double> y("y", {NUM_I}, {Dense});
+    Tensor<double> x("x", {NUM_J}, Format({Dense}));
+    Tensor<double> y("y", {NUM_I}, Format({Dense}));
     IndexExpr precomputed = A(i, j) * x(j);
     y(i) = precomputed;
     IndexStmt stmt = y.getAssignment().concretize();
@@ -1509,8 +1509,8 @@ TEST(generate_evaluation_files, DISABLED_gpu) {
     stringstream source;
     std::shared_ptr<ir::CodeGen> codegen = ir::CodeGen::init_default(source, ir::CodeGen::ImplementationGen);
     Tensor<double> A("A", {NUM_I, NUM_J}, CSR);
-    Tensor<double> x("x", {NUM_J}, {Dense});
-    Tensor<double> y("y", {NUM_I}, {Dense});
+    Tensor<double> x("x", {NUM_J}, Format({Dense}));
+    Tensor<double> y("y", {NUM_I}, Format({Dense}));
     IndexExpr precomputed = A(i, j) * x(j);
     y(i) = precomputed;
     IndexStmt stmt = y.getAssignment().concretize();
@@ -1582,7 +1582,7 @@ TEST(generate_evaluation_files, DISABLED_gpu) {
     std::shared_ptr<ir::CodeGen> codegen = ir::CodeGen::init_default(source, ir::CodeGen::ImplementationGen);
     Tensor<double> A("A", {NUM_I, NUM_J}, {Dense, Dense}); // TODO: change to sparse outputs
     Tensor<double> B("B", {NUM_I, NUM_J, NUM_K}, {Sparse, Sparse, Sparse});
-    Tensor<double> c("c", {NUM_K}, {Dense});
+    Tensor<double> c("c", {NUM_K}, Format({Dense}));
     IndexExpr precomputedExpr = B(i,j,k) * c(k);
     A(i,j) = precomputedExpr;
     IndexStmt stmt = A.getAssignment().concretize();
@@ -1665,8 +1665,8 @@ TEST(generate_figures, DISABLED_cpu) {
     stringstream source;
     std::shared_ptr<ir::CodeGen> codegen = ir::CodeGen::init_default(source, ir::CodeGen::ImplementationGen);
     Tensor<double> A("A", {NUM_I, NUM_J}, CSR);
-    Tensor<double> x("x", {NUM_J}, {Dense});
-    Tensor<double> y("y", {NUM_I}, {Dense});
+    Tensor<double> x("x", {NUM_J}, Format({Dense}));
+    Tensor<double> y("y", {NUM_I}, Format({Dense}));
     y(i) = A(i, j) * x(j);
     IndexStmt stmt = y.getAssignment().concretize();
     bool isFirst = true;

--- a/test/tests-scheduling.cpp
+++ b/test/tests-scheduling.cpp
@@ -114,8 +114,8 @@ TEST(scheduling, lowerDenseMatrixMul) {
 }
 
 TEST(scheduling, lowerSparseCopy) {
-  Tensor<double> A("A", {8}, {Sparse});
-  Tensor<double> C("C", {8}, {Dense});
+  Tensor<double> A("A", {8}, Format({Sparse}));
+  Tensor<double> C("C", {8}, Format({Dense}));
 
   for (int i = 0; i < 8; i++) {
     if (i % 2 == 0) {
@@ -136,7 +136,7 @@ TEST(scheduling, lowerSparseCopy) {
   C.assemble();
   C.compute();
 
-  Tensor<double> expected("expected", {8}, {Dense});
+  Tensor<double> expected("expected", {8}, Format({Dense}));
   expected(i) = A(i);
   expected.compile();
   expected.assemble();
@@ -149,9 +149,9 @@ TEST(scheduling, lowerSparseCopy) {
 }
 
 TEST(scheduling, lowerSparseMulDense) {
-  Tensor<double> A("A", {8}, {Sparse});
-  Tensor<double> B("B", {8}, {Dense});
-  Tensor<double> C("C", {8}, {Dense});
+  Tensor<double> A("A", {8}, Format({Sparse}));
+  Tensor<double> B("B", {8}, Format({Dense}));
+  Tensor<double> C("C", {8}, Format({Dense}));
 
   for (int i = 0; i < 8; i++) {
     if (i % 2 == 0) {
@@ -174,7 +174,7 @@ TEST(scheduling, lowerSparseMulDense) {
   C.assemble();
   C.compute();
 
-  Tensor<double> expected("expected", {8}, {Dense});
+  Tensor<double> expected("expected", {8}, Format({Dense}));
   expected(i) = A(i) * B(i);
   expected.compile();
   expected.assemble();
@@ -187,9 +187,9 @@ TEST(scheduling, lowerSparseMulDense) {
 }
 
 TEST(scheduling, lowerSparseMulSparse) {
-  Tensor<double> A("A", {8}, {Sparse});
-  Tensor<double> B("B", {8}, {Sparse});
-  Tensor<double> C("C", {8}, {Dense});
+  Tensor<double> A("A", {8}, Format({Sparse}));
+  Tensor<double> B("B", {8}, Format({Sparse}));
+  Tensor<double> C("C", {8}, Format({Dense}));
 
   for (int i = 0; i < 8; i++) {
     if (i % 2 == 0) {
@@ -214,7 +214,7 @@ TEST(scheduling, lowerSparseMulSparse) {
   C.assemble();
   C.compute();
 
-  Tensor<double> expected("expected", {8}, {Dense});
+  Tensor<double> expected("expected", {8}, Format({Dense}));
   expected(i) = A(i) * B(i);
   expected.compile();
   expected.assemble();
@@ -227,9 +227,9 @@ TEST(scheduling, lowerSparseMulSparse) {
 }
 
 TEST(scheduling, lowerSparseAddSparse) {
-  Tensor<double> A("A", {8}, {Sparse});
-  Tensor<double> B("B", {8}, {Sparse});
-  Tensor<double> C("C", {8}, {Dense});
+  Tensor<double> A("A", {8}, Format({Sparse}));
+  Tensor<double> B("B", {8}, Format({Sparse}));
+  Tensor<double> C("C", {8}, Format({Dense}));
 
   for (int i = 0; i < 8; i++) {
     if (i % 2 == 0) {
@@ -254,7 +254,7 @@ TEST(scheduling, lowerSparseAddSparse) {
   C.assemble();
   C.compute();
 
-  Tensor<double> expected("expected", {8}, {Dense});
+  Tensor<double> expected("expected", {8}, Format({Dense}));
   expected(i) = A(i) + B(i);
   expected.compile();
   expected.assemble();
@@ -270,7 +270,7 @@ TEST(scheduling, lowerSparseAddSparse) {
 TEST(scheduling, lowerSparseMatrixMul) {
   Tensor<double> A("A", {8, 8}, CSR);
   Tensor<double> B("B", {8, 8}, CSC);
-  Tensor<double> C("C", {8, 8}, {Dense, Dense});
+  Tensor<double> C("C", {8, 8}, Format({Dense, Dense}));
 
   for (int i = 0; i < 8; i++) {
     for (int j = 0; j < 8; j++) {
@@ -318,8 +318,8 @@ TEST(scheduling, lowerSparseMatrixMul) {
 }
 
 TEST(scheduling, parallelizeAtomicReduction) {
-  Tensor<double> A("A", {8}, {Sparse});
-  Tensor<double> B("B", {8}, {Dense});
+  Tensor<double> A("A", {8}, Format({Sparse}));
+  Tensor<double> B("B", {8}, Format({Dense}));
   Tensor<double> C("C");
 
   for (int i = 0; i < 8; i++) {
@@ -365,8 +365,8 @@ TEST(scheduling, parallelizeAtomicReduction) {
 }
 
 TEST(scheduling, parallelizeTemporaryReduction) {
-  Tensor<double> A("A", {8}, {Sparse});
-  Tensor<double> B("B", {8}, {Dense});
+  Tensor<double> A("A", {8}, Format({Sparse}));
+  Tensor<double> B("B", {8}, Format({Dense}));
   Tensor<double> C("C");
 
   for (int i = 0; i < 8; i++) {
@@ -412,9 +412,9 @@ TEST(scheduling, parallelizeTemporaryReduction) {
 }
 
 TEST(scheduling, multilevel_tiling) {
-  Tensor<double> A("A", {8}, {Sparse});
-  Tensor<double> B("B", {8}, {Sparse});
-  Tensor<double> C("C", {8}, {Dense});
+  Tensor<double> A("A", {8}, Format({Sparse}));
+  Tensor<double> B("B", {8}, Format({Sparse}));
+  Tensor<double> C("C", {8}, Format({Dense}));
 
   for (int i = 0; i < 8; i++) {
     A.insert({i}, (double) i);
@@ -426,7 +426,7 @@ TEST(scheduling, multilevel_tiling) {
   A.pack();
   B.pack();
 
-  Tensor<double> expected("expected", {8}, {Dense});
+  Tensor<double> expected("expected", {8}, Format({Dense}));
   expected(i) = A(i) * B(i);
   expected.compile();
   expected.assemble();
@@ -474,7 +474,7 @@ TEST(scheduling, multilevel_tiling) {
 }
 
 TEST(scheduling, pos_noop) {
-  Tensor<double> A("A", {8}, {Sparse});
+  Tensor<double> A("A", {8}, Format({Sparse}));
   Tensor<double> C("C");
 
   for (int i = 0; i < 8; i++) {
@@ -508,9 +508,9 @@ TEST(scheduling, pos_noop) {
 }
 
 TEST(scheduling, pos_mul_dense) {
-  Tensor<double> A("A", {8}, {Sparse});
-  Tensor<double> B("B", {8}, {Dense});
-  Tensor<double> C("C", {8}, {Dense});
+  Tensor<double> A("A", {8}, Format({Sparse}));
+  Tensor<double> B("B", {8}, Format({Dense}));
+  Tensor<double> C("C", {8}, Format({Dense}));
 
   for (int i = 0; i < 8; i++) {
     if (i % 2 == 0) {
@@ -536,7 +536,7 @@ TEST(scheduling, pos_mul_dense) {
   C.assemble();
   C.compute();
 
-  Tensor<double> expected("expected", {8}, {Dense});
+  Tensor<double> expected("expected", {8}, Format({Dense}));
   expected(i) = A(i) * B(i);
   expected.compile();
   expected.assemble();
@@ -545,9 +545,9 @@ TEST(scheduling, pos_mul_dense) {
 }
 
 TEST(scheduling, pos_mul_sparse) {
-  Tensor<double> A("A", {8}, {Sparse});
-  Tensor<double> B("B", {8}, {Sparse});
-  Tensor<double> C("C", {8}, {Dense});
+  Tensor<double> A("A", {8}, Format({Sparse}));
+  Tensor<double> B("B", {8}, Format({Sparse}));
+  Tensor<double> C("C", {8}, Format({Dense}));
 
   for (int i = 0; i < 8; i++) {
     if (i % 2 == 0) {
@@ -575,7 +575,7 @@ TEST(scheduling, pos_mul_sparse) {
   C.assemble();
   C.compute();
 
-  Tensor<double> expected("expected", {8}, {Dense});
+  Tensor<double> expected("expected", {8}, Format({Dense}));
   expected(i) = A(i) * B(i);
   expected.compile();
   expected.assemble();
@@ -584,9 +584,9 @@ TEST(scheduling, pos_mul_sparse) {
 }
 
 TEST(scheduling, pos_mul_dense_split) {
-  Tensor<double> A("A", {8}, {Sparse});
-  Tensor<double> B("B", {8}, {Dense});
-  Tensor<double> C("C", {8}, {Dense});
+  Tensor<double> A("A", {8}, Format({Sparse}));
+  Tensor<double> B("B", {8}, Format({Dense}));
+  Tensor<double> C("C", {8}, Format({Dense}));
 
   for (int i = 0; i < 8; i++) {
     if (i % 2 == 0) {
@@ -612,7 +612,7 @@ TEST(scheduling, pos_mul_dense_split) {
   C.assemble();
   C.compute();
 
-  Tensor<double> expected("expected", {8}, {Dense});
+  Tensor<double> expected("expected", {8}, Format({Dense}));
   expected(i) = A(i) * B(i);
   expected.compile();
   expected.assemble();
@@ -621,9 +621,9 @@ TEST(scheduling, pos_mul_dense_split) {
 }
 
 TEST(scheduling, pos_tile_coord_and_pos) {
-  Tensor<double> A("A", {8}, {Sparse});
-  Tensor<double> B("B", {8}, {Dense});
-  Tensor<double> C("C", {8}, {Dense});
+  Tensor<double> A("A", {8}, Format({Sparse}));
+  Tensor<double> B("B", {8}, Format({Dense}));
+  Tensor<double> C("C", {8}, Format({Dense}));
 
   for (int i = 0; i < 8; i++) {
     if (i % 2 == 0) {
@@ -650,7 +650,7 @@ TEST(scheduling, pos_tile_coord_and_pos) {
   C.assemble();
   C.compute();
 
-  Tensor<double> expected("expected", {8}, {Dense});
+  Tensor<double> expected("expected", {8}, Format({Dense}));
   expected(i) = A(i) * B(i);
   expected.compile();
   expected.assemble();
@@ -671,8 +671,8 @@ TEST(scheduling, spmv_warp_per_row) {
   const int iSIZE = 1024;
   const int jSIZE = 1024;
   Tensor<double> A("A", {iSIZE, jSIZE}, CSR);
-  Tensor<double> x("x", {jSIZE}, {Dense});
-  Tensor<double> y("y", {iSIZE}, {Dense});
+  Tensor<double> x("x", {jSIZE}, Format({Dense}));
+  Tensor<double> y("y", {iSIZE}, Format({Dense}));
 
   for (int i = 0; i < iSIZE; i++) {
     for (int j = 0; j < jSIZE; j++) {
@@ -709,7 +709,7 @@ TEST(scheduling, spmv_warp_per_row) {
   y.assemble();
   y.compute();
 
-  Tensor<double> expected("expected", {iSIZE}, {Dense});
+  Tensor<double> expected("expected", {iSIZE}, Format({Dense}));
   expected(i) = A(i, j) * x(j);
   stmt = expected.getAssignment().concretize();
   expected.compile(stmt);
@@ -719,8 +719,8 @@ TEST(scheduling, spmv_warp_per_row) {
 }
 
 TEST(scheduling, dense_pos_error) {
-  Tensor<double> x("x", {8}, {Dense});
-  Tensor<double> y("y", {8}, {Dense});
+  Tensor<double> x("x", {8}, Format({Dense}));
+  Tensor<double> y("y", {8}, Format({Dense}));
   IndexVar i("i"), ipos("ipos");
   y(i) = x(i);
 
@@ -733,8 +733,8 @@ TEST(scheduling, dense_pos_error) {
 }
 
 TEST(scheduling, pos_var_not_in_access) {
-  Tensor<double> x("x", {8}, {Dense});
-  Tensor<double> y("y", {8}, {Dense});
+  Tensor<double> x("x", {8}, Format({Dense}));
+  Tensor<double> y("y", {8}, Format({Dense}));
   IndexVar i("i"), ipos("ipos"), j("j");
   y(i) = x(i);
 
@@ -747,8 +747,8 @@ TEST(scheduling, pos_var_not_in_access) {
 }
 
 TEST(scheduling, pos_wrong_access) {
-  Tensor<double> x("x", {8}, {Dense});
-  Tensor<double> y("y", {8}, {Dense});
+  Tensor<double> x("x", {8}, Format({Dense}));
+  Tensor<double> y("y", {8}, Format({Dense}));
   IndexVar i("i"), ipos("ipos"), j("j");
   y(i) = x(i);
 
@@ -773,8 +773,8 @@ TEST(scheduling_eval_test, spmv_fuse) {
   int NNZ_PER_WARP = NNZ_PER_THREAD * WARP_SIZE;
   int NNZ_PER_TB = NNZ_PER_THREAD * BLOCK_SIZE;
   Tensor<double> A("A", {NUM_I, NUM_J}, CSR);
-  Tensor<double> x("x", {NUM_J}, {Dense});
-  Tensor<double> y("y", {NUM_I}, {Dense});
+  Tensor<double> x("x", {NUM_J}, Format({Dense}));
+  Tensor<double> y("y", {NUM_I}, Format({Dense}));
 
   srand(59393);
   for (int i = 0; i < NUM_I; i++) {
@@ -816,7 +816,7 @@ TEST(scheduling_eval_test, spmv_fuse) {
   y.assemble();
   y.compute();
 
-  Tensor<double> expected("expected", {NUM_I}, {Dense});
+  Tensor<double> expected("expected", {NUM_I}, Format({Dense}));
   expected(i) = A(i, j) * x(j);
   expected.compile();
   expected.assemble();


### PR DESCRIPTION
Fixes #274

This fixes two classes of build failure that happen on Ubuntu 16.04.

1.  gcc 5.4.0 fails to call the createAccessIterators member function properly
2.  gcc 5.4.0 can't decide between two constructors: Tensor(name, shape, Format) and Tensor(name, shape, ModeFormat)

Taco builds successfully on Ubuntu 16.04 with this patch.

I tested with -DOPENMP=ON and -DPYTHON=ON.   Issue #316 happened; otherwise all tests passed.  I did not test CUDA.
