### PR TITLE
Use exceptions for error reporting in all cases

### DIFF
--- a/include/taco/error.h
+++ b/include/taco/error.h
@@ -57,14 +57,8 @@ struct ErrorReport {
     if (condition) {
       return;
     }
-#ifdef PYTHON
     explodeWithException();
-#else
-    explode();
-#endif
   }
-
-  void explode();
 
   void explodeWithException();
 };

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -59,13 +59,6 @@ ErrorReport::ErrorReport(const char *file, const char *func, int line,
   (*msg) << " ";
 }
 
-void ErrorReport::explode() {
-  std::cerr << msg->str() << endl;
-  delete msg;
-  if (warning) return;
-  abort();
-}
-
 void ErrorReport::explodeWithException() {
   TacoException e = TacoException(msg->str());
   delete msg;

--- a/test/tests-error.cpp
+++ b/test/tests-error.cpp
@@ -11,64 +11,38 @@ const IndexVar i("i"), j("j"), k("k");
 TEST(error, expr_dimension_mismatch_freevar) {
   Tensor<double> a({3}, Format({Sparse}, {0}));
   Tensor<double> b({5}, Format({Sparse}, {0}));
-#ifdef PYTHON
   ASSERT_THROW(a(i) = b(i), taco::TacoException);
-#else
-  ASSERT_DEATH(a(i) = b(i), error::expr_dimension_mismatch);
-#endif
 }
 
 TEST(error, expr_dimension_mismatch_sumvar) {
   Tensor<double> a({5}, Format({Sparse}, {0}));
   Tensor<double> B({5,4}, Format({Sparse,Sparse}, {0,1}));
   Tensor<double> c({3}, Format({Sparse}, {0}));
-#ifdef PYTHON
   ASSERT_THROW(a(i) = B(i,j)*c(j), taco::TacoException);
-#else
-  ASSERT_DEATH(a(i) = B(i,j)*c(j), error::expr_dimension_mismatch);
-#endif
 }
 
 TEST(error, compile_without_expr) {
   Tensor<double> a({5}, Sparse);
-#ifdef PYTHON
   ASSERT_THROW(a.compile(), taco::TacoException);
-#else
-  ASSERT_DEATH(a.compile(), error::compile_without_expr);
-#endif
 }
 
 TEST(error, compile_tensor_name_collision) {
   Tensor<double> a("a", {5}, Sparse);
   Tensor<double> b("a", {5}, Sparse); // name should be "b"
   a(i) = b(i);
-#ifdef PYTHON
   ASSERT_THROW(a.compile(), taco::TacoException);
-#else
-  ASSERT_DEATH(a.compile(), error::compile_tensor_name_collision);
-#endif
 }
 
 TEST(error, assemble_without_compile) {
   Tensor<double> a({5}, Sparse);
   Tensor<double> b({5}, Sparse);
   a(i) = b(i);
-#ifdef PYTHON
   ASSERT_THROW(a.assemble(), taco::TacoException);
-#else
-  ASSERT_DEATH(a.assemble(), error::assemble_without_compile);
-#endif
-
 }
 
 TEST(error, compute_without_compile) {
   Tensor<double> a({5}, Sparse);
   Tensor<double> b({5}, Sparse);
   a(i) = b(i);
-#ifdef PYTHON
   ASSERT_THROW(a.compute(), taco::TacoException);
-#else
-  ASSERT_DEATH(a.compute(), error::compute_without_compile);
-#endif
-
 }

--- a/test/tests-scheduling.cpp
+++ b/test/tests-scheduling.cpp
@@ -725,11 +725,7 @@ TEST(scheduling, dense_pos_error) {
   y(i) = x(i);
 
   IndexStmt stmt = y.getAssignment().concretize();
-#ifdef PYTHON
   ASSERT_THROW(stmt.pos(i, ipos, x(i)), taco::TacoException);
-#else
-  ASSERT_DEATH(stmt.pos(i, ipos, x(i)), "Pos transformation is not valid for dense formats, the coordinate space should be transformed instead");
-#endif
 }
 
 TEST(scheduling, pos_var_not_in_access) {
@@ -739,11 +735,7 @@ TEST(scheduling, pos_var_not_in_access) {
   y(i) = x(i);
 
   IndexStmt stmt = y.getAssignment().concretize();
-#ifdef PYTHON
   ASSERT_THROW(stmt.pos(j, ipos, x(i)), taco::TacoException);
-#else
-  ASSERT_DEATH(stmt.pos(j, ipos, x(i)), "Index variable j does not appear in access: x[(]i[)]");
-#endif
 }
 
 TEST(scheduling, pos_wrong_access) {
@@ -753,13 +745,8 @@ TEST(scheduling, pos_wrong_access) {
   y(i) = x(i);
 
   IndexStmt stmt = y.getAssignment().concretize();
-#ifdef PYTHON
   ASSERT_THROW(stmt.pos(i, ipos, x(j)), taco::TacoException);
   ASSERT_THROW(stmt.pos(i, ipos, y(i)), taco::TacoException);
-#else
-  ASSERT_DEATH(stmt.pos(i, ipos, x(j)), "Access: x[(]j[)] does not appear in index statement as an argument");
-  ASSERT_DEATH(stmt.pos(i, ipos, y(i)), "Access: y[(]i[)] does not appear in index statement as an argument");
-#endif
 }
 
 TEST(scheduling_eval_test, spmv_fuse) {


### PR DESCRIPTION
Previously, exceptions were used only when the Python bindings were enabled.  This meant that C++ applications could only handle errors gracefully when the Python bindings were enabled.

Change it to consistently use exceptions in all cases.