### PR TITLE
Silence a warning about cmake policy CMP0054.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
 project(taco)
 option(CUDA "Build for NVIDIA GPU (CUDA must be preinstalled)" OFF)
 option(PYTHON "Build TACO for python environment" OFF)


### PR DESCRIPTION
Building Taco with CUDA support causes cmake to warning, with cmake version 3.12.0 and later.  Here's what it looks like:

```
$ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPYTHON=ON -DOPENMP=ON -DCUDA=ON ../git
CMake Warning (dev) at /usr/share/cmake-3.18/Modules/CMakeDetermineCompilerId.cmake:72 (if):
  Policy CMP0054 is not set: Only interpret if() arguments as variables or
  keywords when unquoted.  Run "cmake --help-policy CMP0054" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  Quoted variables like "CUDA" will no longer be dereferenced when the policy
  is set to NEW.  Since the policy is not set the OLD behavior will be used.
Call Stack (most recent call first):
  /usr/share/cmake-3.18/Modules/CMakeDetermineCCompiler.cmake:116 (CMAKE_DETERMINE_COMPILER_ID)
  CMakeLists.txt:2 (project)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- The C compiler identification is GNU 10.2.1
-- The CXX compiler identification is GNU 10.2.1
[snip]
```

This patch silences the warning, without breaking older versions of cmake.  (I tested all the way back to 2.8.12)
