### PR TITLE
lower,index_notation: fix compilation warnings

### DIFF
--- a/src/index_notation/provenance_graph.cpp
+++ b/src/index_notation/provenance_graph.cpp
@@ -1068,7 +1068,7 @@ std::vector<ir::Expr> ProvenanceGraph::deriveIterBounds(IndexVar indexVar, std::
 
   std::map<IndexVar, std::vector<ir::Expr>> parentIterBounds;
   std::map<IndexVar, std::vector<ir::Expr>> parentCoordBounds;
-  for (const IndexVar parent : getParents(indexVar)) {
+  for (const IndexVar& parent : getParents(indexVar)) {
     parentIterBounds[parent] = deriveIterBounds(parent, derivedVarOrder, underivedBounds, variableNames, iterators);
     vector<IndexVar> underivedParentAncestors = getUnderivedAncestors(parent);
     // TODO: this is okay for now because we don't need parentCoordBounds for fused taco_iassert(underivedParentAncestors.size() == 1);
@@ -1088,7 +1088,7 @@ bool ProvenanceGraph::hasCoordBounds(IndexVar indexVar) const {
 bool ProvenanceGraph::isPosVariable(taco::IndexVar indexVar) const {
   if (isUnderived(indexVar)) return false;
   if (parentRelMap.at(indexVar).getRelType() == POS) return true;
-  for (const IndexVar parent : getParents(indexVar)) {
+  for (const IndexVar& parent : getParents(indexVar)) {
     if (isPosVariable(parent)) {
       return true;
     }
@@ -1104,7 +1104,7 @@ bool ProvenanceGraph::isPosOfAccess(IndexVar indexVar, Access access) const {
   else if (parentRelMap.at(indexVar).getRelType() == FUSE) {
     return false; // lose pos of access status through fuse
   }
-  for (const IndexVar parent : getParents(indexVar)) {
+  for (const IndexVar& parent : getParents(indexVar)) {
     if (isPosOfAccess(parent, access)) {
       return true;
     }

--- a/src/lower/lowerer_impl.cpp
+++ b/src/lower/lowerer_impl.cpp
@@ -140,7 +140,7 @@ LowererImpl::lower(IndexStmt stmt, string name,
 
   provGraph = ProvenanceGraph(stmt);
 
-  for (const IndexVar indexVar : provGraph.getAllIndexVars()) {
+  for (const IndexVar& indexVar : provGraph.getAllIndexVars()) {
     if (iterators.modeIterators().count(indexVar)) {
       indexVarToExprMap.insert({indexVar, iterators.modeIterators()[indexVar].getIteratorVar()});
     }


### PR DESCRIPTION
Fix a few compilation warnings caused by taking copies of loop variables
instead of references.