### PR TITLE
Clear the needsCompile flag in tensor.compileSource()

### DIFF
--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -830,6 +830,7 @@ void TensorBase::compileSource(std::string source) {
   }
   content->module->setSource(source + "\n" + ss.str());
   content->module->compile();
+  setNeedsCompile(false);
 }
 
 TensorBase::HelperFuncsCache TensorBase::helperFunctions;


### PR DESCRIPTION
This fixes part of #366.  (The segfault on bad tensor names will be fixed separately.)

When data files are provided for all inputs, the `taco` command-line tool runs in "benchmark" mode, executing the generated code in-place.

This didn't quite work.  tensor.compileSource() didn't clear the needsCompile flag, causing the `tensor.assemble` step to complain.