### PR TITLE
Add an error message for invalid input tensor names.

### DIFF
--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -32,6 +32,9 @@ struct TensorStorage::Content {
     int order = (int)dimensions.size();
 
     taco_iassert(order <= INT_MAX && componentType.getNumBits() <= INT_MAX);
+    taco_uassert(order == format.getOrder()) <<
+        "The number of format mode types (" << format.getOrder() << ") " <<
+        "must match the tensor order (" << dimensions.size() << ").";
     vector<int32_t> dimensionsInt32(order);
     vector<int32_t> modeOrdering(order);
     vector<taco_mode_t> modeTypes(order);

--- a/tools/taco.cpp
+++ b/tools/taco.cpp
@@ -839,8 +839,16 @@ int main(int argc, char* argv[]) {
     printCompute = true;
   }
 
-  // Load tensors
+  // pre-parse expression, to determine existence and order of loaded tensors
   map<string,TensorBase> loadedTensors;
+  TensorBase temp_tensor;
+  parser::Parser temp_parser(exprStr, formats, dataTypes, tensorsDimensions, loadedTensors, 42);
+  try {
+    temp_parser.parse();
+    temp_tensor = temp_parser.getResultTensor();
+  } catch (parser::ParseError& e) {
+    return reportError(e.getMessage(), 6);
+  }
 
   // Load tensors
   for (auto& tensorNames : inputFilenames) {
@@ -851,7 +859,32 @@ int main(int argc, char* argv[]) {
       return reportError("Loaded tensors can only be type double", 7);
     }
 
-    Format format = util::contains(formats, name) ? formats.at(name) : Dense;
+    // make sure the tensor exists in the expression (and stash its order)
+    int found_tensor_order;
+    bool found = false;
+    for (auto a : getArgumentAccesses(temp_tensor.getAssignment().concretize())) {
+      if (a.getTensorVar().getName() == name) {
+        found_tensor_order = a.getIndexVars().size();
+        found = true;
+        break;
+      }
+    }
+    if(found == false) {
+      return reportError("Cannot load '" + filename + "': no tensor '" + name + "' found in expression", 8);
+    }
+
+    Format format;
+    if(util::contains(formats, name)) {
+      // format of this tensor is specified on the command line, use it
+      format = formats.at(name);
+    } else {
+      // create a dense default format of the correct order
+      std::vector<ModeFormat> modes;
+      for(int i = 0; i < found_tensor_order; i++) {
+        modes.push_back(Dense);
+      }
+      format = Format({ModeFormatPack(modes)});
+    }
     TensorBase tensor;
     TOOL_BENCHMARK_TIMER(tensor = read(filename,format,false),
                          name+" file read:", timevalue);


### PR DESCRIPTION
This fixes a few things related to the `-i` (input file) parameter of the command line tool.

Fixes:

1. The `TensorBase::TensorBase()` constructor sanity checks the number of format mode types, but this sanity check happens too late: `TensorStorage::Content()` segfaults before the check happens.
2. CLI tool doesn't reject input files with tensor names not mentioned in the expression
3. CLI tool doesn't create default formats of the correct sizes when loading tensors

These are fixed by:

1. copying the check into `TensorStorage::Content`.
2. pre-parsing the expression and making sure the tensor name is in there.
3. creating a `ModeFormat` vector of the right length, rather than the previous default (`Dense`).

There isn't a good framework in place to test the command-line tool, so I tested this by hand.  Details below.