### PR TITLE
Fix warnings in python bindings

### DIFF
--- a/python_bindings/pybind11/include/pybind11/detail/common.h
+++ b/python_bindings/pybind11/include/pybind11/detail/common.h
@@ -648,7 +648,7 @@ inline void ignore_unused(const int *) { }
 #define PYBIND11_EXPAND_SIDE_EFFECTS(PATTERN) (((PATTERN), void()), ...)
 #else
 using expand_side_effects = bool[];
-#define PYBIND11_EXPAND_SIDE_EFFECTS(PATTERN) pybind11::detail::expand_side_effects{ ((PATTERN), void(), false)..., false }
+#define PYBIND11_EXPAND_SIDE_EFFECTS(PATTERN) (void)pybind11::detail::expand_side_effects{ ((PATTERN), void(), false)..., false }
 #endif
 
 NAMESPACE_END(detail)

--- a/python_bindings/pybind11/include/pybind11/detail/internals.h
+++ b/python_bindings/pybind11/include/pybind11/detail/internals.h
@@ -197,7 +197,10 @@ PYBIND11_NOINLINE inline internals &get_internals() {
         auto *&internals_ptr = *internals_pp;
         internals_ptr = new internals();
 #if defined(WITH_THREAD)
-        PyEval_InitThreads();
+
+#       if PY_VERSION_HEX < 0x03090000
+            PyEval_InitThreads();
+#       endif
         PyThreadState *tstate = PyThreadState_Get();
         #if PY_VERSION_HEX >= 0x03070000
             internals_ptr->tstate = PyThread_tss_alloc();


### PR DESCRIPTION
Fix two warnings in the python bindings.

`.../python_bindings/pybind11/include/pybind11/detail/internals.h:200:28: warning: ‘void PyEval_InitThreads()’ is deprecated [-Wdeprecated-declarations]`

This warning happens when building with python 3.9+.

`.../python_bindings/pybind11/include/pybind11/pybind11.h:1078:9: warning: expression result unused [-Wunused-value]`

This warning happens when building with clang 10+.

Both of these fixes are already present in later versions of pybind11:

https://github.com/pybind/pybind11/commit/fe1392d0895e7104aafe60f8bda17cd568d025e5
https://github.com/pybind/pybind11/commit/ae2ee2a4a51914cf78deb5c253a3b03cbb53ce72
