### PR TITLE
tensor,codegen: fix a bug where kernel cache could be modified

### DIFF
--- a/include/taco/codegen/module.h
+++ b/include/taco/codegen/module.h
@@ -21,8 +21,6 @@ public:
     setJITTmpdir();
   }
 
-  void reset();
-
   /// Compile the source into a library, returning its full path
   std::string compile();
   

--- a/src/codegen/module.cpp
+++ b/src/codegen/module.cpp
@@ -32,15 +32,6 @@ void Module::setJITLibname() {
     libname[i] = chars[rand() % chars.length()];
 }
 
-void Module::reset() {
-  funcs.clear();
-  moduleFromUserSource = false;
-  header.str("");
-  header.clear();
-  source.str("");
-  source.clear();
-}
-
 void Module::addFunction(Stmt func) {
   funcs.push_back(func);
 }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -595,7 +595,10 @@ void TensorBase::compile(taco::IndexStmt stmt, bool assembleWhileCompute) {
 
   content->assembleFunc = lower(stmtToCompile, "assemble", true, false);
   content->computeFunc = lower(stmtToCompile, "compute",  assembleWhileCompute, true);
-  content->module->reset();
+  // If we have to recompile the kernel, we need to create a new Module. Since
+  // the module we are holding on to could have been retrieved from the cache,
+  // we can't modify it.
+  content->module = make_shared<Module>();
   content->module->addFunction(content->assembleFunc);
   content->module->addFunction(content->computeFunc);
   content->module->compile();

--- a/test/tests-tensor.cpp
+++ b/test/tests-tensor.cpp
@@ -479,3 +479,18 @@ TEST(tensor, recompile) {
   ASSERT_TRUE(c.needsCompile());
   ASSERT_EQ(c.begin()->second, 42.0);
 }
+
+TEST(tensor, cache) {
+  auto dim = 2;
+  IndexVar i("i"), j("j");
+  Tensor<int> a("a", {dim, dim}, {Dense, Dense});
+  Tensor<int> b("b", {dim, dim}, {Dense, Dense});
+  Tensor<int> c("c", {dim, dim}, {Dense, Dense});
+  // Add a computation to the cache.
+  c(i, j) = a(i, j); c.evaluate();
+  // Add a new computation to the cache.
+  c(i, j) = a(i, j) + b(i, j); c.evaluate();
+  // The addition of the new computation shouldn't have affected the cache's
+  // ability to answer a request for the first query.
+  c(i, j) = a(i, j); c.evaluate();
+}


### PR DESCRIPTION
This commit fixes a bug where upon recompilation of an index statement,
entries in the kernel cache could be inadvertently modified, leading to
confusing segfaults.

An example of the bug is included in the added test, where the second
call to `c(i, j) = a(i, j)` would hit the cache, but then find a module
that had code that corresponded to `c(i, j) = a(i, j) + b(i, j)`.