### PR TITLE
*: add the ability to stride window access

### DIFF
--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -240,6 +240,12 @@ public:
   int getWindowLowerBound(int mode) const;
   int getWindowUpperBound(int mode) const;
 
+  /// getWindowDimension returns the dimension size of a window.
+  int getWindowDimension(int mode) const;
+
+  /// getStride returns the stride of a window.
+  int getStride(int mode) const;
+
   /// Assign the result of an expression to a left-hand-side tensor access.
   /// ```
   /// a(i) = b(i) * c(i);
@@ -851,7 +857,7 @@ public:
 /// before IndexVar so that IndexVar can return objects of type WindowedIndexVar.
 class WindowedIndexVar : public util::Comparable<WindowedIndexVar>, public IndexVarInterface {
 public:
-  WindowedIndexVar(IndexVar base, int lo = -1, int hi = -1);
+  WindowedIndexVar(IndexVar base, int lo = -1, int hi = -1, int stride = 1);
   ~WindowedIndexVar() = default;
 
   /// getIndexVar returns the underlying IndexVar.
@@ -861,6 +867,11 @@ public:
   /// this index variable.
   int getLowerBound() const;
   int getUpperBound() const;
+  /// getStride returns the stride to access the window by.
+  int getStride() const;
+
+  /// getWindowSize returns the number of elements in the window.
+  int getWindowSize() const;
 
 private:
   struct Content;
@@ -882,7 +893,7 @@ public:
   friend bool operator<(const IndexVar&, const IndexVar&);
 
   /// Indexing into an IndexVar returns a window into it.
-  WindowedIndexVar operator()(int lo, int hi);
+  WindowedIndexVar operator()(int lo, int hi, int stride = 1);
 
 private:
   struct Content;
@@ -897,6 +908,7 @@ struct WindowedIndexVar::Content {
   IndexVar base;
   int lo;
   int hi;
+  int stride;
 };
 
 std::ostream& operator<<(std::ostream&, const std::shared_ptr<IndexVarInterface>&);

--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -1,6 +1,7 @@
 #ifndef TACO_INDEX_NOTATION_H
 #define TACO_INDEX_NOTATION_H
 
+#include <functional>
 #include <ostream>
 #include <string>
 #include <memory>
@@ -30,6 +31,7 @@ class Format;
 class Schedule;
 
 class IndexVar;
+class WindowedIndexVar;
 class TensorVar;
 
 class IndexExpr;
@@ -227,6 +229,16 @@ public:
 
   /// Returns the index variables used to index into the Access's TensorVar.
   const std::vector<IndexVar>& getIndexVars() const;
+
+  /// hasWindowedModes returns true if any accessed modes are windowed.
+  bool hasWindowedModes() const;
+
+  /// Returns whether or not the input mode (0-indexed) is windowed.
+  bool isModeWindowed(int mode) const;
+
+  /// Return the {lower,upper} bound of the window on the input mode (0-indexed).
+  int getWindowLowerBound(int mode) const;
+  int getWindowUpperBound(int mode) const;
 
   /// Assign the result of an expression to a left-hand-side tensor access.
   /// ```
@@ -800,11 +812,67 @@ public:
 /// Create a multi index statement.
 Multi multi(IndexStmt stmt1, IndexStmt stmt2);
 
+/// IndexVarInterface is a marker superclass for IndexVar-like objects.
+/// It is intended to be used in situations where many IndexVar-like objects
+/// must be stored together, like when building an Access AST node where some
+/// of the access variables are windowed. Use cases for IndexVarInterface
+/// will inspect the underlying type of the IndexVarInterface. For sake of
+/// completeness, the current implementers of IndexVarInterface are:
+/// * IndexVar
+/// * WindowedIndexVar
+/// If this set changes, make sure to update the match function.
+class IndexVarInterface {
+public:
+  virtual ~IndexVarInterface() = default;
+
+  /// match performs a dynamic case analysis of the implementers of IndexVarInterface
+  /// as a utility for handling the different values within. It mimics the dynamic
+  /// type assertion of Go.
+  static void match(
+      std::shared_ptr<IndexVarInterface> ptr,
+      std::function<void(std::shared_ptr<IndexVar>)> ivarFunc,
+      std::function<void(std::shared_ptr<WindowedIndexVar>)> wvarFunc
+  ) {
+    auto iptr = std::dynamic_pointer_cast<IndexVar>(ptr);
+    auto wptr = std::dynamic_pointer_cast<WindowedIndexVar>(ptr);
+    if (iptr != nullptr) {
+      ivarFunc(iptr);
+    } else if (wptr != nullptr) {
+      wvarFunc(wptr);
+    } else {
+      taco_iassert("IndexVarInterface was not IndexVar or WindowedIndexVar");
+    }
+  }
+};
+
+/// WindowedIndexVar represents an IndexVar that has been windowed. For example,
+///   A(i) = B(i(2, 4))
+/// In this case, i(2, 4) is a WindowedIndexVar. WindowedIndexVar is defined
+/// before IndexVar so that IndexVar can return objects of type WindowedIndexVar.
+class WindowedIndexVar : public util::Comparable<WindowedIndexVar>, public IndexVarInterface {
+public:
+  WindowedIndexVar(IndexVar base, int lo = -1, int hi = -1);
+  ~WindowedIndexVar() = default;
+
+  /// getIndexVar returns the underlying IndexVar.
+  IndexVar getIndexVar() const;
+
+  /// get{Lower,Upper}Bound returns the {lower,upper} bound of the window of
+  /// this index variable.
+  int getLowerBound() const;
+  int getUpperBound() const;
+
+private:
+  struct Content;
+  std::shared_ptr<Content> content;
+};
+
 /// Index variables are used to index into tensors in index expressions, and
 /// they represent iteration over the tensor modes they index into.
-class IndexVar : public util::Comparable<IndexVar> {
+class IndexVar : public util::Comparable<IndexVar>, public IndexVarInterface {
 public:
   IndexVar();
+  ~IndexVar() = default;
   IndexVar(const std::string& name);
 
   /// Returns the name of the index variable.
@@ -813,6 +881,8 @@ public:
   friend bool operator==(const IndexVar&, const IndexVar&);
   friend bool operator<(const IndexVar&, const IndexVar&);
 
+  /// Indexing into an IndexVar returns a window into it.
+  WindowedIndexVar operator()(int lo, int hi);
 
 private:
   struct Content;
@@ -823,7 +893,15 @@ struct IndexVar::Content {
   std::string name;
 };
 
+struct WindowedIndexVar::Content {
+  IndexVar base;
+  int lo;
+  int hi;
+};
+
+std::ostream& operator<<(std::ostream&, const std::shared_ptr<IndexVarInterface>&);
 std::ostream& operator<<(std::ostream&, const IndexVar&);
+std::ostream& operator<<(std::ostream&, const WindowedIndexVar&);
 
 /// A suchthat statement provides a set of IndexVarRel that constrain
 /// the iteration space for the child concrete index notation

--- a/include/taco/index_notation/index_notation_nodes.h
+++ b/include/taco/index_notation/index_notation_nodes.h
@@ -26,6 +26,23 @@ struct AccessNode : public IndexExprNode {
 
   TensorVar tensorVar;
   std::vector<IndexVar> indexVars;
+
+  // An AccessNode carries the windowing information for an IndexVar + TensorVar
+  // combination. windowedModes contains the lower and upper bounds of each
+  // windowed mode (0-indexed).
+  struct Window {
+    int lo;
+    int hi;
+    friend bool operator==(const Window& a, const Window& b) {
+      return a.lo == b.lo && a.hi == b.hi;
+    }
+  };
+  std::map<int, Window> windowedModes;
+
+protected:
+  /// Initialize an AccessNode with just a TensorVar. If this constructor is used,
+  /// then indexVars must be set afterwards.
+  explicit AccessNode(TensorVar tensorVar) : IndexExprNode(tensorVar.getType().getDataType()), tensorVar(tensorVar) {}
 };
 
 struct LiteralNode : public IndexExprNode {

--- a/include/taco/index_notation/index_notation_nodes.h
+++ b/include/taco/index_notation/index_notation_nodes.h
@@ -33,8 +33,9 @@ struct AccessNode : public IndexExprNode {
   struct Window {
     int lo;
     int hi;
+    int stride;
     friend bool operator==(const Window& a, const Window& b) {
-      return a.lo == b.lo && a.hi == b.hi;
+      return a.lo == b.lo && a.hi == b.hi && a.stride == b.stride;
     }
   };
   std::map<int, Window> windowedModes;

--- a/include/taco/lower/iterator.h
+++ b/include/taco/lower/iterator.h
@@ -159,6 +159,17 @@ public:
   /// Returns true if the iterator is defined, false otherwise.
   bool defined() const;
 
+  /// Methods for querying and operating on windowed tensor modes.
+
+  /// isWindowed returns true if this iterator is operating over a window
+  /// of a tensor mode.
+  bool isWindowed() const;
+
+  /// getWindow{Lower,Upper}Bound return the {Lower,Upper} bound of the
+  /// window that this iterator operates over.
+  ir::Expr getWindowLowerBound() const;
+  ir::Expr getWindowUpperBound() const;
+
   friend bool operator==(const Iterator&, const Iterator&);
   friend bool operator<(const Iterator&, const Iterator&);
   friend std::ostream& operator<<(std::ostream&, const Iterator&);
@@ -169,6 +180,10 @@ private:
 
   Iterator(std::shared_ptr<Content> content);
   void setChild(const Iterator& iterator) const;
+
+  friend class Iterators;
+  /// setWindowBounds sets the window bounds of this iterator.
+  void setWindowBounds(ir::Expr lo, ir::Expr hi);
 };
 
 /**

--- a/include/taco/lower/iterator.h
+++ b/include/taco/lower/iterator.h
@@ -165,10 +165,22 @@ public:
   /// of a tensor mode.
   bool isWindowed() const;
 
+  /// isStrided returns true if this iterator has a stride != 1. Currently
+  /// only windowed iterators can have strides.
+  bool isStrided() const;
+
   /// getWindow{Lower,Upper}Bound return the {Lower,Upper} bound of the
   /// window that this iterator operates over.
   ir::Expr getWindowLowerBound() const;
   ir::Expr getWindowUpperBound() const;
+
+  /// getStride returns an Expr holding the stride that this iterator is
+  /// configured with.
+  ir::Expr getStride() const;
+
+  /// getWindowVar returns a Var specific to thw window that this iterator
+  /// is operating over. It can be used as temporary storage.
+  ir::Expr getWindowVar() const;
 
   friend bool operator==(const Iterator&, const Iterator&);
   friend bool operator<(const Iterator&, const Iterator&);
@@ -183,7 +195,7 @@ private:
 
   friend class Iterators;
   /// setWindowBounds sets the window bounds of this iterator.
-  void setWindowBounds(ir::Expr lo, ir::Expr hi);
+  void setWindowBounds(ir::Expr lo, ir::Expr hi, ir::Expr stride);
 };
 
 /**

--- a/include/taco/lower/lowerer_impl.h
+++ b/include/taco/lower/lowerer_impl.h
@@ -399,6 +399,12 @@ protected:
   // range of [lo, hi).
   ir::Expr projectCanonicalSpaceToWindowedPosition(Iterator iterator, ir::Expr expr);
 
+  /// strideBoundsGuard inserts a guard against accessing values from an
+  /// iterator that don't fit in the stride that the iterator is configured
+  /// with. It takes a boolean incrementPosVars to control whether the outer
+  /// loop iterator variable should be incremented when the guard is fired.
+  ir::Stmt strideBoundsGuard(Iterator iterator, ir::Expr access, bool incrementPosVar);
+
 private:
   bool assemble;
   bool compute;

--- a/include/taco/lower/lowerer_impl.h
+++ b/include/taco/lower/lowerer_impl.h
@@ -375,8 +375,29 @@ protected:
   /// Create an expression to index into a tensor value array.
   ir::Expr generateValueLocExpr(Access access) const;
 
-  /// Expression that evaluates to true if none of the iteratators are exhausted
+  /// Expression that evaluates to true if none of the iterators are exhausted
   ir::Expr checkThatNoneAreExhausted(std::vector<Iterator> iterators);
+
+  /// Expression that returns the beginning of a window to iterate over
+  /// in a compressed iterator. It is used when operating over windows of
+  /// tensors, instead of the full tensor.
+  ir::Expr searchForStartOfWindowPosition(Iterator iterator, ir::Expr start, ir::Expr end);
+
+  /// Statement that guards against going out of bounds of the window that
+  /// the input iterator was configured with.
+  ir::Stmt upperBoundGuardForWindowPosition(Iterator iterator, ir::Expr access);
+
+  /// Expression that recovers a canonical index variable from a position in
+  /// a windowed position iterator. A windowed position iterator iterates over
+  /// values in the range [lo, hi). This expression projects values in that
+  /// range back into the canonical range of [0, n).
+  ir::Expr projectWindowedPositionToCanonicalSpace(Iterator iterator, ir::Expr expr);
+
+  // projectCanonicalSpaceToWindowedPosition is the opposite of
+  // projectWindowedPositionToCanonicalSpace. It takes an expression ranging
+  // through the canonical space of [0, n) and projects it up to the windowed
+  // range of [lo, hi).
+  ir::Expr projectCanonicalSpaceToWindowedPosition(Iterator iterator, ir::Expr expr);
 
 private:
   bool assemble;

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -386,6 +386,9 @@ public:
   /// Create an index expression that accesses (reads or writes) this tensor.
   Access operator()(const std::vector<IndexVar>& indices);
 
+  /// Create a possibly windowed index expression that accesses (reads or writes) this tensor.
+  Access operator()(const std::vector<std::shared_ptr<IndexVarInterface>>& indices);
+
   /// Create an index expression that accesses (reads) this (scalar) tensor.
   Access operator()();
 
@@ -621,6 +624,20 @@ public:
   template <typename... IndexVars>
   Access operator()(const IndexVars&... indices);
 
+  /// The below two Access methods are used to allow users to access tensors
+  /// with a mix of IndexVar's and WindowedIndexVar's. This allows natural
+  /// expressions like
+  ///   A(i, j(1, 3)) = B(i(2, 4), j) * C(i(5, 7), j(7, 9))
+  /// to be constructed without adjusting the original API.
+
+  /// Create an index expression that accesses (reads, writes) this tensor.
+  template <typename... IndexVars>
+  Access operator()(const WindowedIndexVar& first, const IndexVars&... indices);
+
+  /// Create an index expression that accesses (reads, writes) this tensor.
+  template <typename... IndexVars>
+  Access operator()(const IndexVar& first, const IndexVars&... indices);
+
   ScalarAccess<CType> operator()(const std::vector<int>& indices);
 
   /// Create an index expression that accesses (reads) this tensor.
@@ -629,6 +646,15 @@ public:
 
   /// Assign an expression to a scalar tensor.
   void operator=(const IndexExpr& expr);
+
+private:
+  /// The _access method family is the template level implementation of
+  /// Access() expressions containing mixes of IndexVar and WindowedIndexVar objects.
+  template <typename First, typename... Rest>
+  std::vector<std::shared_ptr<IndexVarInterface>> _access(const First& first, const Rest&... rest);
+  std::vector<std::shared_ptr<IndexVarInterface>> _access();
+  template <typename... Args>
+  Access _access_wrapper(const Args&... args);
 };
 
 template <typename CType>
@@ -1082,6 +1108,63 @@ template <typename CType>
 template <typename... IndexVars>
 Access Tensor<CType>::operator()(const IndexVars&... indices) {
   return TensorBase::operator()(std::vector<IndexVar>{indices...});
+}
+
+/// The _access() methods perform primitive recursion on the input variadic template.
+/// This means that each instance of the _access method matches on the first element
+/// of the variadic template parameter pack, performs an "action", then recurses
+/// with the remaining elements in the parameter pack through a recursive call
+/// to _access. Since this is recursion, we need a base case. The empty argument
+/// instance of _access returns an empty value of the desired type, in this case
+/// a vector of IndexVarInterface.
+template <typename CType>
+std::vector<std::shared_ptr<IndexVarInterface>> Tensor<CType>::_access() {
+  return std::vector<std::shared_ptr<IndexVarInterface>>{};
+}
+
+/// The recursive case of _access matches on the first element, and attempts to
+/// create a shared_ptr out of it. It then makes a recursive call to get a
+/// vector with the rest of the elements. Then, it pushes the first element onto
+/// the back of the vector -- this check ensures that the type First is indeed
+/// a member of IndexVarInterface.
+template <typename CType>
+template <typename First, typename... Rest>
+std::vector<std::shared_ptr<IndexVarInterface>> Tensor<CType>::_access(const First& first, const Rest&... rest) {
+  auto var = std::make_shared<First>(first);
+  auto ret = _access(rest...);
+  ret.push_back(var);
+  return ret;
+}
+
+/// _access_wrapper just calls into _access and reverses the result to get the initial
+/// order of the arguments.
+template <typename CType>
+template <typename... Args>
+Access Tensor<CType>::_access_wrapper(const Args&... args) {
+  auto resultReversed = this->_access(args...);
+  std::vector<std::shared_ptr<IndexVarInterface>> result;
+  result.reserve(resultReversed.size());
+  for (auto it = resultReversed.rbegin(); it != resultReversed.rend(); it++) {
+    result.push_back(*it);
+  }
+  return TensorBase::operator()(result);
+}
+
+/// We have to case on whether the first argument is an IndexVar or a WindowedIndexVar
+/// so that the template engine can differentiate between the two versions.
+// TODO (rohany): I think that there is a chance here that I might not need these
+//  two methods if I have _access. I think that instead I would just have to remove
+//  the other operator() methods that also take in IndexVar... so that there isn't
+//  any confusion.
+template <typename CType>
+template <typename... IndexVars>
+Access Tensor<CType>::operator()(const IndexVar& first, const IndexVars&... indices) {
+  return this->_access_wrapper(first, indices...);
+}
+template <typename CType>
+template <typename... IndexVars>
+Access Tensor<CType>::operator()(const WindowedIndexVar& first, const IndexVars&... indices) {
+  return this->_access_wrapper(first, indices...);
 }
 
 template <typename CType>

--- a/src/codegen/codegen_c.cpp
+++ b/src/codegen/codegen_c.cpp
@@ -516,7 +516,7 @@ void CodeGen_C::visit(const Allocate* op) {
     stream << ", ";
   }
   else {
-    stream << "malloc(";
+    stream << "calloc(1, ";
   }
   stream << "sizeof(" << elementType << ")";
   stream << " * ";

--- a/src/error/error_checks.cpp
+++ b/src/error/error_checks.cpp
@@ -58,7 +58,7 @@ std::pair<bool, string> dimensionsTypecheck(const std::vector<IndexVar>& resultV
       // as the shape, rather than the shape of the underlying tensor.
       auto a = Access(readNode);
       if (a.isModeWindowed(mode)) {
-        dimension = Dimension(a.getWindowUpperBound(mode) - a.getWindowLowerBound(mode));
+        dimension = Dimension(a.getWindowDimension(mode));
       }
 
       if (util::contains(indexVarDims,var) && indexVarDims.at(var) != dimension) {

--- a/src/error/error_checks.cpp
+++ b/src/error/error_checks.cpp
@@ -53,6 +53,14 @@ std::pair<bool, string> dimensionsTypecheck(const std::vector<IndexVar>& resultV
     for (size_t mode = 0; mode < readNode->indexVars.size(); mode++) {
       IndexVar var = readNode->indexVars[mode];
       Dimension dimension = readNode->tensorVar.getType().getShape().getDimension(mode);
+
+      // If this access has windowed modes, use the dimensions of those windows
+      // as the shape, rather than the shape of the underlying tensor.
+      auto a = Access(readNode);
+      if (a.isModeWindowed(mode)) {
+        dimension = Dimension(a.getWindowUpperBound(mode) - a.getWindowLowerBound(mode));
+      }
+
       if (util::contains(indexVarDims,var) && indexVarDims.at(var) != dimension) {
         errors.push_back(addDimensionError(var, indexVarDims.at(var), dimension));
       } else {

--- a/src/lower/iterator.cpp
+++ b/src/lower/iterator.cpp
@@ -33,9 +33,15 @@ struct Iterator::Content {
   // the expressions representing an upper and lower bound. An iterator
   // is windowed if window is not NULL.
   struct Window {
-      ir::Expr lo;
-      ir::Expr hi;
-      Window(ir::Expr _lo, ir::Expr _hi) : lo(_lo), hi(_hi) {};
+    // windowVar is a Var specific to this iterator. It is intended to
+    // be used as temporary storage to avoid duplicate memory loads of
+    // expressions that are used in window/stride related bounds checking.
+    ir::Expr windowVar;
+    ir::Expr lo;
+    ir::Expr hi;
+    ir::Expr stride;
+    Window(ir::Expr _lo, ir::Expr _hi, ir::Expr _stride, ir::Expr _windowVar) :
+      windowVar(_windowVar), lo(_lo), hi(_hi), stride(_stride) {};
   };
   std::unique_ptr<Window> window;
 };
@@ -347,8 +353,27 @@ ir::Expr Iterator::getWindowUpperBound() const {
   return this->content->window->hi;
 }
 
-void Iterator::setWindowBounds(ir::Expr lo, ir::Expr hi) {
-  this->content->window = std::make_unique<Content::Window>(Content::Window(lo, hi));
+ir::Expr Iterator::getStride() const {
+  taco_iassert(this->isWindowed());
+  return this->content->window->stride;
+}
+
+ir::Expr Iterator::getWindowVar() const {
+  taco_iassert(this->isWindowed());
+  return this->content->window->windowVar;
+}
+
+bool Iterator::isStrided() const {
+  // TODO (rohany): Do we need to have a window in order to stride?
+  taco_iassert(this->isWindowed());
+  auto strideLiteral = this->content->window->stride.as<ir::Literal>();
+  return !(strideLiteral != nullptr && strideLiteral->getIntValue() == 1);
+}
+
+void Iterator::setWindowBounds(ir::Expr lo, ir::Expr hi, ir::Expr stride) {
+  auto windowVarName = this->getIndexVar().getName() + this->getMode().getName() + "_window";
+  auto wvar = ir::Var::make(windowVarName, Int());
+  this->content->window = std::make_unique<Content::Window>(Content::Window(lo, hi, stride, wvar));
 }
 
 bool operator==(const Iterator& a, const Iterator& b) {
@@ -508,7 +533,8 @@ Iterators::createAccessIterators(Access access, Format format, Expr tensorIR, Pr
       if (access.isModeWindowed(modeNumber)) {
         auto lo = ir::Literal::make(access.getWindowLowerBound(modeNumber));
         auto hi = ir::Literal::make(access.getWindowUpperBound(modeNumber));
-        iterator.setWindowBounds(lo, hi);
+        auto stride = ir::Literal::make(access.getStride(modeNumber));
+        iterator.setWindowBounds(lo, hi, stride);
       }
 
       content->levelIterators.insert({{access,modeNumber+1}, iterator});

--- a/src/lower/lowerer_impl.cpp
+++ b/src/lower/lowerer_impl.cpp
@@ -178,7 +178,7 @@ LowererImpl::lower(IndexStmt stmt, string name,
         // The mode value used to access .levelIterator is 1-indexed, while
         // the mode input to getDimension is 0-indexed. So, we shift it up by 1.
         auto iter = iterators.levelIterator(ModeAccess(a, mode+1));
-        return ir::Sub::make(iter.getWindowUpperBound(), iter.getWindowLowerBound());
+        return ir::Div::make(ir::Sub::make(iter.getWindowUpperBound(), iter.getWindowLowerBound()), iter.getStride());
       } else {
         return GetProperty::make(tensorVars.at(tv), TensorProperty::Dimension, mode);
       }
@@ -1016,6 +1016,7 @@ Stmt LowererImpl::lowerForallPosition(Forall forall, Iterator iterator,
 {
   Expr coordinate = getCoordinateVar(forall.getIndexVar());
   Stmt declareCoordinate = Stmt();
+  Stmt strideGuard = Stmt();
   Stmt boundsGuard = Stmt();
   if (provGraph.isCoordVariable(forall.getIndexVar())) {
     Expr coordinateArray = iterator.posAccess(iterator.getPosVar(),
@@ -1023,6 +1024,13 @@ Stmt LowererImpl::lowerForallPosition(Forall forall, Iterator iterator,
     // If the iterator is windowed, we must recover the coordinate index
     // variable from the windowed space.
     if (iterator.isWindowed()) {
+      if (iterator.isStrided()) {
+        // In this case, we're iterating over a compressed level with a for
+        // loop. Since the iterator variable will get incremented by the for
+        // loop, the guard introduced for stride checking doesn't need to
+        // increment the iterator variable.
+        strideGuard = this->strideBoundsGuard(iterator, coordinateArray, false /* incrementPosVar */);
+      }
       coordinateArray = this->projectWindowedPositionToCanonicalSpace(iterator, coordinateArray);
       boundsGuard = this->upperBoundGuardForWindowPosition(iterator, coordinate);
     }
@@ -1090,7 +1098,7 @@ Stmt LowererImpl::lowerForallPosition(Forall forall, Iterator iterator,
   return Block::blanks(
                        boundsCompute,
                        For::make(iterator.getPosVar(), startBound, endBound, 1,
-                                 Block::make(declareCoordinate, boundsGuard, body),
+                                 Block::make(strideGuard, declareCoordinate, boundsGuard, body),
                                  kind,
                                  ignoreVectorize ? ParallelUnit::NotParallel : forall.getParallelUnit(), ignoreVectorize ? 0 : forall.getUnrollFactor()),
                        posAppend);
@@ -1350,15 +1358,34 @@ Stmt LowererImpl::resolveCoordinate(std::vector<Iterator> mergers, ir::Expr coor
       ModeFunction posAccess = merger.posAccess(merger.getPosVar(),
                                                 coordinates(merger));
       auto access = posAccess[0];
+      auto windowVarDecl = Stmt();
+      auto stride = Stmt();
       auto guard = Stmt();
       // If the iterator is windowed, we must recover the coordinate index
       // variable from the windowed space.
       if (merger.isWindowed()) {
+
+        // If the iterator is strided, then we have to skip over coordinates
+        // that don't match the stride. To do that, we insert a guard on the
+        // access. We first extract the access into a temp to avoid emitting
+        // a duplicate load on the _crd array.
+        if (merger.isStrided()) {
+          windowVarDecl = VarDecl::make(merger.getWindowVar(), access);
+          access = merger.getWindowVar();
+          // Since we're merging values from a compressed array (not iterating over it),
+          // we need to advance the outer loop if the current coordinate is not
+          // along the desired stride. So, we pass true to the incrementPosVar
+          // argument of strideBoundsGuard.
+          stride = this->strideBoundsGuard(merger, access, true /* incrementPosVar */);
+        }
+
         access = this->projectWindowedPositionToCanonicalSpace(merger, access);
         guard = this->upperBoundGuardForWindowPosition(merger, coordinate);
       }
       Stmt resolution = emitVarDecl ? VarDecl::make(coordinate, access) : Assign::make(coordinate, access);
       return Block::make(posAccess.compute(),
+                         windowVarDecl,
+                         stride,
                          resolution,
                          guard);
     }
@@ -2616,6 +2643,23 @@ Stmt LowererImpl::codeToLoadCoordinatesFromPosIterators(vector<Iterator> iterato
       // TODO (rohany): Would be cleaner to have this logic be moved into the
       //  ModeFunction, rather than having to check in some places?
       if (posIter.isWindowed()) {
+
+        // If the iterator is strided, then we have to skip over coordinates
+        // that don't match the stride. To do that, we insert a guard on the
+        // access. We first extract the access into a temp to avoid emitting
+        // a duplicate load on the _crd array.
+        if (posIter.isStrided()) {
+          loadPosIterCoordinateStmts.push_back(VarDecl::make(posIter.getWindowVar(), access));
+          access = posIter.getWindowVar();
+          // TODO (rohany): Is this even right? It seems like this function could
+          //  be used in other places.
+          // Since we're locating into a compressed array (not iterating over it),
+          // we need to advance the outer loop if the current coordinate is not
+          // along the desired stride. So, we pass true to the incrementPosVar
+          // argument of strideBoundsGuard.
+          loadPosIterCoordinateStmts.push_back(this->strideBoundsGuard(posIter, access, true /* incrementPosVar */));
+        }
+
         access = this->projectWindowedPositionToCanonicalSpace(posIter, access);
       }
       if (declVars) {
@@ -2778,19 +2822,37 @@ Expr LowererImpl::searchForStartOfWindowPosition(Iterator iterator, ir::Expr sta
 }
 
 Stmt LowererImpl::upperBoundGuardForWindowPosition(Iterator iterator, ir::Expr access) {
-    taco_iassert(iterator.isWindowed());
-    return ir::IfThenElse::make(
-            ir::Gte::make(access, ir::Sub::make(iterator.getWindowUpperBound(), iterator.getWindowLowerBound())),
-            ir::Break::make()
-    );
+  taco_iassert(iterator.isWindowed());
+  return ir::IfThenElse::make(
+    ir::Gte::make(access, ir::Sub::make(iterator.getWindowUpperBound(), iterator.getWindowLowerBound())),
+    ir::Break::make()
+  );
+}
+
+Stmt LowererImpl::strideBoundsGuard(Iterator iterator, ir::Expr access, bool incrementPosVar) {
+  Stmt cont = ir::Continue::make();
+  // TODO (rohany): It's unclear to me when incrementPosVar should be set to true.
+  //  Intuitively, only when the iterator is part of a while loop and not a for
+  //  loop. Is this boolean sufficient to know that from the parts of the code
+  //  that call this function?
+  if (incrementPosVar) {
+    cont = ir::Block::make({
+      ir::Assign::make(iterator.getPosVar(), ir::Add::make(iterator.getPosVar(), ir::Literal::make(1))),
+      cont
+    });
+  }
+  return ir::IfThenElse::make(
+      ir::Neq::make(ir::Rem::make(access, iterator.getStride()), ir::Literal::make(0)),
+      cont
+  );
 }
 
 Expr LowererImpl::projectWindowedPositionToCanonicalSpace(Iterator iterator, ir::Expr expr) {
-  return ir::Sub::make(expr, iterator.getWindowLowerBound());
+  return ir::Div::make(ir::Sub::make(expr, iterator.getWindowLowerBound()), iterator.getStride());
 }
 
 Expr LowererImpl::projectCanonicalSpaceToWindowedPosition(Iterator iterator, ir::Expr expr) {
-  return ir::Add::make(expr, iterator.getWindowLowerBound());
+  return ir::Mul::make(ir::Add::make(expr, iterator.getWindowLowerBound()), iterator.getStride());
 }
 
 }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -477,6 +477,7 @@ struct AccessTensorNode : public AccessNode {
           "slice upper bound must be <= tensor dimension (" << tensor.getDimension(i) << ")";
         this->windowedModes[i].lo = lo;
         this->windowedModes[i].hi = hi;
+        this->windowedModes[i].stride = wvar->getStride();
       });
     }
     // Initialize this->indexVars.
@@ -628,7 +629,7 @@ void TensorBase::compile(taco::IndexStmt stmt, bool assembleWhileCompute) {
 
   content->assembleFunc = lower(stmtToCompile, "assemble", true, false);
   content->computeFunc = lower(stmtToCompile, "compute",  assembleWhileCompute, true);
-  content->module->reset();
+  content->module = make_shared<Module>();
   content->module->addFunction(content->assembleFunc);
   content->module->addFunction(content->computeFunc);
   content->module->compile();

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,3 +1,5 @@
+#include <functional>
+
 #include "test.h"
 #include "taco/tensor.h"
 
@@ -49,6 +51,20 @@ ostream& operator<<(ostream& os, const NotationTest& test) {
   os << "Expected: " << test.expected << endl;
   os << "Actual:   " << test.actual << endl;
   return os;
+}
+
+void ASSERT_THROWS_EXCEPTION_WITH_ERROR(std::function<void()> f, std::string err) {
+  EXPECT_THROW({
+    try {
+      f();
+    } catch (TacoException& e) {
+      // Catch and inspect the exception to make sure that err is within it.
+      auto s = std::string(e.what());
+      ASSERT_TRUE(s.find(err) != std::string::npos);
+      // Throw the exception back up to gtest.
+      throw;
+    }
+  }, TacoException);
 }
 
 }}

--- a/test/test.h
+++ b/test/test.h
@@ -3,6 +3,7 @@
 
 #include "gtest/gtest.h"
 
+#include <functional>
 #include <iostream>
 #include <vector>
 #include <memory>
@@ -92,6 +93,10 @@ void ASSERT_COMPONENTS_EQUALS(vector<vector<vector<int>>> expectedIndices,
   ASSERT_EQ(expectedValues.size(), nnz);
   ASSERT_ARRAY_EQ(expectedValues, {(double*)storage.getValues().getData(),nnz});
 }
+
+// ASSERT_THROWS_EXCEPTION_WITH_ERROR asserts that the input function throws
+// a TacoException with the input string err contained within the body.
+void ASSERT_THROWS_EXCEPTION_WITH_ERROR(std::function<void()> f, std::string err);
 
 struct NotationTest {
   NotationTest(IndexStmt actual, IndexStmt expected)

--- a/test/tests-windowing.cpp
+++ b/test/tests-windowing.cpp
@@ -240,3 +240,52 @@ TEST(windowing, assignment) {
     testFn({Dense, x});
   }
 }
+
+TEST(windowing, stride) {
+  auto dim = 10;
+  Tensor<int> expectedAdd("expectedAdd", {2, 2}, {Dense, Dense});
+  expectedAdd.insert({0, 0}, 0); expectedAdd.insert({0, 1}, 10);
+  expectedAdd.insert({1, 0}, 10); expectedAdd.insert({1, 1}, 20);
+  expectedAdd.pack();
+  Tensor<int> expectedAssign("expectedAssign", {2, 2}, {Dense, Dense});
+  expectedAssign.insert({0, 0}, 0); expectedAssign.insert({0, 1}, 5);
+  expectedAssign.insert({1, 0}, 5); expectedAssign.insert({1, 1}, 10);
+  expectedAssign.pack();
+
+  Tensor<int> expectedMul("expectedMul", {2, 2}, {Dense, Dense});
+  expectedMul.insert({0, 0}, 0); expectedMul.insert({0, 1}, 25);
+  expectedMul.insert({1, 0}, 25); expectedMul.insert({1, 1}, 100);
+  expectedMul.pack();
+
+  for (auto& x : {Dense, Sparse}) {
+    for (auto& y : {Dense, Sparse}) {
+      Tensor<int> a("a", {dim, dim}, {Dense, x});
+      Tensor<int> b("b", {dim, dim}, {Dense, y});
+      Tensor<int> c("c", {2, 2}, {Dense, Dense});
+      for (int i = 0; i < dim; i++) {
+        for (int j = 0; j < dim; j++) {
+          a.insert({i, j}, i+j);
+          b.insert({i, j}, i+j);
+        }
+      }
+      a.pack(); b.pack();
+
+      IndexVar i("i"), j("j");
+
+      // Test a strided assignment.
+      c(i, j) = a(i(0, 10, 5), j(0, 10, 5));
+      c.evaluate();
+      ASSERT_TRUE(equals(c, expectedAssign)) << c << endl << expectedAssign << endl << x << " " << y << endl;
+
+      // Test a strided addition.
+      c(i, j) = a(i(0, 10, 5), j(0, 10, 5)) + b(i(0, 10, 5), j(0, 10, 5));
+      c.evaluate();
+      ASSERT_TRUE(equals(c, expectedAdd)) << c << endl << expectedAdd << endl;
+
+      // Test a strided multiplication.
+      c(i, j) = a(i(0, 10, 5), j(0, 10, 5)) * b(i(0, 10, 5), j(0, 10, 5));
+      c.evaluate();
+      ASSERT_TRUE(equals(c, expectedMul)) << c << endl << expectedMul << endl;
+    }
+  }
+}

--- a/test/tests-windowing.cpp
+++ b/test/tests-windowing.cpp
@@ -1,0 +1,242 @@
+#include "test.h"
+#include "taco/tensor.h"
+#include "taco/codegen/module.h"
+#include "taco/index_notation/index_notation.h"
+#include "taco/lower/lower.h"
+
+using namespace taco;
+
+// mixIndexing is a compilation test to ensure that we can index into a
+// tensor with a mix of IndexVars and WindowedIndexVars.
+TEST(windowing, mixIndexing) {
+  auto dim = 10;
+  Tensor<int> a("a", {dim, dim, dim, dim, dim}, {Dense, Dense, Dense, Dense, Dense});
+  IndexVar i, j, k, l, m;
+  auto w1 = a(i, j(1, 3), k, l(4, 5), m(6, 7));
+  auto w2 = a(i(1, 3), j(2, 4), k, l, m(3, 5));
+}
+
+TEST(windowing, boundsChecks) {
+  Tensor<int> a("a", {5}, {Dense});
+  IndexVar i("i");
+  ASSERT_THROWS_EXCEPTION_WITH_ERROR([&]() { a(i(-1, 4)); }, "slice lower bound");
+  ASSERT_THROWS_EXCEPTION_WITH_ERROR([&]() { a(i(0, 10)); }, "slice upper bound");
+}
+
+// sliceMultipleWays tests that the same tensor can be sliced in different ways
+// in the same expression.
+TEST(windowing, sliceMultipleWays) {
+  auto dim = 10;
+  Tensor<int> a("a", {dim}, {Dense});
+  Tensor<int> b("b", {dim}, {Sparse});
+  Tensor<int> c("c", {dim}, {Dense});
+  Tensor<int> expected("expected", {dim}, {Dense});
+  for (int i = 0; i < dim; i++) {
+    a.insert({i}, i);
+    b.insert({i}, i);
+  }
+  expected.insert({2}, 10);
+  expected.insert({3}, 13);
+  a.pack(); b.pack(); expected.pack();
+  IndexVar i("i"), j("j");
+
+  c(i(2, 4)) = a(i(5, 7)) + a(i(1, 3)) + b(i(4, 6));
+  c.evaluate();
+  ASSERT_TRUE(equals(expected, c));
+}
+
+// basic tests a windowed tensor expression with different combinations
+// of tensor formats.
+TEST(windowing, basic) {
+  Tensor<int> expectedAdd("expectedAdd", {2, 2}, {Dense, Dense});
+  expectedAdd.insert({0, 0}, 14);
+  expectedAdd.insert({0, 1}, 17);
+  expectedAdd.insert({1, 0}, 17);
+  expectedAdd.insert({1, 1}, 20);
+  expectedAdd.pack();
+  Tensor<int> expectedMul("expectedMul", {2, 2}, {Dense, Dense});
+  expectedMul.insert({0, 0}, 64);
+  expectedMul.insert({0, 1}, 135);
+  expectedMul.insert({1, 0}, 135);
+  expectedMul.insert({1, 1}, 240);
+  expectedMul.pack();
+  Tensor<int> d("d", {2, 2}, {Dense, Dense});
+
+  // These dimensions are chosen so that one is above the constant in `mode_format_dense.cpp:54`
+  // where the known stride is generated vs using the dimension.
+  // TODO (rohany): Change that constant to be in a header file and import it here.
+  for (auto& dim : {6, 20}) {
+    for (auto &x : {Dense, Sparse}) {
+      for (auto &y : {Dense, Sparse}) {
+        for (auto &z : {Dense, Sparse}) {
+          Tensor<int> a("a", {dim, dim}, {Dense, x});
+          Tensor<int> b("b", {dim, dim}, {Dense, y});
+          Tensor<int> c("c", {dim, dim}, {Dense, z});
+          for (int i = 0; i < dim; i++) {
+            for (int j = 0; j < dim; j++) {
+              a.insert({i, j}, i + j);
+              b.insert({i, j}, i + j);
+              c.insert({i, j}, i + j);
+            }
+          }
+
+          a.pack();
+          b.pack();
+          c.pack();
+
+          IndexVar i, j;
+          d(i, j) = a(i(2, 4), j(2, 4)) + b(i(4, 6), j(4, 6)) + c(i(1, 3), j(1, 3));
+          d.evaluate();
+          ASSERT_TRUE(equals(expectedAdd, d))
+                        << endl << expectedAdd << endl << endl << d << endl
+                        << dim << " " << x << " " << y << " " << z << endl;
+
+          d(i, j) = a(i(2, 4), j(2, 4)) * b(i(4, 6), j(4, 6)) * c(i(1, 3), j(1, 3));
+          d.evaluate();
+          ASSERT_TRUE(equals(expectedMul, d))
+                        << endl << expectedMul << endl << endl << d << endl
+                        << dim << " " << x << " " << y << " " << z << endl;
+        }
+      }
+    }
+  }
+}
+
+// slicedOutput tests that operations can write to a window within an output tensor.
+TEST(windowing, slicedOutput) {
+  auto dim = 10;
+  Tensor<int> expected("expected", {10, 10}, {Dense, Dense});
+  expected.insert({8, 8}, 12);
+  expected.insert({8, 9}, 14);
+  expected.insert({9, 8}, 14);
+  expected.insert({9, 9}, 16);
+  expected.pack();
+  for (auto& x : {Dense, Sparse}) {
+    for (auto& y : {Dense, Sparse}) {
+      Tensor<int> a("a", {dim, dim}, {Dense, x});
+      Tensor<int> b("b", {dim, dim}, {Dense, y});
+      Tensor<int> c("c", {dim, dim}, {Dense, Dense});
+      for (int i = 0; i < dim; i++) {
+        for (int j = 0; j < dim; j++) {
+          a.insert({i, j}, i + j);
+          b.insert({i, j}, i + j);
+        }
+      }
+      a.pack();
+      b.pack();
+
+      IndexVar i, j;
+      c(i(8, 10), j(8, 10)) = a(i(2, 4), j(2, 4)) + b(i(4, 6), j(4, 6));
+      c.evaluate();
+      ASSERT_TRUE(equals(expected, c))
+                    << endl << expected << endl << endl << c << endl
+                    << dim << " " << x << " " << y << endl;
+    }
+  }
+}
+
+// transformations tests how windowing interacts with sparse iteration space
+// transformations and different mode formats.
+TEST(windowing, transformations) {
+  auto dim = 10;
+  Tensor<int> expected("expected", {2, 2}, {Dense, Dense});
+  expected.insert({0, 0}, 12);
+  expected.insert({0, 1}, 14);
+  expected.insert({1, 0}, 14);
+  expected.insert({1, 1}, 16);
+  expected.pack();
+
+  IndexVar i("i"), j("j"), i1 ("i1"), i2 ("i2");
+  auto testFn = [&](std::function<IndexStmt(IndexStmt)> modifier, std::vector<Format> formats) {
+    for (auto& format : formats) {
+      Tensor<int> a("a", {dim, dim}, format);
+      Tensor<int> b("b", {dim, dim}, format);
+      for (int i = 0; i < dim; i++) {
+        for (int j = 0; j < dim; j++) {
+          a.insert({i, j}, i + j);
+          b.insert({i, j}, i + j);
+        }
+      }
+      a.pack(); b.pack();
+
+      Tensor<int> c("c", {2, 2}, {Dense, Dense});
+      c(i, j) = a(i(2, 4), j(2, 4)) + b(i(4, 6), j(4, 6));
+      auto stmt = c.getAssignment().concretize();
+      c.compile(modifier(stmt));
+      c.evaluate();
+      equals(c, expected);
+      ASSERT_TRUE(equals(c, expected)) << endl << c << endl << expected << endl << format << endl;
+    }
+  };
+
+  std::vector<Format> allFormats = {{Dense, Dense}, {Dense, Sparse}, {Sparse, Dense}, {Sparse, Sparse}};
+  testFn([&](IndexStmt stmt) {
+    return stmt.split(i, i1, i2, 4).unroll(i2, 4);
+ }, allFormats);
+
+  // TODO (rohany): Can we only reorder these loops in the Dense,Dense case? It seems so.
+  testFn([&](IndexStmt stmt) {
+    return stmt.reorder(i, j);
+  }, {{Dense, Dense}});
+
+  // We can only (currently) parallelize the outer dimension loop if it is dense.
+  testFn([&](IndexStmt stmt) {
+    return stmt.parallelize(i, taco::ParallelUnit::CPUThread, taco::OutputRaceStrategy::NoRaces);
+  }, {{Dense, Dense}, {Dense, Sparse}});
+}
+
+// assignment tests assignments of and to windows in different combinations.
+TEST(windowing, assignment) {
+  auto dim = 10;
+
+  auto testFn = [&](Format srcFormat) {
+    Tensor<int> A("A", {dim, dim}, srcFormat);
+
+    for (int i = 0; i < dim; i++) {
+      for (int j = 0; j < dim; j++) {
+        A.insert({i, j}, i + j);
+      }
+    }
+    A.pack();
+
+    IndexVar i, j;
+
+    // First assign a window of A to a window of B.
+    Tensor<int> B("B", {dim, dim}, {Dense, Dense});
+    B(i(2, 4), j(3, 5)) = A(i(4, 6), j(5, 7));
+    B.evaluate();
+    Tensor<int> expected("expected", {dim, dim}, {Dense, Dense});
+    expected.insert({2, 3}, 9); expected.insert({2, 4}, 10);
+    expected.insert({3, 3}, 10); expected.insert({3, 4}, 11);
+    expected.pack();
+    ASSERT_TRUE(equals(B, expected)) << B << std::endl << expected << std::endl;
+
+    // Assign a window of A to b.
+    B = Tensor<int>("B", {2, 2}, {Dense, Dense});
+    B(i, j) = A(i(4, 6), j(5, 7));
+    B.evaluate();
+    expected = Tensor<int>("expected", {2, 2}, {Dense, Dense});
+    expected.insert({0, 0}, 9); expected.insert({0, 1}, 10);
+    expected.insert({1, 0}, 10); expected.insert({1, 1}, 11);
+    expected.pack();
+    ASSERT_TRUE(equals(B, expected)) << B << std::endl << expected << std::endl;
+
+    // Assign A to a window of B.
+    A = Tensor<int>("A", {2, 2}, srcFormat);
+    A.insert({0, 0}, 0); A.insert({0, 1}, 1);
+    A.insert({1, 0}, 1); A.insert({1, 1}, 2);
+    A.pack();
+    B = Tensor<int>("B", {dim, dim}, {Dense, Dense});
+    B(i(4, 6), j(5, 7)) = A(i, j);
+    B.evaluate();
+    expected = Tensor<int>("expected", {dim, dim}, {Dense, Dense});
+    expected.insert({4, 5}, 0); expected.insert({4, 6}, 1);
+    expected.insert({5, 5}, 1); expected.insert({5, 6}, 2);
+    expected.pack();
+    ASSERT_TRUE(equals(B, expected)) << B << std::endl << expected << std::endl;
+  };
+
+  for (auto& x : {Dense, Sparse}) {
+    testFn({Dense, x});
+  }
+}


### PR DESCRIPTION
This commit extends the windowing syntax to include an optional third
parameter to a window expression on an index variable:

```
a(i) = b(i(0, n, 5 /* stride */))
```

This stride parameters means that the window should be accessed along
the provided stride, which defaults to 1.

Striding is implemented with a similar idea as windowing, where
coordinates in the stride are mapped to a canonical index space of `[0,n)`.
For compressed modes, coordinates that don't match the stride are
skipped.

Depends on #372.