### PR TITLE
tensor,module: add a utility to allow for debugging generated kernels

### DIFF
--- a/include/taco/codegen/module.h
+++ b/include/taco/codegen/module.h
@@ -25,6 +25,12 @@ public:
 
   /// Compile the source into a library, returning its full path
   std::string compile();
+
+  /// Compile the sources at the given prefix and link the compiled code. A
+  /// libPrefix is of the form path/prefix, where files path/prefix.{c, h} are
+  /// present. debugCompileSourceFile can be used to recompile an existing
+  /// generated code file with handwritten changes to debug.
+  void debugCompileSourceFile(std::string libPrefix);
   
   /// Compile the module into a source file located at the specified location
   /// path and prefix.  The generated source will be path/prefix.{.c|.bc, .h}
@@ -82,6 +88,12 @@ private:
   
   void setJITLibname();
   void setJITTmpdir();
+
+  /// compileAndLink compiles the files at prefix into a library file named
+  /// output, and dynamically links output into the TACO process. libPrefix
+  /// is of the form path/prefix, where files path/prefix.{c, cu, h, cpp}
+  /// are placed to be compiled.
+  void compileAndLink(std::string libPrefix, std::string output);
 };
 
 } // namespace ir

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -413,6 +413,21 @@ public:
 
   void compile(IndexStmt stmt, bool assembleWhileCompute=false);
 
+  /// debugCompileSource can be used to edit TACO generated code (to add prints
+  /// or assertions etc) and use the TACO machinery to execute the edited code.
+  /// debugCompileSource takes in a string libPrefix that is the path to a
+  /// group of TACO generated files. In particular, TACO generates files like
+  /// path/prefix.{c, h, ...}. In this case, libPrefix should equal "path/prefix".
+  /// An example workflow is as follows:
+  ///    Tensor a; Tensor b; IndexVar i;
+  ///    a(i) = b(i);
+  ///    // a.compile(); Compile the expression once to generate code.
+  ///    a.debugCompileSource("/tmp/....");
+  ///    a.evaluate();
+  // TODO (rohany): This should only get compiled in a test/debug build, but
+  //  I'm not sure that we have the flags set up to do this.
+  void debugCompileSource(std::string libPrefix);
+
   /// Assemble the tensor storage, including index and value arrays.
   void assemble();
 

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -573,6 +573,7 @@ void TensorBase::compile() {
   stmt = parallelizeOuterLoop(stmt);
   compile(stmt, content->assembleWhileCompute);
 }
+
 void TensorBase::compile(taco::IndexStmt stmt, bool assembleWhileCompute) {
   if (!needsCompile()) {
     return;
@@ -600,6 +601,14 @@ void TensorBase::compile(taco::IndexStmt stmt, bool assembleWhileCompute) {
   content->module->addFunction(content->computeFunc);
   content->module->compile();
   cacheComputeKernel(concretizedAssign, content->module);
+}
+
+void TensorBase::debugCompileSource(std::string libPrefix) {
+  // We're directly compiling user provided source, so mark compilation as done.
+  this->setNeedsCompile(false);
+  // Make a new module and compile the source.
+  content->module = make_shared<Module>();
+  content->module->debugCompileSourceFile(libPrefix);
 }
 
 taco_tensor_t* TensorBase::getTacoTensorT() {


### PR DESCRIPTION
This commit adds a function `debugCompileSource` to a `Tensor` that
allows for the `Tensor` to use a kernel from a provided source file
instead of generating a new one. This allows developers to add
prints/assertions to TACO generated code to debug faster.

Inspired by Amalee's PR (#302), I would have found a command like this
very useful for debugging generated code.