### PR TITLE
*: add the ability to apply filters to individual tensor elements

### DIFF
--- a/include/taco/ir/ir.h
+++ b/include/taco/ir/ir.h
@@ -67,7 +67,8 @@ enum class IRNodeType {
   GetProperty,
   Continue,
   Sort,
-  Break
+  Break,
+  Ternary
 };
 
 enum class TensorProperty {
@@ -769,6 +770,19 @@ struct GetProperty : public ExprNode<GetProperty> {
                    int index, std::string name);
   
   static const IRNodeType _type_info = IRNodeType::GetProperty;
+};
+
+/** A ternary operator.
+ * This is an expression that performs some branching -- b ? x : y.
+ */
+struct Ternary : public ExprNode<Ternary> {
+  Expr cond;
+  Expr whenTrue;
+  Expr whenFalse;
+
+  static Expr make(Expr cond, Expr whenTrue, Expr whenFalse);
+
+  static const IRNodeType _type_info = IRNodeType::Ternary;
 };
 
 template <typename E>

--- a/include/taco/ir/ir_printer.h
+++ b/include/taco/ir/ir_printer.h
@@ -70,6 +70,7 @@ protected:
   virtual void visit(const GetProperty*);
   virtual void visit(const Sort*);
   virtual void visit(const Break*);
+  virtual void visit(const Ternary*);
 
   std::ostream &stream;
   int indent;

--- a/include/taco/ir/ir_rewriter.h
+++ b/include/taco/ir/ir_rewriter.h
@@ -70,6 +70,7 @@ protected:
   virtual void visit(const GetProperty* op);
   virtual void visit(const Sort *op);
   virtual void visit(const Break *op);
+  virtual void visit(const Ternary* op);
 };
 
 }}

--- a/include/taco/ir/ir_visitor.h
+++ b/include/taco/ir/ir_visitor.h
@@ -50,6 +50,7 @@ struct Print;
 struct GetProperty;
 struct Sort;
 struct Break;
+struct Ternary;
 
 /// Extend this class to visit every node in the IR.
 class IRVisitorStrict {
@@ -102,6 +103,7 @@ public:
   virtual void visit(const GetProperty*) = 0;
   virtual void visit(const Sort*) = 0;
   virtual void visit(const Break*) = 0;
+  virtual void visit(const Ternary*) = 0;
 };
 
 
@@ -157,6 +159,7 @@ public:
   virtual void visit(const GetProperty* op);
   virtual void visit(const Sort* op);
   virtual void visit(const Break* op);
+  virtual void visit(const Ternary* op);
 };
 
 }}

--- a/include/taco/lower/iterator.h
+++ b/include/taco/lower/iterator.h
@@ -159,6 +159,17 @@ public:
   /// Returns true if the iterator is defined, false otherwise.
   bool defined() const;
 
+  /// Methods for querying and operating on windowed tensor modes.
+
+  /// isWindowed returns true if this iterator is operating over a window
+  /// of a tensor mode.
+  bool isWindowed() const;
+
+  /// getWindow{Lower,Upper}Bound return the {Lower,Upper} bound of the
+  /// window that this iterator operates over.
+  ir::Expr getWindowLowerBound() const;
+  ir::Expr getWindowUpperBound() const;
+
   friend bool operator==(const Iterator&, const Iterator&);
   friend bool operator<(const Iterator&, const Iterator&);
   friend std::ostream& operator<<(std::ostream&, const Iterator&);
@@ -169,6 +180,10 @@ private:
 
   Iterator(std::shared_ptr<Content> content);
   void setChild(const Iterator& iterator) const;
+
+  friend class Iterators;
+  /// setWindowBounds sets the window bounds of this iterator.
+  void setWindowBounds(ir::Expr lo, ir::Expr hi);
 };
 
 /**

--- a/include/taco/lower/lowerer_impl.h
+++ b/include/taco/lower/lowerer_impl.h
@@ -375,8 +375,29 @@ protected:
   /// Create an expression to index into a tensor value array.
   ir::Expr generateValueLocExpr(Access access) const;
 
-  /// Expression that evaluates to true if none of the iteratators are exhausted
+  /// Expression that evaluates to true if none of the iterators are exhausted
   ir::Expr checkThatNoneAreExhausted(std::vector<Iterator> iterators);
+
+  /// Expression that returns the beginning of a window to iterate over
+  /// in a compressed iterator. It is used when operating over windows of
+  /// tensors, instead of the full tensor.
+  ir::Expr searchForStartOfWindowPosition(Iterator iterator, ir::Expr start, ir::Expr end);
+
+  /// Statement that guards against going out of bounds of the window that
+  /// the input iterator was configured with.
+  ir::Stmt upperBoundGuardForWindowPosition(Iterator iterator, ir::Expr access);
+
+  /// Expression that recovers a canonical index variable from a position in
+  /// a windowed position iterator. A windowed position iterator iterates over
+  /// values in the range [lo, hi). This expression projects values in that
+  /// range back into the canonical range of [0, n).
+  ir::Expr projectWindowedPositionToCanonicalSpace(Iterator iterator, ir::Expr expr);
+
+  // projectCanonicalSpaceToWindowedPosition is the opposite of
+  // projectWindowedPositionToCanonicalSpace. It takes an expression ranging
+  // through the canonical space of [0, n) and projects it up to the windowed
+  // range of [lo, hi).
+  ir::Expr projectCanonicalSpaceToWindowedPosition(Iterator iterator, ir::Expr expr);
 
 private:
   bool assemble;

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -386,6 +386,9 @@ public:
   /// Create an index expression that accesses (reads or writes) this tensor.
   Access operator()(const std::vector<IndexVar>& indices);
 
+  /// Create a possibly windowed index expression that accesses (reads or writes) this tensor.
+  Access operator()(const std::vector<std::shared_ptr<IndexVarInterface>>& indices);
+
   /// Create an index expression that accesses (reads) this (scalar) tensor.
   Access operator()();
 
@@ -621,6 +624,20 @@ public:
   template <typename... IndexVars>
   Access operator()(const IndexVars&... indices);
 
+  /// The below two Access methods are used to allow users to access tensors
+  /// with a mix of IndexVar's and WindowedIndexVar's. This allows natural
+  /// expressions like
+  ///   A(i, j(1, 3)) = B(i(2, 4), j) * C(i(5, 7), j(7, 9))
+  /// to be constructed without adjusting the original API.
+
+  /// Create an index expression that accesses (reads, writes) this tensor.
+  template <typename... IndexVars>
+  Access operator()(const WindowedIndexVar& first, const IndexVars&... indices);
+
+  /// Create an index expression that accesses (reads, writes) this tensor.
+  template <typename... IndexVars>
+  Access operator()(const IndexVar& first, const IndexVars&... indices);
+
   ScalarAccess<CType> operator()(const std::vector<int>& indices);
 
   /// Create an index expression that accesses (reads) this tensor.
@@ -629,6 +646,15 @@ public:
 
   /// Assign an expression to a scalar tensor.
   void operator=(const IndexExpr& expr);
+
+private:
+  /// The _access method family is the template level implementation of
+  /// Access() expressions containing mixes of IndexVar and WindowedIndexVar objects.
+  template <typename First, typename... Rest>
+  std::vector<std::shared_ptr<IndexVarInterface>> _access(const First& first, const Rest&... rest);
+  std::vector<std::shared_ptr<IndexVarInterface>> _access();
+  template <typename... Args>
+  Access _access_wrapper(const Args&... args);
 };
 
 template <typename CType>
@@ -1082,6 +1108,63 @@ template <typename CType>
 template <typename... IndexVars>
 Access Tensor<CType>::operator()(const IndexVars&... indices) {
   return TensorBase::operator()(std::vector<IndexVar>{indices...});
+}
+
+/// The _access() methods perform primitive recursion on the input variadic template.
+/// This means that each instance of the _access method matches on the first element
+/// of the variadic template parameter pack, performs an "action", then recurses
+/// with the remaining elements in the parameter pack through a recursive call
+/// to _access. Since this is recursion, we need a base case. The empty argument
+/// instance of _access returns an empty value of the desired type, in this case
+/// a vector of IndexVarInterface.
+template <typename CType>
+std::vector<std::shared_ptr<IndexVarInterface>> Tensor<CType>::_access() {
+  return std::vector<std::shared_ptr<IndexVarInterface>>{};
+}
+
+/// The recursive case of _access matches on the first element, and attempts to
+/// create a shared_ptr out of it. It then makes a recursive call to get a
+/// vector with the rest of the elements. Then, it pushes the first element onto
+/// the back of the vector -- this check ensures that the type First is indeed
+/// a member of IndexVarInterface.
+template <typename CType>
+template <typename First, typename... Rest>
+std::vector<std::shared_ptr<IndexVarInterface>> Tensor<CType>::_access(const First& first, const Rest&... rest) {
+  auto var = std::make_shared<First>(first);
+  auto ret = _access(rest...);
+  ret.push_back(var);
+  return ret;
+}
+
+/// _access_wrapper just calls into _access and reverses the result to get the initial
+/// order of the arguments.
+template <typename CType>
+template <typename... Args>
+Access Tensor<CType>::_access_wrapper(const Args&... args) {
+  auto resultReversed = this->_access(args...);
+  std::vector<std::shared_ptr<IndexVarInterface>> result;
+  result.reserve(resultReversed.size());
+  for (auto it = resultReversed.rbegin(); it != resultReversed.rend(); it++) {
+    result.push_back(*it);
+  }
+  return TensorBase::operator()(result);
+}
+
+/// We have to case on whether the first argument is an IndexVar or a WindowedIndexVar
+/// so that the template engine can differentiate between the two versions.
+// TODO (rohany): I think that there is a chance here that I might not need these
+//  two methods if I have _access. I think that instead I would just have to remove
+//  the other operator() methods that also take in IndexVar... so that there isn't
+//  any confusion.
+template <typename CType>
+template <typename... IndexVars>
+Access Tensor<CType>::operator()(const IndexVar& first, const IndexVars&... indices) {
+  return this->_access_wrapper(first, indices...);
+}
+template <typename CType>
+template <typename... IndexVars>
+Access Tensor<CType>::operator()(const WindowedIndexVar& first, const IndexVars&... indices) {
+  return this->_access_wrapper(first, indices...);
 }
 
 template <typename CType>

--- a/src/codegen/codegen_c.cpp
+++ b/src/codegen/codegen_c.cpp
@@ -516,7 +516,7 @@ void CodeGen_C::visit(const Allocate* op) {
     stream << ", ";
   }
   else {
-    stream << "malloc(";
+    stream << "calloc(1, ";
   }
   stream << "sizeof(" << elementType << ")";
   stream << " * ";

--- a/src/codegen/codegen_cuda.cpp
+++ b/src/codegen/codegen_cuda.cpp
@@ -1293,9 +1293,14 @@ void CodeGen_CUDA::visit(const Call* op) {
   stream << op->func << "(";
   parentPrecedence = Precedence::CALL;
 
-  // Need to print cast to type so that arguments match
+  // Need to print cast to type so that arguments match.
   if (op->args.size() > 0) {
-    if (op->type != op->args[0].type() || isa<Literal>(op->args[0])) {
+    // However, the binary search arguments take int* as their first
+    // argument. This pointer information isn't carried anywhere in
+    // the argument expressions, so we need to special case and not
+    // emit an invalid cast for that argument.
+    auto opIsBinarySearch = op->func == "taco_binarySearchAfter" || op->func == "taco_binarySearchBefore";
+    if (!opIsBinarySearch && (op->type != op->args[0].type() || isa<Literal>(op->args[0]))) {
       stream << "(" << printCUDAType(op->type, false) << ") ";
     }
     op->args[0].accept(this);

--- a/src/error/error_checks.cpp
+++ b/src/error/error_checks.cpp
@@ -53,6 +53,14 @@ std::pair<bool, string> dimensionsTypecheck(const std::vector<IndexVar>& resultV
     for (size_t mode = 0; mode < readNode->indexVars.size(); mode++) {
       IndexVar var = readNode->indexVars[mode];
       Dimension dimension = readNode->tensorVar.getType().getShape().getDimension(mode);
+
+      // If this access has windowed modes, use the dimensions of those windows
+      // as the shape, rather than the shape of the underlying tensor.
+      auto a = Access(readNode);
+      if (a.isModeWindowed(mode)) {
+        dimension = Dimension(a.getWindowUpperBound(mode) - a.getWindowLowerBound(mode));
+      }
+
       if (util::contains(indexVarDims,var) && indexVarDims.at(var) != dimension) {
         errors.push_back(addDimensionError(var, indexVarDims.at(var), dimension));
       } else {

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -185,7 +185,7 @@ struct Isomorphic : public IndexNotationVisitorStrict {
         return;
       }
     }
-    eq = true;
+    eq = anode->windowedModes == bnode->windowedModes;
   }
 
   void visit(const LiteralNode* anode) {
@@ -746,8 +746,8 @@ IndexExpr operator/(const IndexExpr& lhs, const IndexExpr& rhs) {
 Access::Access(const AccessNode* n) : IndexExpr(n) {
 }
 
-Access::Access(const TensorVar& tensor, const std::vector<IndexVar>& indices)
-    : Access(new AccessNode(tensor, indices)) {
+Access::Access(const TensorVar& tensor, const std::vector<IndexVar>& indices, const std::map<int, AccessWindow>& windows)
+    : Access(new AccessNode(tensor, indices, windows)) {
 }
 
 const TensorVar& Access::getTensorVar() const {
@@ -758,11 +758,45 @@ const std::vector<IndexVar>& Access::getIndexVars() const {
   return getNode(*this)->indexVars;
 }
 
+bool Access::hasWindowedModes() const {
+  return !getNode(*this)->windowedModes.empty();
+}
+
+bool Access::isModeWindowed(int mode) const {
+  auto node = getNode(*this);
+  return node->windowedModes.find(mode) != node->windowedModes.end();
+}
+
+int Access::getWindowLowerBound(int mode) const {
+  taco_iassert(this->isModeWindowed(mode));
+  return getNode(*this)->windowedModes.at(mode).lo;
+}
+
+int Access::getWindowUpperBound(int mode) const {
+  taco_iassert(this->isModeWindowed(mode));
+  return getNode(*this)->windowedModes.at(mode).hi;
+}
+
 static void check(Assignment assignment) {
-  auto tensorVar = assignment.getLhs().getTensorVar();
-  auto freeVars = assignment.getLhs().getIndexVars();
+  auto lhs = assignment.getLhs();
+  auto tensorVar = lhs.getTensorVar();
+  auto freeVars = lhs.getIndexVars();
   auto indexExpr = assignment.getRhs();
   auto shape = tensorVar.getType().getShape();
+
+  // If the LHS access has any windowed modes, use the dimensions of those
+  // windows as the shape, rather than the shape of the underlying tensor.
+  if (lhs.hasWindowedModes()) {
+    vector<Dimension> dims(shape.getOrder());
+    for (int i = 0; i < shape.getOrder();i++) {
+      dims[i] = shape.getDimension(i);
+      if (lhs.isModeWindowed(i)) {
+        dims[i] = Dimension(lhs.getWindowUpperBound(i) - lhs.getWindowLowerBound(i));
+      }
+    }
+    shape = Shape(dims);
+  }
+
   auto typecheck = error::dimensionsTypecheck(freeVars, indexExpr, shape);
   taco_uassert(typecheck.first) << error::expr_dimension_mismatch << " " << typecheck.second;
 }
@@ -1800,6 +1834,10 @@ std::string IndexVar::getName() const {
   return content->name;
 }
 
+WindowedIndexVar IndexVar::operator()(int lo, int hi) {
+  return WindowedIndexVar(*this, lo, hi);
+}
+
 bool operator==(const IndexVar& a, const IndexVar& b) {
   return a.content == b.content;
 }
@@ -1808,8 +1846,40 @@ bool operator<(const IndexVar& a, const IndexVar& b) {
   return a.content < b.content;
 }
 
+std::ostream& operator<<(std::ostream& os, const std::shared_ptr<IndexVarInterface>& var) {
+  std::stringstream ss;
+  IndexVarInterface::match(var, [&](std::shared_ptr<IndexVar> ivar) {
+    ss << *ivar;
+  }, [&](std::shared_ptr<WindowedIndexVar> wvar) {
+    ss << *wvar;
+  });
+  return os << ss.str();
+}
+
 std::ostream& operator<<(std::ostream& os, const IndexVar& var) {
   return os << var.getName();
+}
+
+std::ostream& operator<<(std::ostream& os, const WindowedIndexVar& var) {
+  return os << var.getIndexVar();
+}
+
+WindowedIndexVar::WindowedIndexVar(IndexVar base, int lo, int hi) : content( new Content){
+  this->content->base = base;
+  this->content->lo = lo;
+  this->content->hi = hi;
+}
+
+IndexVar WindowedIndexVar::getIndexVar() const {
+  return this->content->base;
+}
+
+int WindowedIndexVar::getLowerBound() const {
+  return this->content->lo;
+}
+
+int WindowedIndexVar::getUpperBound() const {
+  return this->content->hi;
 }
 
 // class TensorVar
@@ -1951,6 +2021,20 @@ static bool isValid(Assignment assignment, string* reason) {
   auto result = lhs.getTensorVar();
   auto freeVars = lhs.getIndexVars();
   auto shape = result.getType().getShape();
+
+  // If the LHS access has any windowed modes, use the dimensions of those
+  // windows as the shape, rather than the shape of the underlying tensor.
+  if (lhs.hasWindowedModes()) {
+    vector<Dimension> dims(shape.getOrder());
+    for (int i = 0; i < shape.getOrder();i++) {
+      dims[i] = shape.getDimension(i);
+      if (lhs.isModeWindowed(i)) {
+        dims[i] = Dimension(lhs.getWindowUpperBound(i) - lhs.getWindowLowerBound(i));
+      }
+    }
+    shape = Shape(dims);
+  }
+
   auto typecheck = error::dimensionsTypecheck(freeVars, rhs, shape);
   if (!typecheck.first) {
     *reason = error::expr_dimension_mismatch + " " + typecheck.second;

--- a/src/index_notation/index_notation_rewriter.cpp
+++ b/src/index_notation/index_notation_rewriter.cpp
@@ -327,7 +327,7 @@ struct ReplaceIndexVars : public IndexNotationRewriter {
       }
     }
     if (modified) {
-      expr = Access(op->tensorVar, indexVars);
+      expr = Access(op->tensorVar, indexVars, op->windowedModes);
     }
     else {
       expr = op;

--- a/src/ir/ir.cpp
+++ b/src/ir/ir.cpp
@@ -873,6 +873,15 @@ Expr GetProperty::make(Expr tensor, TensorProperty property, int mode) {
   
   return gp;
 }
+
+Expr Ternary::make(Expr cond, Expr whenTrue, Expr whenFalse) {
+  // TODO (rohany): Add in checks to make sure whenTrue and whenFalse have the same type.
+  auto node = new Ternary;
+  node->cond = cond;
+  node->whenTrue = whenTrue;
+  node->whenFalse = whenFalse;
+  return node;
+}
   
 // visitor methods
 template<> void ExprNode<Literal>::accept(IRVisitorStrict *v)
@@ -969,6 +978,8 @@ template<> void StmtNode<Sort>::accept(IRVisitorStrict *v)
   const { v->visit((const Sort*)this); }
 template<> void StmtNode<Break>::accept(IRVisitorStrict *v)
   const { v->visit((const Break*)this); }
+template<> void ExprNode<Ternary>::accept(IRVisitorStrict *v)
+  const { v->visit((const Ternary*)this); }
 
 // printing methods
 std::ostream& operator<<(std::ostream& os, const Stmt& stmt) {

--- a/src/ir/ir_printer.cpp
+++ b/src/ir/ir_printer.cpp
@@ -593,6 +593,19 @@ void IRPrinter::visit(const Sort* op) {
   stream << endl;
 }
 
+void IRPrinter::visit(const Ternary* op) {
+  // Add an outer parenthesis.
+  stream << "(";
+
+  stream << "(";
+  op->cond.accept(this);
+  stream << ") ? ";
+  op->whenTrue.accept(this);
+  stream << " : ";
+  op->whenFalse.accept(this);
+
+  stream << ")";
+}
 
 void IRPrinter::resetNameCounters() {
   // seed the unique names with all C99 keywords

--- a/src/ir/ir_rewriter.cpp
+++ b/src/ir/ir_rewriter.cpp
@@ -501,5 +501,16 @@ void IRRewriter::visit(const Sort* op) {
   }
 }
 
+void IRRewriter::visit(const Ternary* op) {
+  auto cond = rewrite(op->cond);
+  auto whenTrue = rewrite(op->whenTrue);
+  auto whenFalse = rewrite(op->whenFalse);
+  if (cond == op->cond && whenTrue == op->whenTrue && whenFalse == op->whenFalse) {
+    expr = op;
+  } else {
+    expr = Ternary::make(cond, whenTrue, whenFalse);
+  }
+}
+
 
 }}

--- a/src/ir/ir_visitor.cpp
+++ b/src/ir/ir_visitor.cpp
@@ -244,5 +244,11 @@ void IRVisitor::visit(const Sort* op) {
     e.accept(this);
 }
 
+void IRVisitor::visit(const Ternary* op) {
+  op->cond.accept(this);
+  op->whenTrue.accept(this);
+  op->whenFalse.accept(this);
+}
+
 }  // namespace ir
 }  // namespace taco

--- a/src/lower/iterator.cpp
+++ b/src/lower/iterator.cpp
@@ -28,6 +28,16 @@ struct Iterator::Content {
   ir::Expr segendVar;
   ir::Expr validVar;
   ir::Expr beginVar;
+
+  // AccessWindow represents a window (or slice) into a tensor mode, given by
+  // the expressions representing an upper and lower bound. An iterator
+  // is windowed if window is not NULL.
+  struct Window {
+      ir::Expr lo;
+      ir::Expr hi;
+      Window(ir::Expr _lo, ir::Expr _hi) : lo(_lo), hi(_hi) {};
+  };
+  std::unique_ptr<Window> window;
 };
 
 Iterator::Iterator() : content(nullptr) {
@@ -323,6 +333,24 @@ bool Iterator::defined() const {
   return content != nullptr;
 }
 
+bool Iterator::isWindowed() const {
+  return this->content->window != nullptr;
+}
+
+ir::Expr Iterator::getWindowLowerBound() const {
+  taco_iassert(this->isWindowed());
+  return this->content->window->lo;
+}
+
+ir::Expr Iterator::getWindowUpperBound() const {
+  taco_iassert(this->isWindowed());
+  return this->content->window->hi;
+}
+
+void Iterator::setWindowBounds(ir::Expr lo, ir::Expr hi) {
+  this->content->window = std::make_unique<Content::Window>(Content::Window(lo, hi));
+}
+
 bool operator==(const Iterator& a, const Iterator& b) {
   if (a.isDimensionIterator() && b.isDimensionIterator()) {
     return a.getIndexVar() == b.getIndexVar();
@@ -425,7 +453,7 @@ Iterators::Iterators(IndexStmt stmt, const map<TensorVar, Expr>& tensorVars)
     })
   );
 
-  // Reverse the levelITerators map for fast modeAccess lookup
+  // Reverse the levelIterators map for fast modeAccess lookup
   for (auto& iterator : content->levelIterators) {
     content->modeAccesses.insert({iterator.second, iterator.first});
   }
@@ -440,6 +468,8 @@ Iterators::createAccessIterators(Access access, Format format, Expr tensorIR, Pr
       << tensorConcrete << ", Format" << format;
   Shape shape = tensorConcrete.getType().getShape();
 
+  // TODO (rohany): What's the deal with this parent iterator? It seems like
+  //  I don't need to attempt to window it, because it doesn't "have" a mode.
   Iterator parent(tensorIR);
   content->levelIterators.insert({{access,0}, parent});
 
@@ -472,6 +502,15 @@ Iterators::createAccessIterators(Access access, Format format, Expr tensorIR, Pr
 
       string name = iteratorIndexVar.getName() + tensorConcrete.getName();
       Iterator iterator(iteratorIndexVar, tensorIR, mode, parent, name, true);
+
+      // If the access that this iterator corresponds to has a window, then
+      // adjust the iterator appropriately.
+      if (access.isModeWindowed(modeNumber)) {
+        auto lo = ir::Literal::make(access.getWindowLowerBound(modeNumber));
+        auto hi = ir::Literal::make(access.getWindowUpperBound(modeNumber));
+        iterator.setWindowBounds(lo, hi);
+      }
+
       content->levelIterators.insert({{access,modeNumber+1}, iterator});
       if (iteratorIndexVar != indexVar) {
         // add to allowing lowering to find correct iterator for this pos variable

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -509,6 +509,13 @@ struct AccessTensorNode : public AccessNode {
 
     tensor.setAssignment(assign);
   }
+
+  virtual AccessNode* applyFilter(const std::function<ir::Expr(ir::Expr)>& f) const {
+    auto node = new AccessTensorNode(this->tensor, indexVars);
+    node->windowedModes = this->windowedModes;
+    node->filter = f;
+    return node;
+  }
 };
 
 const Access TensorBase::operator()(const std::vector<IndexVar>& indices) const {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,3 +1,5 @@
+#include <functional>
+
 #include "test.h"
 #include "taco/tensor.h"
 
@@ -49,6 +51,20 @@ ostream& operator<<(ostream& os, const NotationTest& test) {
   os << "Expected: " << test.expected << endl;
   os << "Actual:   " << test.actual << endl;
   return os;
+}
+
+void ASSERT_THROWS_EXCEPTION_WITH_ERROR(std::function<void()> f, std::string err) {
+  EXPECT_THROW({
+    try {
+      f();
+    } catch (TacoException& e) {
+      // Catch and inspect the exception to make sure that err is within it.
+      auto s = std::string(e.what());
+      ASSERT_TRUE(s.find(err) != std::string::npos);
+      // Throw the exception back up to gtest.
+      throw;
+    }
+  }, TacoException);
 }
 
 }}

--- a/test/test.h
+++ b/test/test.h
@@ -3,6 +3,7 @@
 
 #include "gtest/gtest.h"
 
+#include <functional>
 #include <iostream>
 #include <vector>
 #include <memory>
@@ -92,6 +93,10 @@ void ASSERT_COMPONENTS_EQUALS(vector<vector<vector<int>>> expectedIndices,
   ASSERT_EQ(expectedValues.size(), nnz);
   ASSERT_ARRAY_EQ(expectedValues, {(double*)storage.getValues().getData(),nnz});
 }
+
+// ASSERT_THROWS_EXCEPTION_WITH_ERROR asserts that the input function throws
+// a TacoException with the input string err contained within the body.
+void ASSERT_THROWS_EXCEPTION_WITH_ERROR(std::function<void()> f, std::string err);
 
 struct NotationTest {
   NotationTest(IndexStmt actual, IndexStmt expected)

--- a/test/tests-filtering.cpp
+++ b/test/tests-filtering.cpp
@@ -1,0 +1,37 @@
+#include "test.h"
+#include "taco/tensor.h"
+#include "taco/codegen/module.h"
+#include "taco/index_notation/index_notation.h"
+#include "taco/lower/lower.h"
+
+using namespace taco;
+
+// A basic test that filters values in a tensor with a simple predicate.
+TEST(filtering, basic) {
+  auto dim = 10;
+  Tensor<int> a("a", {dim, dim}, {Dense, Sparse});
+  Tensor<int> b("b", {dim, dim}, {Dense, Dense});
+  Tensor<int> c("c", {dim, dim}, {Dense, Dense});
+  Tensor<int> expected("expected", {dim, dim}, {Dense, Dense});
+
+  for (int i = 0; i < dim; i++) {
+    for (int j = 0; j < dim; j++) {
+      a.insert({i, j}, i + j);
+      b.insert({i, j}, i + j);
+      if (i + j >= 5) {
+        expected.insert({i, j}, 2 * (i + j));
+      }
+    }
+  }
+  a.pack(); b.pack(); expected.pack();
+
+  // Apply a filter that elements must be larger than 5.
+  auto filter = [](ir::Expr val) {
+    return ir::Gte::make(val, ir::Literal::make(5));
+  };
+
+  IndexVar i("i"), j("j");
+  c(i, j) = (a(i, j) | filter) + (b(i, j) | filter);
+  c.evaluate();
+  ASSERT_TRUE(equals(c, expected)) << c << endl << expected << endl;
+}

--- a/test/tests-windowing.cpp
+++ b/test/tests-windowing.cpp
@@ -1,0 +1,361 @@
+#include "test.h"
+#include "taco/tensor.h"
+#include "taco/codegen/module.h"
+#include "taco/index_notation/index_notation.h"
+#include "taco/lower/lower.h"
+
+using namespace taco;
+
+// mixIndexing is a compilation test to ensure that we can index into a
+// tensor with a mix of IndexVars and WindowedIndexVars.
+TEST(windowing, mixIndexing) {
+  auto dim = 10;
+  Tensor<int> a("a", {dim, dim, dim, dim, dim}, {Dense, Dense, Dense, Dense, Dense});
+  IndexVar i, j, k, l, m;
+  auto w1 = a(i, j(1, 3), k, l(4, 5), m(6, 7));
+  auto w2 = a(i(1, 3), j(2, 4), k, l, m(3, 5));
+}
+
+TEST(windowing, boundsChecks) {
+  Tensor<int> a("a", {5}, {Dense});
+  IndexVar i("i");
+  ASSERT_THROWS_EXCEPTION_WITH_ERROR([&]() { a(i(-1, 4)); }, "slice lower bound");
+  ASSERT_THROWS_EXCEPTION_WITH_ERROR([&]() { a(i(0, 10)); }, "slice upper bound");
+}
+
+// sliceMultipleWays tests that the same tensor can be sliced in different ways
+// in the same expression.
+TEST(windowing, sliceMultipleWays) {
+  auto dim = 10;
+  Tensor<int> a("a", {dim}, {Dense});
+  Tensor<int> b("b", {dim}, {Sparse});
+  Tensor<int> c("c", {dim}, {Dense});
+  Tensor<int> expected("expected", {dim}, {Dense});
+  for (int i = 0; i < dim; i++) {
+    a.insert({i}, i);
+    b.insert({i}, i);
+  }
+  expected.insert({2}, 10);
+  expected.insert({3}, 13);
+  a.pack(); b.pack(); expected.pack();
+  IndexVar i("i"), j("j");
+
+  c(i(2, 4)) = a(i(5, 7)) + a(i(1, 3)) + b(i(4, 6));
+  c.evaluate();
+  ASSERT_TRUE(equals(expected, c));
+}
+
+// basic tests a windowed tensor expression with different combinations
+// of tensor formats.
+TEST(windowing, basic) {
+  Tensor<int> expectedAdd("expectedAdd", {2, 2}, {Dense, Dense});
+  expectedAdd.insert({0, 0}, 14);
+  expectedAdd.insert({0, 1}, 17);
+  expectedAdd.insert({1, 0}, 17);
+  expectedAdd.insert({1, 1}, 20);
+  expectedAdd.pack();
+  Tensor<int> expectedMul("expectedMul", {2, 2}, {Dense, Dense});
+  expectedMul.insert({0, 0}, 64);
+  expectedMul.insert({0, 1}, 135);
+  expectedMul.insert({1, 0}, 135);
+  expectedMul.insert({1, 1}, 240);
+  expectedMul.pack();
+  Tensor<int> d("d", {2, 2}, {Dense, Dense});
+
+  // These dimensions are chosen so that one is above the constant in `mode_format_dense.cpp:54`
+  // where the known stride is generated vs using the dimension.
+  // TODO (rohany): Change that constant to be in a header file and import it here.
+  for (auto& dim : {6, 20}) {
+    for (auto &x : {Dense, Sparse}) {
+      for (auto &y : {Dense, Sparse}) {
+        for (auto &z : {Dense, Sparse}) {
+          Tensor<int> a("a", {dim, dim}, {Dense, x});
+          Tensor<int> b("b", {dim, dim}, {Dense, y});
+          Tensor<int> c("c", {dim, dim}, {Dense, z});
+          for (int i = 0; i < dim; i++) {
+            for (int j = 0; j < dim; j++) {
+              a.insert({i, j}, i + j);
+              b.insert({i, j}, i + j);
+              c.insert({i, j}, i + j);
+            }
+          }
+
+          a.pack();
+          b.pack();
+          c.pack();
+
+          IndexVar i, j;
+          d(i, j) = a(i(2, 4), j(2, 4)) + b(i(4, 6), j(4, 6)) + c(i(1, 3), j(1, 3));
+          d.evaluate();
+          ASSERT_TRUE(equals(expectedAdd, d))
+                        << endl << expectedAdd << endl << endl << d << endl
+                        << dim << " " << x << " " << y << " " << z << endl;
+
+          d(i, j) = a(i(2, 4), j(2, 4)) * b(i(4, 6), j(4, 6)) * c(i(1, 3), j(1, 3));
+          d.evaluate();
+          ASSERT_TRUE(equals(expectedMul, d))
+                        << endl << expectedMul << endl << endl << d << endl
+                        << dim << " " << x << " " << y << " " << z << endl;
+        }
+      }
+    }
+  }
+}
+
+// slicedOutput tests that operations can write to a window within an output tensor.
+TEST(windowing, slicedOutput) {
+  auto dim = 10;
+  Tensor<int> expected("expected", {10, 10}, {Dense, Dense});
+  expected.insert({8, 8}, 12);
+  expected.insert({8, 9}, 14);
+  expected.insert({9, 8}, 14);
+  expected.insert({9, 9}, 16);
+  expected.pack();
+  for (auto& x : {Dense, Sparse}) {
+    for (auto& y : {Dense, Sparse}) {
+      Tensor<int> a("a", {dim, dim}, {Dense, x});
+      Tensor<int> b("b", {dim, dim}, {Dense, y});
+      Tensor<int> c("c", {dim, dim}, {Dense, Dense});
+      for (int i = 0; i < dim; i++) {
+        for (int j = 0; j < dim; j++) {
+          a.insert({i, j}, i + j);
+          b.insert({i, j}, i + j);
+        }
+      }
+      a.pack();
+      b.pack();
+
+      IndexVar i, j;
+      c(i(8, 10), j(8, 10)) = a(i(2, 4), j(2, 4)) + b(i(4, 6), j(4, 6));
+      c.evaluate();
+      ASSERT_TRUE(equals(expected, c))
+                    << endl << expected << endl << endl << c << endl
+                    << dim << " " << x << " " << y << endl;
+    }
+  }
+}
+
+// matrixMultiple tests a matrix multiply, and in the process is testing
+// windowing on expressions that contain reductions.
+TEST(windowing, matrixMultiply) {
+  auto dim = 10;
+  auto windowDim = 4;
+
+  Tensor<int> a("a", {windowDim, windowDim}, {Dense, Dense});
+  Tensor<int> b("b", {windowDim, windowDim}, {Dense, Dense});
+  Tensor<int> c("c", {windowDim, windowDim}, {Dense, Dense});
+  Tensor<int> expected("expected", {windowDim, windowDim}, {Dense, Dense});
+
+  for (auto& x : {Dense, Sparse}) {
+    for (auto& y : {Dense, Sparse}) {
+      Tensor<int> aw("aw", {dim, dim}, {Dense, x});
+      Tensor<int> bw("bw", {dim, dim}, {Dense, y});
+      for (int i = 0; i < dim; i++) {
+        for (int j = 0; j < dim; j++) {
+          aw.insert({i, j}, i + j);
+          bw.insert({i, j}, i + j);
+        }
+      }
+      aw.pack(); bw.pack();
+
+      IndexVar i("i"), j("j"), k("k");
+      // Evaluate the windowed matrix multiply.
+      c(i, k) = aw(i(4, 8), j(2, 6)) * bw(j(0, 4), k(6, 10));
+      c.evaluate();
+
+      // Copy the windowed portions of aw and bw into separate tensors, and test
+      // that the un-windowed matrix multiplication has the same results.
+      a(i, j) = aw(i(4, 8), j(2, 6));
+      a.evaluate();
+      b(i, j) = bw(i(0, 4), j(6, 10));
+      b.evaluate();
+      expected(i, k) = a(i, j) * b(j, k);
+      expected.evaluate();
+
+      ASSERT_TRUE(equals(expected, c)) << expected << endl << c << endl;
+    }
+  }
+}
+
+// workspace tests that workspaces can be assigned to and used in computations
+// that involve windowed tensors.
+TEST(windowing, workspace) {
+  auto dim = 10;
+  size_t windowDim = 4;
+  Tensor<int> d("d", {static_cast<int>(windowDim)}, {Dense});
+  Tensor<int> expected("expected", {static_cast<int>(windowDim)}, {Dense});
+  expected.insert({0}, 8); expected.insert({1}, 11);
+  expected.insert({2}, 14); expected.insert({3}, 17);
+  expected.pack();
+
+  for (auto& x : {Dense, Sparse}) {
+    for (auto& y : {Dense, Sparse}) {
+      Tensor<int> a("a", {dim}, {x});
+      Tensor<int> b("b", {dim}, {y});
+      Tensor<int> c("c", {dim}, {Dense});
+      for (int i = 0; i < dim; i++) {
+        a.insert({i}, i);
+        b.insert({i}, i);
+        c.insert({i}, i);
+      }
+      a.pack();
+      b.pack();
+      c.pack();
+      IndexVar i("i");
+      TensorVar p("p", Type(Int(), {windowDim}), Dense);
+      auto precomputed = a(i(2, 6)) + b(i(6, 10));
+      d(i) = precomputed + c(i(0, 4));
+      auto stmt = d.getAssignment().concretize();
+      stmt = stmt.precompute(precomputed, i, i, p);
+      d.compile(stmt.concretize());
+      d.evaluate();
+      ASSERT_TRUE(equals(d, expected)) << expected << endl << d << endl;
+    }
+  }
+}
+
+// transformations tests how windowing interacts with sparse iteration space
+// transformations and different mode formats.
+TEST(windowing, transformations) {
+  auto dim = 10;
+  Tensor<int> expected("expected", {2, 2}, {Dense, Dense});
+  expected.insert({0, 0}, 12);
+  expected.insert({0, 1}, 14);
+  expected.insert({1, 0}, 14);
+  expected.insert({1, 1}, 16);
+  expected.pack();
+
+  IndexVar i("i"), j("j"), i1 ("i1"), i2 ("i2");
+  auto testFn = [&](std::function<IndexStmt(IndexStmt)> modifier, std::vector<Format> formats) {
+    for (auto& format : formats) {
+      Tensor<int> a("a", {dim, dim}, format);
+      Tensor<int> b("b", {dim, dim}, format);
+      for (int i = 0; i < dim; i++) {
+        for (int j = 0; j < dim; j++) {
+          a.insert({i, j}, i + j);
+          b.insert({i, j}, i + j);
+        }
+      }
+      a.pack(); b.pack();
+
+      Tensor<int> c("c", {2, 2}, {Dense, Dense});
+      c(i, j) = a(i(2, 4), j(2, 4)) + b(i(4, 6), j(4, 6));
+      auto stmt = c.getAssignment().concretize();
+      c.compile(modifier(stmt));
+      c.evaluate();
+      equals(c, expected);
+      ASSERT_TRUE(equals(c, expected)) << endl << c << endl << expected << endl << format << endl;
+    }
+  };
+
+  std::vector<Format> allFormats = {{Dense, Dense}, {Dense, Sparse}, {Sparse, Dense}, {Sparse, Sparse}};
+  testFn([&](IndexStmt stmt) {
+    return stmt.split(i, i1, i2, 4).unroll(i2, 4);
+ }, allFormats);
+
+  // TODO (rohany): Can we only reorder these loops in the Dense,Dense case? It seems so.
+  testFn([&](IndexStmt stmt) {
+    return stmt.reorder(i, j);
+  }, {{Dense, Dense}});
+
+  // We can only (currently) parallelize the outer dimension loop if it is dense.
+  testFn([&](IndexStmt stmt) {
+    return stmt.parallelize(i, taco::ParallelUnit::CPUThread, taco::OutputRaceStrategy::NoRaces);
+  }, {{Dense, Dense}, {Dense, Sparse}});
+}
+
+// assignment tests assignments of and to windows in different combinations.
+TEST(windowing, assignment) {
+  auto dim = 10;
+
+  auto testFn = [&](Format srcFormat) {
+    Tensor<int> A("A", {dim, dim}, srcFormat);
+
+    for (int i = 0; i < dim; i++) {
+      for (int j = 0; j < dim; j++) {
+        A.insert({i, j}, i + j);
+      }
+    }
+    A.pack();
+
+    IndexVar i, j;
+
+    // First assign a window of A to a window of B.
+    Tensor<int> B("B", {dim, dim}, {Dense, Dense});
+    B(i(2, 4), j(3, 5)) = A(i(4, 6), j(5, 7));
+    B.evaluate();
+    Tensor<int> expected("expected", {dim, dim}, {Dense, Dense});
+    expected.insert({2, 3}, 9); expected.insert({2, 4}, 10);
+    expected.insert({3, 3}, 10); expected.insert({3, 4}, 11);
+    expected.pack();
+    ASSERT_TRUE(equals(B, expected)) << B << std::endl << expected << std::endl;
+
+    // Assign a window of A to b.
+    B = Tensor<int>("B", {2, 2}, {Dense, Dense});
+    B(i, j) = A(i(4, 6), j(5, 7));
+    B.evaluate();
+    expected = Tensor<int>("expected", {2, 2}, {Dense, Dense});
+    expected.insert({0, 0}, 9); expected.insert({0, 1}, 10);
+    expected.insert({1, 0}, 10); expected.insert({1, 1}, 11);
+    expected.pack();
+    ASSERT_TRUE(equals(B, expected)) << B << std::endl << expected << std::endl;
+
+    // Assign A to a window of B.
+    A = Tensor<int>("A", {2, 2}, srcFormat);
+    A.insert({0, 0}, 0); A.insert({0, 1}, 1);
+    A.insert({1, 0}, 1); A.insert({1, 1}, 2);
+    A.pack();
+    B = Tensor<int>("B", {dim, dim}, {Dense, Dense});
+    B(i(4, 6), j(5, 7)) = A(i, j);
+    B.evaluate();
+    expected = Tensor<int>("expected", {dim, dim}, {Dense, Dense});
+    expected.insert({4, 5}, 0); expected.insert({4, 6}, 1);
+    expected.insert({5, 5}, 1); expected.insert({5, 6}, 2);
+    expected.pack();
+    ASSERT_TRUE(equals(B, expected)) << B << std::endl << expected << std::endl;
+  };
+
+  for (auto& x : {Dense, Sparse}) {
+    testFn({Dense, x});
+  }
+}
+
+TEST(windowing, cuda) {
+  if (!should_use_CUDA_codegen()) {
+    return;
+  }
+  auto dim = 10;
+  Tensor<int> expected("expected", {2, 2}, {Dense, Dense});
+  expected.insert({0, 0}, 12); expected.insert({0, 1}, 14);
+  expected.insert({1, 0}, 14); expected.insert({1, 1}, 16);
+  expected.pack();
+
+  for (auto& x : {Dense, Sparse}) {
+    for (auto& y : {Dense, Sparse}) {
+      Tensor<int> a("a", {dim, dim}, {Dense, x});
+      Tensor<int> b("b", {dim, dim}, {Dense, y});
+      Tensor<int> c("c", {2, 2}, {Dense, Dense});
+
+      for (int i = 0; i < dim; i++) {
+        for (int j = 0; j < dim; j++) {
+          a.insert({i, j}, i + j);
+          b.insert({i, j}, i + j);
+        }
+      }
+      a.pack(); b.pack();
+
+      IndexVar i("i"), j("j"), i1("i1"), i2("i2"), i3("i3"), i4("i4");
+      c(i, j) = a(i(4, 6), j(4, 6)) + b(i(2, 4), j(2, 4));
+      auto stmt = c.getAssignment().concretize();
+      stmt = stmt.split(i, i1, i2, 512)
+                 .split(i2, i3, i4, 32)
+                 .parallelize(i1, ParallelUnit::GPUBlock, OutputRaceStrategy::NoRaces)
+                 .parallelize(i3, ParallelUnit::GPUWarp, OutputRaceStrategy::NoRaces)
+                 .parallelize(i4, ParallelUnit::GPUThread, OutputRaceStrategy::NoRaces);
+
+      c.compile(stmt);
+      c.evaluate();
+      ASSERT_TRUE(equals(c, expected)) << c << endl << expected << endl;
+    }
+  }
+}


### PR DESCRIPTION
This commit adds the ability to perform filtering operations (similar to
Numpy's boolean filtering). An example of this is below:

```
// Construct a filtering function that selects values != 1.
auto filter = [](ir::Expr var) {
  return ir::Neq::make(var, ir::Literal::make(1));
}
// Add together all elements in b and c that aren't equal to 1.
a(i) = (b(i) | filter) + (c(i) | filter);
```

Note that this functionality only works when we can assume that the zero
element is both an identity and an annihilator for the group that the
algebra is defined over.