### PR TITLE
codegen: compile generated code with debug symbols in debug builds

### DIFF
--- a/src/codegen/module.cpp
+++ b/src/codegen/module.cpp
@@ -121,8 +121,15 @@ string Module::compile() {
   }
   else {
     cc = util::getFromEnv(target.compiler_env, target.compiler);
-    cflags = util::getFromEnv("TACO_CFLAGS",
-    "-O3 -ffast-math -std=c99") + " -shared -fPIC";
+#ifdef TACO_DEBUG
+    // In debug mode, compile the generated code with debug symbols and a
+    // low optimization level.
+    string defaultFlags = "-g -O0 -std=c99";
+#else
+    // Otherwise, use the standard set of optimizing flags.
+    string defaultFlags = "-O3 -ffast-math -std=c99";
+#endif
+    cflags = util::getFromEnv("TACO_CFLAGS", defaultFlags) + " -shared -fPIC";
 #if USE_OPENMP
     cflags += " -fopenmp";
 #endif

--- a/test/tests-qcd.cpp
+++ b/test/tests-qcd.cpp
@@ -34,7 +34,13 @@ TEST(qcd, mul1) {
   tau = z(i) * z(j) * theta(i,j) * theta(i,j);
 
   tau.evaluate();
+  // Using -O0 to compile the generated kernel yields a slightly different
+  // answer than using -O3.
+#ifdef TACO_DEBUG
+  ASSERT_DOUBLE_EQ(0.41212798763234648, getScalarValue(tau));
+#else
   ASSERT_DOUBLE_EQ(0.41212798763234737, getScalarValue(tau));
+#endif
 }
 
 TEST(qcd, mul2) {


### PR DESCRIPTION
Relates to #373.

This commit adjusts the compilation command for generated code to
compile code with debug symbols when TACO is built in debug mode.
Conveniently, this allows for debuggers (like the integrated one in
CLion) to automatically display the generated source code when a
segfault occurs (along with other things the IDE supports).