### PR TITLE
Add code coverage targets to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,8 @@ endif()
 project(taco)
 option(CUDA "Build for NVIDIA GPU (CUDA must be preinstalled)" OFF)
 option(PYTHON "Build TACO for python environment" OFF)
-option(OPENMP" Build with OpenMP execution support" OFF)
+option(OPENMP "Build with OpenMP execution support" OFF)
+option(COVERAGE "Build with code coverage analysis" OFF)
 if(CUDA)
   message("-- Searching for CUDA Installation")
   find_package(CUDA REQUIRED)
@@ -75,6 +76,15 @@ if(OPENMP)
   set(C_CXX_FLAGS "-fopenmp ${C_CXX_FLAGS}")
 endif(OPENMP)
 
+if(COVERAGE)
+  find_program(PATH_TO_GCOVR gcovr REQUIRED)
+  # add coverage tooling to build flags
+  set(C_CXX_FLAGS "${C_CXX_FLAGS} -g -fprofile-arcs -ftest-coverage")
+  # name the coverage files "foo.gcno", not "foo.cpp.gcno"
+  set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
+  message("-- Code coverage analysis (gcovr) enabled")
+endif(COVERAGE)
+
 set(C_CXX_FLAGS "${C_CXX_FLAGS}")
 set(CMAKE_C_FLAGS "${C_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${C_CXX_FLAGS} -std=c++14")
@@ -103,3 +113,23 @@ if(PYTHON)
 endif(PYTHON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmissing-declarations")
 add_custom_target(src DEPENDS apps)
+
+if(COVERAGE)
+  # code coverage analysis target
+  add_custom_target(gcovr
+    COMMAND mkdir -p coverage
+    COMMAND ${CMAKE_MAKE_PROGRAM} test
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+  add_custom_command(TARGET gcovr
+    COMMAND echo "Running gcovr..."
+    COMMAND ${PATH_TO_GCOVR} -r ${CMAKE_SOURCE_DIR} --html --html-details -o coverage/index.html ${CMAKE_BINARY_DIR}
+    COMMAND echo "See coverage/index.html for coverage information."
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+  add_dependencies(gcovr taco-test)
+  if(PYTHON)
+    add_dependencies(gcovr core_modules)
+  endif(PYTHON)
+  set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES coverage)
+endif(COVERAGE)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,25 @@ To run the Python test suite individually:
     python3 build/python_bindings/unit_tests.py
 
 
+## Code coverage analysis
+
+To enable code coverage analysis, configure with `-DCOVERAGE=ON`.  This requires
+the `gcovr` tool to be installed in your PATH.
+
+For best results, the build type should be set to `Debug`.  For example:
+
+    cmake -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=ON ..
+
+Then to run code coverage analysis:
+
+    make gcovr
+
+This will run the test suite and produce some coverage analysis.  This process
+requires that the tests pass, so any failures must be fixed first.
+If all goes well, coverage results will be output to the `coverage/` folder.
+See `coverage/index.html` for a high level report, and click individual files
+to see the line-by-line results.
+
 # Library example
 
 The following sparse tensor-times-vector multiplication example in C++


### PR DESCRIPTION
There are some gaps in our test coverage.  This makes them visible.

This PR adds an easy way to run a code coverage analysis tool, showing you which parts of the code are being exercised by the test suite.  It requires the `gcovr` tool to be installed.  Its presence is detected during the config phase.

To use it:

```
mkdir build
cd build
cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCOVERAGE=ON ..
make gcovr
google-chrome coverage/index.html
```

The index page looks like this:

![image](https://user-images.githubusercontent.com/50254/106025012-5ad1ec80-6096-11eb-9fd2-9a3751f3ee9a.png)

Clicking on a filename gives you a line-by-line analysis.

![image](https://user-images.githubusercontent.com/50254/106025509-ce73f980-6096-11eb-9032-0da15a50137d.png)
