### PR TITLE
Fix warnings in Release builds

### DIFF
--- a/src/codegen/codegen_cuda.cpp
+++ b/src/codegen/codegen_cuda.cpp
@@ -1424,8 +1424,7 @@ void CodeGen_CUDA::visit(const Store* op) {
       } else if (isa<Add>(op->data)) {
         auto add = to<Add>(op->data);
         taco_iassert(isa<Load>(add->a));
-        auto load = to<Load>(add->a);
-        taco_iassert(load->arr == op->arr && load->loc == op->loc);
+        taco_iassert(to<Load>(add->a)->arr == op->arr && to<Load>(add->a)->loc == op->loc);
         if (deviceFunctionLoopDepth == 0 || op->atomic_parallel_unit == ParallelUnit::GPUWarp) {
           // use atomicAddWarp
           doIndent();
@@ -1454,8 +1453,7 @@ void CodeGen_CUDA::visit(const Store* op) {
       } else if (isa<BitOr>(op->data)) {
         auto bitOr = to<BitOr>(op->data);
         taco_iassert(isa<Load>(bitOr->a));
-        auto load = to<Load>(bitOr->a);
-        taco_iassert(load->arr == op->arr && load->loc == op->loc);
+        taco_iassert(to<Load>(bitOr->a)->arr == op->arr && to<Load>(bitOr->a)->loc == op->loc);
 
         doIndent();
         stream << "atomicOr(&";

--- a/src/lower/lowerer_impl.cpp
+++ b/src/lower/lowerer_impl.cpp
@@ -1075,9 +1075,14 @@ Stmt LowererImpl::lowerForallFusedPosition(Forall forall, Iterator iterator,
   if (underivedAncestors.size() > 1) {
     // each underived ancestor is initialized to min coordinate bound
     IndexVar posIteratorVar;
+#if TACO_ASSERTS
     bool hasIteratorAncestor = provGraph.getPosIteratorAncestor(
         iterator.getIndexVar(), &posIteratorVar);
     taco_iassert(hasIteratorAncestor);
+#else /* !TACO_ASSERTS */
+    provGraph.getPosIteratorAncestor(
+        iterator.getIndexVar(), &posIteratorVar);
+#endif /* TACO_ASSERTS */
     // get pos variable then search for leveliterators to find the corresponding iterator
 
     Iterator posIterator;


### PR DESCRIPTION
Fix a few warnings that appear with `-DCMAKE_BUILD_TYPE=Release`.

```
/home/infinoid/workspace/taco/git/src/codegen/codegen_cuda.cpp: In member function ‘virtual void taco::ir::CodeGen_CUDA::visit(const taco::ir::Store*)’:
/home/infinoid/workspace/taco/git/src/codegen/codegen_cuda.cpp:1427:14: warning: unused variable ‘load’ [-Wunused-variable]
 1427 |         auto load = to<Load>(add->a);
      |              ^~~~
/home/infinoid/workspace/taco/git/src/codegen/codegen_cuda.cpp:1457:14: warning: unused variable ‘load’ [-Wunused-variable]
 1457 |         auto load = to<Load>(bitOr->a);
      |              ^~~~
/home/infinoid/workspace/taco/git/src/lower/lowerer_impl.cpp: In member function ‘virtual taco::ir::Stmt taco::LowererImpl::lowerForallFusedPosition(taco::Forall, taco::Iterator, std::vector<taco::Iterator>, std::vector<taco::Iterator>, std::vector<taco::Iterator>, std::set<taco::Access>, taco::ir::Stmt)’:
/home/infinoid/workspace/taco/git/src/lower/lowerer_impl.cpp:1078:10: warning: unused variable ‘hasIteratorAncestor’ [-Wunused-variable]
 1078 |     bool hasIteratorAncestor = provGraph.getPosIteratorAncestor(
      |          ^~~~~~~~~~~~~~~~~~~
```

In Release builds, `taco_iassert()` is a noop, thus vars only used in the assert are unused.