### PR TITLE
index_notation: implement the `divide` transformation

### DIFF
--- a/include/taco/index_notation/provenance_graph.h
+++ b/include/taco/index_notation/provenance_graph.h
@@ -3,7 +3,7 @@
 
 namespace taco {
 struct IndexVarRelNode;
-enum IndexVarRelType {UNDEFINED, SPLIT, POS, FUSE, BOUND, PRECOMPUTE};
+enum IndexVarRelType {UNDEFINED, SPLIT, DIVIDE, POS, FUSE, BOUND, PRECOMPUTE};
 
 /// A pointer class for IndexVarRelNodes provides some operations for all IndexVarRelTypes
 class IndexVarRel : public util::IntrusivePtr<const IndexVarRelNode> {
@@ -110,6 +110,59 @@ private:
 };
 
 bool operator==(const SplitRelNode&, const SplitRelNode&);
+
+// DivideRelNode takes a parentVar's iteration space and divides it into divFactor
+// equal pieces. outerVar iterates over the number of pieces, and innerVar iterates
+// over each piece.
+  struct DivideRelNode : public IndexVarRelNode {
+    DivideRelNode(IndexVar parentVar, IndexVar outerVar, IndexVar innerVar, size_t divFactor);
+
+    const IndexVar &getParentVar() const;
+
+    const IndexVar &getOuterVar() const;
+
+    const IndexVar &getInnerVar() const;
+
+    const size_t &getDivFactor() const;
+
+    void print(std::ostream &stream) const;
+
+    bool equals(const DivideRelNode &rel) const;
+
+    std::vector<IndexVar> getParents() const; // parentVar
+    std::vector<IndexVar> getChildren() const; // outerVar, innerVar
+    std::vector<IndexVar> getIrregulars() const; // innerVar
+
+    // computeRelativeBound performs similar logic to SplitRelNode::computeRelativeBound.
+    std::vector<ir::Expr>
+    computeRelativeBound(std::set<IndexVar> definedVars, std::map<IndexVar, std::vector<ir::Expr>> computedBounds,
+                         std::map<IndexVar, ir::Expr> variableExprs, Iterators iterators,
+                         ProvenanceGraph provGraph) const;
+
+    /// outerVar has bounds 0 -> divFactor and innerVar has parentBounds / divFactor.
+    std::vector<ir::Expr>
+    deriveIterBounds(IndexVar indexVar, std::map<IndexVar, std::vector<ir::Expr>> parentIterBounds,
+                     std::map<IndexVar, std::vector<ir::Expr>> parentCoordBounds,
+                     std::map<taco::IndexVar, taco::ir::Expr> variableNames, Iterators iterators,
+                     ProvenanceGraph provGraph) const;
+
+    /// parentVar = outerVar * (parentBounds / divFactor) + innerVar.
+    ir::Expr recoverVariable(IndexVar indexVar, std::map<IndexVar, ir::Expr> variableNames, Iterators iterators,
+                             std::map<IndexVar, std::vector<ir::Expr>> parentIterBounds,
+                             std::map<IndexVar, std::vector<ir::Expr>> parentCoordBounds,
+                             ProvenanceGraph provGraph) const;
+
+    /// outerVar = parentVar / (parentBounds / divFactor), innerVar = parentVar - outerVar * (parentBounds / divFactor).
+    ir::Stmt
+    recoverChild(IndexVar indexVar, std::map<IndexVar, ir::Expr> relVariables, bool emitVarDecl, Iterators iterators,
+                 ProvenanceGraph provGraph) const;
+
+  private:
+    struct Content;
+    std::shared_ptr<Content> content;
+  };
+
+bool operator==(const DivideRelNode&, const DivideRelNode&);
 
 /// The Pos relation maps an index variable to the position space of a given access
 struct PosRelNode : public IndexVarRelNode {
@@ -343,11 +396,16 @@ public:
   ir::Expr recoverVariable(IndexVar indexVar, std::vector<IndexVar> definedVarOrder, std::map<IndexVar, std::vector<ir::Expr>> underivedBounds, std::map<IndexVar, ir::Expr> childVariables, Iterators iterators) const;
 
   /// Recover a child from other variables in relationship ex. split inner from parent and outer
-  /// emitVarDecl = whether to emit new variables or just assign values to existign variables
+  /// emitVarDecl = whether to emit new variables or just assign values to existing variables.
   ir::Stmt recoverChild(IndexVar indexVar, std::map<IndexVar, ir::Expr> relVariables, bool emitVarDecl, Iterators iterators) const;
 
   /// Retrieves set of all index variables
   std::set<IndexVar> getAllIndexVars() const;
+
+  /// isDivided returns whether or not the target IndexVar was divided through
+  /// a `.divide` scheduling operation.
+  bool isDivided(IndexVar indexVar) const;
+
 private:
   std::map<IndexVar, IndexVarRel> childRelMap;
   std::map<IndexVar, IndexVarRel> parentRelMap;

--- a/src/index_notation/provenance_graph.cpp
+++ b/src/index_notation/provenance_graph.cpp
@@ -30,6 +30,9 @@ void IndexVarRel::print(std::ostream& stream) const {
       case SPLIT:
         getNode<SplitRelNode>()->print(stream);
         break;
+      case DIVIDE:
+        getNode<DivideRelNode>()->print(stream);
+        break;
       case POS:
         getNode<PosRelNode>()->print(stream);
         break;
@@ -56,12 +59,12 @@ bool IndexVarRel::equals(const IndexVarRel &rel) const {
   switch(getRelType()) {
     case SPLIT:
       return getNode<SplitRelNode>()->equals(*rel.getNode<SplitRelNode>());
+    case DIVIDE:
+      return getNode<DivideRelNode>()->equals(*rel.getNode<DivideRelNode>());
     case POS:
       return getNode<PosRelNode>()->equals(*rel.getNode<PosRelNode>());
-      break;
     case FUSE:
       return getNode<FuseRelNode>()->equals(*rel.getNode<FuseRelNode>());
-      break;
     case UNDEFINED:
       return true;
     case BOUND:
@@ -259,6 +262,145 @@ ir::Stmt SplitRelNode::recoverChild(taco::IndexVar indexVar,
 }
 
 bool operator==(const SplitRelNode& a, const SplitRelNode& b) {
+  return a.equals(b);
+}
+
+struct DivideRelNode::Content {
+  IndexVar parentVar;
+  IndexVar outerVar;
+  IndexVar innerVar;
+  size_t divFactor;
+};
+
+DivideRelNode::DivideRelNode(IndexVar parentVar, IndexVar outerVar, IndexVar innerVar, size_t divFactor)
+  : IndexVarRelNode(DIVIDE), content(new Content) {
+  content->parentVar = parentVar;
+  content->outerVar = outerVar;
+  content->innerVar = innerVar;
+  content->divFactor = divFactor;
+}
+
+const IndexVar& DivideRelNode::getParentVar() const {
+  return content->parentVar;
+}
+const IndexVar& DivideRelNode::getOuterVar() const {
+  return content->outerVar;
+}
+const IndexVar& DivideRelNode::getInnerVar() const {
+  return content->innerVar;
+}
+const size_t& DivideRelNode::getDivFactor() const {
+  return content->divFactor;
+}
+
+void DivideRelNode::print(std::ostream &stream) const {
+  stream << "divide(" << getParentVar() << ", " << getOuterVar() << ", " << getInnerVar() << ", " << getDivFactor() << ")";
+}
+
+bool DivideRelNode::equals(const DivideRelNode &rel) const {
+  return getParentVar() == rel.getParentVar() && getOuterVar() == rel.getOuterVar() &&
+    getInnerVar() == rel.getInnerVar() && getDivFactor() == rel.getDivFactor();
+}
+
+std::vector<IndexVar> DivideRelNode::getParents() const {
+  return {getParentVar()};
+}
+
+std::vector<IndexVar> DivideRelNode::getChildren() const {
+  return {getOuterVar(), getInnerVar()};
+}
+
+std::vector<IndexVar> DivideRelNode::getIrregulars() const {
+  return {getOuterVar()};
+}
+
+std::vector<ir::Expr> DivideRelNode::computeRelativeBound(std::set<IndexVar> definedVars, std::map<IndexVar, std::vector<ir::Expr>> computedBounds, std::map<IndexVar, ir::Expr> variableExprs, Iterators iterators, ProvenanceGraph provGraph) const {
+  taco_iassert(computedBounds.count(getParentVar()) == 1);
+  std::vector<ir::Expr> parentBound = computedBounds.at(getParentVar());
+  bool outerVarDefined = definedVars.count(getOuterVar());
+  bool innerVarDefined = definedVars.count(getInnerVar());
+
+  if (provGraph.isPosVariable(getParentVar()) || !outerVarDefined) {
+    return parentBound; // splitting pos space does not change coordinate bounds
+  }
+
+  auto divFactorType = variableExprs[getParentVar()].type();
+  auto divFactor = ir::Literal::make(getDivFactor(), divFactorType);
+  auto divFactorMinusOne = ir::Literal::make(getDivFactor() - 1, divFactorType);
+  auto dimLen = ir::Div::make(ir::Add::make(parentBound[1], divFactorMinusOne), divFactor);
+
+  if(!innerVarDefined) {
+    // outerVar constraints the space to a length parentBounds / divFactor strip starting at
+    // outerVar * parentBounds / divFactor.
+    auto lower = ir::Mul::make(variableExprs[getOuterVar()], dimLen);
+    auto upper = ir::Mul::make(ir::Add::make(variableExprs[getOuterVar()], 1), dimLen);
+    return {lower, upper};
+  } else {
+    taco_iassert(outerVarDefined && innerVarDefined);
+    // outerVar and innerVar constrain space to a length 1 strip starting at
+    // outerVar * parentBounds + innerVar.
+    auto lower = ir::Add::make(ir::Mul::make(variableExprs[getOuterVar()], dimLen), variableExprs[getInnerVar()]);
+    auto upper = ir::Min::make(parentBound[1], ir::Add::make(lower, 1));
+    return {lower, upper};
+  }
+}
+
+std::vector<ir::Expr> DivideRelNode::deriveIterBounds(taco::IndexVar indexVar,
+                                                     std::map<IndexVar, std::vector<ir::Expr>> parentIterBounds,
+                                                     std::map<IndexVar, std::vector<ir::Expr>> parentCoordBounds,
+                                                     std::map<taco::IndexVar, taco::ir::Expr> variableNames,
+                                                     Iterators iterators, ProvenanceGraph provGraph) const {
+  taco_iassert(indexVar == getOuterVar() || indexVar == getInnerVar());
+  taco_iassert(parentIterBounds.size() == 1);
+  taco_iassert(parentIterBounds.count(getParentVar()) == 1);
+
+  std::vector<ir::Expr> parentBound = parentIterBounds.at(getParentVar());
+  Datatype divFactorType = parentBound[0].type();
+  auto divFactor = ir::Literal::make(getDivFactor(), divFactorType);
+  if (indexVar == getOuterVar()) {
+    // The loop has been divided into divFactor pieces, so the outer variable
+    // ranges from 0 to divFactor.
+    ir::Expr minBound = 0;
+    ir::Expr maxBound = divFactor;
+    return {minBound, maxBound};
+  }
+  else if (indexVar == getInnerVar()) {
+    // The inner loop ranges over a chunk of size parentBound / divFactor.
+    ir::Expr minBound = ir::Div::make(parentBound[0], divFactor);
+    ir::Expr maxBound = ir::Div::make(ir::Add::make(parentBound[1], ir::Literal::make(getDivFactor()-1, divFactorType)), divFactor);
+    return {minBound, maxBound};
+  }
+  taco_ierror;
+  return {};
+}
+
+ir::Expr DivideRelNode::recoverVariable(taco::IndexVar indexVar,
+                                       std::map<taco::IndexVar, taco::ir::Expr> variableNames,
+                                       Iterators iterators, std::map<IndexVar, std::vector<ir::Expr>> parentIterBounds, std::map<IndexVar, std::vector<ir::Expr>> parentCoordBounds, ProvenanceGraph provGraph) const {
+  taco_iassert(indexVar == getParentVar());
+  taco_iassert(variableNames.count(getParentVar()) && variableNames.count(getOuterVar()) && variableNames.count(getInnerVar()));
+  // Extract divFactor and divFactor - 1.
+  Datatype divFactorType = variableNames[getParentVar()].type();
+  auto divFactor = ir::Literal::make(getDivFactor(), divFactorType);
+  auto divFactorMinusOne = ir::Literal::make(getDivFactor() - 1, divFactorType);
+  // Get the size of the dimension being iterated over.
+  auto parentBounds = parentIterBounds.at(getParentVar());
+  auto dimSize = ir::Sub::make(parentBounds[1], parentBounds[0]);
+  // The bounds for the dimension are adjusted so that dimensions that aren't
+  // divisible by divFactor have the last piece included.
+  auto bounds = ir::Div::make(ir::Add::make(dimSize, divFactorMinusOne), divFactor);
+  return ir::Add::make(ir::Mul::make(variableNames[getOuterVar()], bounds), variableNames[getInnerVar()]);
+}
+
+ir::Stmt DivideRelNode::recoverChild(taco::IndexVar indexVar,
+                                    std::map<taco::IndexVar, taco::ir::Expr> variableNames, bool emitVarDecl, Iterators iterators, ProvenanceGraph provGraph) const {
+  // We need bounds on the parent in order to recover the different
+  // child values, but it doesn't seem like we have access to them here.
+  taco_not_supported_yet;
+  return ir::Stmt();
+}
+
+bool operator==(const DivideRelNode& a, const DivideRelNode& b) {
   return a.equals(b);
 }
 
@@ -1230,6 +1372,19 @@ ir::Stmt ProvenanceGraph::recoverChild(taco::IndexVar indexVar,
 
 std::set<IndexVar> ProvenanceGraph::getAllIndexVars() const {
   return nodes;
+}
+
+bool ProvenanceGraph::isDivided(IndexVar indexVar) const {
+  // See if the indexVar has any children. If so, look at the relation that
+  // created the parent-child relationship. If it is a divide, return true.
+  auto children = this->getChildren(indexVar);
+  if (children.size() > 0) {
+    auto rel = this->childRelMap.at(indexVar);
+    if (rel.getRelType() == DIVIDE) {
+      return true;
+    }
+  }
+  return false;
 }
 
 }

--- a/src/lower/lowerer_impl.cpp
+++ b/src/lower/lowerer_impl.cpp
@@ -4,6 +4,7 @@
 #include "taco/index_notation/index_notation.h"
 #include "taco/index_notation/index_notation_nodes.h"
 #include "taco/index_notation/index_notation_visitor.h"
+#include "taco/index_notation/provenance_graph.h"
 #include "taco/ir/ir.h"
 #include "ir/ir_generators.h"
 #include "taco/ir/ir_visitor.h"
@@ -471,6 +472,31 @@ Stmt LowererImpl::lowerForall(Forall forall)
                                         Continue::make());
           recoverySteps.push_back(guard);
       }
+    }
+
+    // If this index variable was divided into multiple equal chunks, then we
+    // must add an extra guard to make sure that further scheduling operations
+    // on descendent index variables exceed the bounds of each equal portion of
+    // the loop. For a concrete example, consider a loop of size 10 that is divided
+    // into two equal components -- 5 and 5. If the loop is then transformed
+    // with .split(..., 3), each inner chunk of 5 will be split into chunks of
+    // 3. Without an extra guard, the second chunk of 3 in the first group of 5
+    // may attempt to perform an iteration for the second group of 5, which is
+    // incorrect.
+    if (this->provGraph.isDivided(varToRecover)) {
+      // Collect the children iteration variables.
+      auto children = this->provGraph.getChildren(varToRecover);
+      auto outer = children[0];
+      auto inner = children[1];
+      // Find the iteration bounds of the inner variable -- that is the size
+      // that the outer loop was broken into.
+      auto bounds = this->provGraph.deriveIterBounds(inner, definedIndexVarsOrdered, underivedBounds, indexVarToExprMap, iterators);
+      // Use the difference between the bounds to find the size of the loop.
+      auto dimLen = ir::Sub::make(bounds[1], bounds[0]);
+      // For a variable f divided into into f1 and f2, the guard ensures that
+      // for iteration f, f should be within f1 * dimLen and (f1 + 1) * dimLen.
+      auto guard = ir::Gte::make(this->indexVarToExprMap[varToRecover], ir::Mul::make(ir::Add::make(this->indexVarToExprMap[outer], 1), dimLen));
+      recoverySteps.push_back(IfThenElse::make(guard, ir::Continue::make()));
     }
   }
   Stmt recoveryStmt = Block::make(recoverySteps);

--- a/test/tests-scheduling.cpp
+++ b/test/tests-scheduling.cpp
@@ -8,6 +8,8 @@
 #include "codegen/codegen.h"
 #include "taco/lower/lower.h"
 
+#include <functional>
+
 using namespace taco;
 const IndexVar i("i"), j("j"), k("k");
 
@@ -857,4 +859,60 @@ TEST(scheduling_eval_test, spmv_fuse) {
   expected.assemble();
   expected.compute();
   ASSERT_TENSOR_EQ(expected, y);
+}
+
+TEST(scheduling, divide) {
+  auto dim = 256;
+  float sparsity = 0.1;
+  Tensor<int> A("A", {dim, dim}, {Dense, Sparse});
+  Tensor<int> x("x", {dim}, {Dense});
+  IndexVar i("i"), i1("i1"), i2("i2"), j("j"), f("f"), fpos("fpos"), f0("f0"), f1("f1");
+
+  srand(59393);
+  for (int i = 0; i < dim; i++) {
+    for (int j = 0; j < dim; j++) {
+      auto rand_float = (float)rand()/(float)(RAND_MAX);
+      if (rand_float < sparsity) {
+        A.insert({i, j},((int)(rand_float * 10 / sparsity)));
+      }
+    }
+  }
+
+  for (int j = 0; j < dim; j++) {
+    float rand_float = (float)rand()/(float)(RAND_MAX);
+    x.insert({j}, ((int)(rand_float*10)));
+  }
+
+  x.pack(); A.pack();
+
+  auto test = [&](std::function<IndexStmt(IndexStmt)> f) {
+    Tensor<int> y("y", {dim}, {Dense});
+    y(i) = A(i, j) * x(j);
+    auto stmt = f(y.getAssignment().concretize());
+    y.compile(stmt);
+    y.evaluate();
+    Tensor<int> expected("expected", {dim}, {Dense});
+    expected(i) = A(i, j) * x(j);
+    expected.evaluate();
+    ASSERT_TRUE(equals(expected, y)) << expected << endl << y << endl;
+  };
+
+  // Test that a simple divide works.
+  test([&](IndexStmt stmt) {
+    return stmt.divide(i, i1, i2, 2);
+  });
+
+  // Test when the divide factor doesn't divide the dimension evenly.
+  test([&](IndexStmt stmt) {
+    return stmt.divide(i, i1, i2, 3);
+  });
+
+  // Test a more complicated case where we fuse loops and then divide them.
+  test([&](IndexStmt stmt) {
+    return stmt.fuse(i, j, f).pos(f, fpos, A(i, j)).divide(fpos, f0, f1, 2).split(f1, i1, i2, 4);
+  });
+  test([&](IndexStmt stmt) {
+    IndexVar i3, i4;
+    return stmt.fuse(i, j, f).pos(f, fpos, A(i, j)).divide(fpos, f0, f1, 4).split(f1, i1, i2, 16).split(i2, i3, i4, 8);
+  });
 }

--- a/tools/taco.cpp
+++ b/tools/taco.cpp
@@ -326,31 +326,34 @@ static bool setSchedulingCommands(vector<vector<string>> scheduleCommands, parse
       stmt = stmt.fuse(findVar(i), findVar(j), fused);
 
     } else if (command == "split") {
-      taco_uassert(scheduleCommand.size() == 4) << "'split' scheduling directive takes 4 parameters: split(i, i1, i2, splitFactor)";
+      taco_uassert(scheduleCommand.size() == 4)
+          << "'split' scheduling directive takes 4 parameters: split(i, i1, i2, splitFactor)";
       string i, i1, i2;
       size_t splitFactor;
-      i  = scheduleCommand[0];
+      i = scheduleCommand[0];
       i1 = scheduleCommand[1];
       i2 = scheduleCommand[2];
-      taco_uassert(sscanf(scheduleCommand[3].c_str(), "%zu", &splitFactor) == 1) << "failed to parse fourth parameter to `split` directive as a size_t";
+      taco_uassert(sscanf(scheduleCommand[3].c_str(), "%zu", &splitFactor) == 1)
+          << "failed to parse fourth parameter to `split` directive as a size_t";
 
       IndexVar split1(i1);
       IndexVar split2(i2);
       stmt = stmt.split(findVar(i), split1, split2, splitFactor);
+    } else if (command == "divide") {
+      taco_uassert(scheduleCommand.size() == 4)
+          << "'divide' scheduling directive takes 4 parameters: split(i, i1, i2, divFactor)";
+      string i, i1, i2;
+      i = scheduleCommand[0];
+      i1 = scheduleCommand[1];
+      i2 = scheduleCommand[2];
 
-    // } else if (command == "divide") {
-    //   string i, i1, i2;
-    //   in >> i;
-    //   in >> i1;
-    //   in >> i2;
+      size_t divideFactor;
+      taco_uassert(sscanf(scheduleCommand[3].c_str(), "%zu", &divideFactor) == 1)
+          << "failed to parse fourth parameter to `divide` directive as a size_t";
 
-    //   size_t divideFactor;
-    //   in >> divideFactor;
-
-    //   IndexVar divide1(i1);
-    //   IndexVar divide2(i2);
-    //   stmt = stmt.divide(findVar(i), divide1, divide2, divideFactor);
-
+      IndexVar divide1(i1);
+      IndexVar divide2(i2);
+      stmt = stmt.divide(findVar(i), divide1, divide2, divideFactor);
     } else if (command == "precompute") {
       string exprStr, i, iw;
       taco_uassert(scheduleCommand.size() == 3) << "'precompute' scheduling directive takes 3 parameters: precompute(expr, i, iw)";


### PR DESCRIPTION
The divide transformation divides a loop up into `n` equal components,
whereas split breaks a loop up into a components of size `n`.