### PR TITLE
Add a SpTV+openmp+atomics test case for #316

### DIFF
--- a/test/tests-scheduling-eval.cpp
+++ b/test/tests-scheduling-eval.cpp
@@ -345,13 +345,6 @@ TEST(scheduling_eval, test_spmvCPU_temp) {
   A.pack();
 
 
-  IndexVar i0("i0"), i1("i1"), kpos("kpos"), kpos0("kpos0"), kpos1("kpos1");
-  TensorVar tj("tj", Float64);
-  IndexVar jw("iw");
-
-  y(i) = A(i, j) * x(j);
-  Access tjAccess = tj();
-
   y(i) = A(i, j) * x(j);
   IndexStmt stmt = y.getAssignment().concretize();
   stmt = stmt.parallelize(i, ParallelUnit::CPUThread, OutputRaceStrategy::Atomics);
@@ -364,6 +357,57 @@ TEST(scheduling_eval, test_spmvCPU_temp) {
 
   Tensor<double> expected("expected", {NUM_I}, Format({Dense}));
   expected(i) = A(i, j) * x(j);
+  expected.compile();
+  expected.assemble();
+  expected.compute();
+  ASSERT_TENSOR_EQ(expected, y);
+}
+
+TEST(scheduling_eval, test_sptvCPU_temp) {
+  if (should_use_CUDA_codegen()) {
+    return;
+  }
+  int NUM_I = 1021/10;
+  int NUM_J = 1039/10;
+  int NUM_K = 1049/10;
+  float SPARSITY = .01;
+  Tensor<double> A("A", {NUM_I, NUM_J, NUM_K}, Format({Sparse, Sparse, Sparse}));
+  Tensor<double> x("x", {NUM_K}, Format({Dense}));
+  Tensor<double> y("y", {NUM_J}, Format({Dense}));
+
+  srand(4357);
+  for (int i = 0; i < NUM_I; i++) {
+    for (int j = 0; j < NUM_J; j++) {
+      for (int k = 0; k < NUM_K; k++) {
+        float rand_float = (float)rand()/(float)(RAND_MAX);
+        if (rand_float < SPARSITY) {
+          A.insert({i, j, k}, (double) ((int) (rand_float*3/SPARSITY)));
+        }
+      }
+    }
+  }
+
+  for (int k = 0; k < NUM_K; k++) {
+    float rand_float = (float)rand()/(float)(RAND_MAX);
+    x.insert({k}, (double) ((int) (rand_float*3/SPARSITY)));
+  }
+
+  x.pack();
+  A.pack();
+
+
+  y(j) = A(i, j, k) * x(k);
+  IndexStmt stmt = y.getAssignment().concretize();
+  stmt = stmt.reorder({i,j,k}).parallelize(j, ParallelUnit::CPUThread, OutputRaceStrategy::Atomics);
+
+  //printToFile("test_sptvCPU_temp", stmt);
+
+  y.compile(stmt);
+  y.assemble();
+  y.compute();
+
+  Tensor<double> expected("expected", {NUM_J}, Format({Dense}));
+  expected(j) = A(i, j, k) * x(k);
   expected.compile();
   expected.assemble();
   expected.compute();


### PR DESCRIPTION
This improves test coverage of suppressed atomics in openmp code.

It is a C++ API version of the example given here: https://github.com/tensor-compiler/taco/pull/401#issuecomment-777803611

I used the `spmvCPU_temp` test as a starting point for this, and I noticed some dead code (copypasta?).  I removed the dead code.

I also noticed that the C++ API doesn't have the same default loop order as the command line tool for this example.  I had to add a `.reorder({i,j,k})` call, otherwise the generated code refers to an index variable that hasn't been declared yet.  I will log that as a separate issue.