### PR TITLE
*: add the ability to stride window access

### DIFF
--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -242,6 +242,12 @@ public:
   int getWindowLowerBound(int mode) const;
   int getWindowUpperBound(int mode) const;
 
+  /// getWindowSize returns the dimension size of a window.
+  int getWindowSize(int mode) const;
+
+  /// getStride returns the stride of a window.
+  int getStride(int mode) const;
+
   /// Assign the result of an expression to a left-hand-side tensor access.
   /// ```
   /// a(i) = b(i) * c(i);
@@ -853,7 +859,7 @@ public:
 /// before IndexVar so that IndexVar can return objects of type WindowedIndexVar.
 class WindowedIndexVar : public util::Comparable<WindowedIndexVar>, public IndexVarInterface {
 public:
-  WindowedIndexVar(IndexVar base, int lo = -1, int hi = -1);
+  WindowedIndexVar(IndexVar base, int lo = -1, int hi = -1, int stride = 1);
   ~WindowedIndexVar() = default;
 
   /// getIndexVar returns the underlying IndexVar.
@@ -863,6 +869,11 @@ public:
   /// this index variable.
   int getLowerBound() const;
   int getUpperBound() const;
+  /// getStride returns the stride to access the window by.
+  int getStride() const;
+
+  /// getWindowSize returns the number of elements in the window.
+  int getWindowSize() const;
 
 private:
   struct Content;
@@ -884,7 +895,7 @@ public:
   friend bool operator<(const IndexVar&, const IndexVar&);
 
   /// Indexing into an IndexVar returns a window into it.
-  WindowedIndexVar operator()(int lo, int hi);
+  WindowedIndexVar operator()(int lo, int hi, int stride = 1);
 
 private:
   struct Content;
@@ -899,6 +910,7 @@ struct WindowedIndexVar::Content {
   IndexVar base;
   int lo;
   int hi;
+  int stride;
 };
 
 std::ostream& operator<<(std::ostream&, const std::shared_ptr<IndexVarInterface>&);

--- a/include/taco/index_notation/index_notation_nodes.h
+++ b/include/taco/index_notation/index_notation_nodes.h
@@ -20,8 +20,9 @@ namespace taco {
 struct AccessWindow {
   int lo;
   int hi;
+  int stride;
   friend bool operator==(const AccessWindow& a, const AccessWindow& b) {
-    return a.lo == b.lo && a.hi == b.hi;
+    return a.lo == b.lo && a.hi == b.hi && a.stride == b.stride;
   }
 };
 

--- a/include/taco/lower/iterator.h
+++ b/include/taco/lower/iterator.h
@@ -166,10 +166,22 @@ public:
   /// of a tensor mode.
   bool isWindowed() const;
 
+  /// isStrided returns true if this iterator has a stride != 1. Currently
+  /// only windowed iterators can have strides.
+  bool isStrided() const;
+
   /// getWindow{Lower,Upper}Bound return the {Lower,Upper} bound of the
   /// window that this iterator operates over.
   ir::Expr getWindowLowerBound() const;
   ir::Expr getWindowUpperBound() const;
+
+  /// getStride returns an Expr holding the stride that this iterator is
+  /// configured with.
+  ir::Expr getStride() const;
+
+  /// getWindowVar returns a Var specific to thw window that this iterator
+  /// is operating over. It can be used as temporary storage.
+  ir::Expr getWindowVar() const;
 
   friend bool operator==(const Iterator&, const Iterator&);
   friend bool operator<(const Iterator&, const Iterator&);
@@ -184,7 +196,7 @@ private:
 
   friend class Iterators;
   /// setWindowBounds sets the window bounds of this iterator.
-  void setWindowBounds(ir::Expr lo, ir::Expr hi);
+  void setWindowBounds(ir::Expr lo, ir::Expr hi, ir::Expr stride);
 };
 
 /**

--- a/include/taco/lower/lowerer_impl.h
+++ b/include/taco/lower/lowerer_impl.h
@@ -399,6 +399,12 @@ protected:
   // range of [lo, hi).
   ir::Expr projectCanonicalSpaceToWindowedPosition(Iterator iterator, ir::Expr expr);
 
+  /// strideBoundsGuard inserts a guard against accessing values from an
+  /// iterator that don't fit in the stride that the iterator is configured
+  /// with. It takes a boolean incrementPosVars to control whether the outer
+  /// loop iterator variable should be incremented when the guard is fired.
+  ir::Stmt strideBoundsGuard(Iterator iterator, ir::Expr access, bool incrementPosVar);
+
 private:
   bool assemble;
   bool compute;

--- a/src/error/error_checks.cpp
+++ b/src/error/error_checks.cpp
@@ -58,7 +58,7 @@ std::pair<bool, string> dimensionsTypecheck(const std::vector<IndexVar>& resultV
       // as the shape, rather than the shape of the underlying tensor.
       auto a = Access(readNode);
       if (a.isModeWindowed(mode)) {
-        dimension = Dimension(a.getWindowUpperBound(mode) - a.getWindowLowerBound(mode));
+        dimension = Dimension(a.getWindowSize(mode));
       }
 
       if (util::contains(indexVarDims,var) && indexVarDims.at(var) != dimension) {

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -777,6 +777,17 @@ int Access::getWindowUpperBound(int mode) const {
   return getNode(*this)->windowedModes.at(mode).hi;
 }
 
+int Access::getWindowSize(int mode) const {
+  taco_iassert(this->isModeWindowed(mode));
+  auto w = getNode(*this)->windowedModes.at(mode);
+  return (w.hi - w.lo) / w.stride;
+}
+
+int Access::getStride(int mode) const {
+  taco_iassert(this->isModeWindowed(mode));
+  return getNode(*this)->windowedModes.at(mode).stride;
+}
+
 static void check(Assignment assignment) {
   auto lhs = assignment.getLhs();
   auto tensorVar = lhs.getTensorVar();
@@ -791,7 +802,7 @@ static void check(Assignment assignment) {
     for (int i = 0; i < shape.getOrder();i++) {
       dims[i] = shape.getDimension(i);
       if (lhs.isModeWindowed(i)) {
-        dims[i] = Dimension(lhs.getWindowUpperBound(i) - lhs.getWindowLowerBound(i));
+        dims[i] = Dimension(lhs.getWindowSize(i));
       }
     }
     shape = Shape(dims);
@@ -1834,8 +1845,8 @@ std::string IndexVar::getName() const {
   return content->name;
 }
 
-WindowedIndexVar IndexVar::operator()(int lo, int hi) {
-  return WindowedIndexVar(*this, lo, hi);
+WindowedIndexVar IndexVar::operator()(int lo, int hi, int stride) {
+  return WindowedIndexVar(*this, lo, hi, stride);
 }
 
 bool operator==(const IndexVar& a, const IndexVar& b) {
@@ -1864,10 +1875,11 @@ std::ostream& operator<<(std::ostream& os, const WindowedIndexVar& var) {
   return os << var.getIndexVar();
 }
 
-WindowedIndexVar::WindowedIndexVar(IndexVar base, int lo, int hi) : content( new Content){
+WindowedIndexVar::WindowedIndexVar(IndexVar base, int lo, int hi, int stride) : content( new Content){
   this->content->base = base;
   this->content->lo = lo;
   this->content->hi = hi;
+  this->content->stride = stride;
 }
 
 IndexVar WindowedIndexVar::getIndexVar() const {
@@ -1880,6 +1892,14 @@ int WindowedIndexVar::getLowerBound() const {
 
 int WindowedIndexVar::getUpperBound() const {
   return this->content->hi;
+}
+
+int WindowedIndexVar::getStride() const {
+  return this->content->stride;
+}
+
+int WindowedIndexVar::getWindowSize() const {
+  return (this->content->hi - this->content->lo) / this->content->stride;
 }
 
 // class TensorVar
@@ -2029,7 +2049,7 @@ static bool isValid(Assignment assignment, string* reason) {
     for (int i = 0; i < shape.getOrder();i++) {
       dims[i] = shape.getDimension(i);
       if (lhs.isModeWindowed(i)) {
-        dims[i] = Dimension(lhs.getWindowUpperBound(i) - lhs.getWindowLowerBound(i));
+        dims[i] = Dimension(lhs.getWindowSize(i));
       }
     }
     shape = Shape(dims);

--- a/src/lower/lowerer_impl.cpp
+++ b/src/lower/lowerer_impl.cpp
@@ -178,7 +178,7 @@ LowererImpl::lower(IndexStmt stmt, string name,
         // The mode value used to access .levelIterator is 1-indexed, while
         // the mode input to getDimension is 0-indexed. So, we shift it up by 1.
         auto iter = iterators.levelIterator(ModeAccess(a, mode+1));
-        return ir::Sub::make(iter.getWindowUpperBound(), iter.getWindowLowerBound());
+        return ir::Div::make(ir::Sub::make(iter.getWindowUpperBound(), iter.getWindowLowerBound()), iter.getStride());
       } else {
         return GetProperty::make(tensorVars.at(tv), TensorProperty::Dimension, mode);
       }
@@ -1014,6 +1014,7 @@ Stmt LowererImpl::lowerForallPosition(Forall forall, Iterator iterator,
 {
   Expr coordinate = getCoordinateVar(forall.getIndexVar());
   Stmt declareCoordinate = Stmt();
+  Stmt strideGuard = Stmt();
   Stmt boundsGuard = Stmt();
   if (provGraph.isCoordVariable(forall.getIndexVar())) {
     Expr coordinateArray = iterator.posAccess(iterator.getPosVar(),
@@ -1021,6 +1022,13 @@ Stmt LowererImpl::lowerForallPosition(Forall forall, Iterator iterator,
     // If the iterator is windowed, we must recover the coordinate index
     // variable from the windowed space.
     if (iterator.isWindowed()) {
+      if (iterator.isStrided()) {
+        // In this case, we're iterating over a compressed level with a for
+        // loop. Since the iterator variable will get incremented by the for
+        // loop, the guard introduced for stride checking doesn't need to
+        // increment the iterator variable.
+        strideGuard = this->strideBoundsGuard(iterator, coordinateArray, false /* incrementPosVar */);
+      }
       coordinateArray = this->projectWindowedPositionToCanonicalSpace(iterator, coordinateArray);
       boundsGuard = this->upperBoundGuardForWindowPosition(iterator, coordinate);
     }
@@ -1088,7 +1096,7 @@ Stmt LowererImpl::lowerForallPosition(Forall forall, Iterator iterator,
   return Block::blanks(
                        boundsCompute,
                        For::make(iterator.getPosVar(), startBound, endBound, 1,
-                                 Block::make(declareCoordinate, boundsGuard, body),
+                                 Block::make(strideGuard, declareCoordinate, boundsGuard, body),
                                  kind,
                                  ignoreVectorize ? ParallelUnit::NotParallel : forall.getParallelUnit(), ignoreVectorize ? 0 : forall.getUnrollFactor()),
                        posAppend);
@@ -1353,15 +1361,34 @@ Stmt LowererImpl::resolveCoordinate(std::vector<Iterator> mergers, ir::Expr coor
       ModeFunction posAccess = merger.posAccess(merger.getPosVar(),
                                                 coordinates(merger));
       auto access = posAccess[0];
+      auto windowVarDecl = Stmt();
+      auto stride = Stmt();
       auto guard = Stmt();
       // If the iterator is windowed, we must recover the coordinate index
       // variable from the windowed space.
       if (merger.isWindowed()) {
+
+        // If the iterator is strided, then we have to skip over coordinates
+        // that don't match the stride. To do that, we insert a guard on the
+        // access. We first extract the access into a temp to avoid emitting
+        // a duplicate load on the _crd array.
+        if (merger.isStrided()) {
+          windowVarDecl = VarDecl::make(merger.getWindowVar(), access);
+          access = merger.getWindowVar();
+          // Since we're merging values from a compressed array (not iterating over it),
+          // we need to advance the outer loop if the current coordinate is not
+          // along the desired stride. So, we pass true to the incrementPosVar
+          // argument of strideBoundsGuard.
+          stride = this->strideBoundsGuard(merger, access, true /* incrementPosVar */);
+        }
+
         access = this->projectWindowedPositionToCanonicalSpace(merger, access);
         guard = this->upperBoundGuardForWindowPosition(merger, coordinate);
       }
       Stmt resolution = emitVarDecl ? VarDecl::make(coordinate, access) : Assign::make(coordinate, access);
       return Block::make(posAccess.compute(),
+                         windowVarDecl,
+                         stride,
                          resolution,
                          guard);
     }
@@ -2634,6 +2661,21 @@ Stmt LowererImpl::codeToLoadCoordinatesFromPosIterators(vector<Iterator> iterato
       // TODO (rohany): Would be cleaner to have this logic be moved into the
       //  ModeFunction, rather than having to check in some places?
       if (posIter.isWindowed()) {
+
+        // If the iterator is strided, then we have to skip over coordinates
+        // that don't match the stride. To do that, we insert a guard on the
+        // access. We first extract the access into a temp to avoid emitting
+        // a duplicate load on the _crd array.
+        if (posIter.isStrided()) {
+          loadPosIterCoordinateStmts.push_back(VarDecl::make(posIter.getWindowVar(), access));
+          access = posIter.getWindowVar();
+          // Since we're locating into a compressed array (not iterating over it),
+          // we need to advance the outer loop if the current coordinate is not
+          // along the desired stride. So, we pass true to the incrementPosVar
+          // argument of strideBoundsGuard.
+          loadPosIterCoordinateStmts.push_back(this->strideBoundsGuard(posIter, access, true /* incrementPosVar */));
+        }
+
         access = this->projectWindowedPositionToCanonicalSpace(posIter, access);
       }
       if (declVars) {
@@ -2796,19 +2838,37 @@ Expr LowererImpl::searchForStartOfWindowPosition(Iterator iterator, ir::Expr sta
 }
 
 Stmt LowererImpl::upperBoundGuardForWindowPosition(Iterator iterator, ir::Expr access) {
-    taco_iassert(iterator.isWindowed());
-    return ir::IfThenElse::make(
-            ir::Gte::make(access, ir::Sub::make(iterator.getWindowUpperBound(), iterator.getWindowLowerBound())),
-            ir::Break::make()
-    );
+  taco_iassert(iterator.isWindowed());
+  return ir::IfThenElse::make(
+    ir::Gte::make(access, ir::Sub::make(iterator.getWindowUpperBound(), iterator.getWindowLowerBound())),
+    ir::Break::make()
+  );
+}
+
+Stmt LowererImpl::strideBoundsGuard(Iterator iterator, ir::Expr access, bool incrementPosVar) {
+  Stmt cont = ir::Continue::make();
+  // If requested to increment the iterator's position variable, add the increment
+  // before the continue statement.
+  if (incrementPosVar) {
+    cont = ir::Block::make({
+                               ir::Assign::make(iterator.getPosVar(),
+                                                ir::Add::make(iterator.getPosVar(), ir::Literal::make(1))),
+                               cont
+                           });
+  }
+  // The guard makes sure that the coordinate being accessed is along the stride.
+  return ir::IfThenElse::make(
+      ir::Neq::make(ir::Rem::make(access, iterator.getStride()), ir::Literal::make(0)),
+      cont
+  );
 }
 
 Expr LowererImpl::projectWindowedPositionToCanonicalSpace(Iterator iterator, ir::Expr expr) {
-  return ir::Sub::make(expr, iterator.getWindowLowerBound());
+  return ir::Div::make(ir::Sub::make(expr, iterator.getWindowLowerBound()), iterator.getStride());
 }
 
 Expr LowererImpl::projectCanonicalSpaceToWindowedPosition(Iterator iterator, ir::Expr expr) {
-  return ir::Add::make(expr, iterator.getWindowLowerBound());
+  return ir::Mul::make(ir::Add::make(expr, iterator.getWindowLowerBound()), iterator.getStride());
 }
 
 }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -477,6 +477,7 @@ struct AccessTensorNode : public AccessNode {
           "slice upper bound must be <= tensor dimension (" << tensor.getDimension(i) << ")";
         this->windowedModes[i].lo = lo;
         this->windowedModes[i].hi = hi;
+        this->windowedModes[i].stride = wvar->getStride();
       });
     }
     // Initialize this->indexVars.


### PR DESCRIPTION
This commit extends the windowing syntax to include an optional third
parameter to a window expression on an index variable:

```
a(i) = b(i(0, n, 5 /* stride */))
```

This stride parameters means that the window should be accessed along
the provided stride, which defaults to 1.

Striding is implemented with a similar idea as windowing, where
coordinates in the stride are mapped to a canonical index space of `[0,n)`.
For compressed modes, coordinates that don't match the stride are
skipped.