### PR TITLE
*: add support for using arbitrary indexing sets to window tensors

### DIFF
--- a/include/taco/index_notation/index_notation_nodes.h
+++ b/include/taco/index_notation/index_notation_nodes.h
@@ -3,8 +3,10 @@
 
 #include <vector>
 #include <memory>
+#include <functional>
 
 #include "taco/type.h"
+#include "taco/tensor.h"
 #include "taco/index_notation/index_notation.h"
 #include "taco/index_notation/index_notation_nodes_abstract.h"
 #include "taco/index_notation/index_notation_visitor.h"
@@ -13,11 +15,40 @@
 
 namespace taco {
 
+struct AccessWindow;
+struct IndexSet;
+
+// IndexVarIterationModifier is a marker interface for describing iteration
+// transformations onto a particular index variable. Currently, the type is
+// inhabited only by
+// * AccessWindow
+// * IndexSet
+struct IndexVarIterationModifier {
+  virtual ~IndexVarIterationModifier() = default;
+
+  // match performs dynamic dispatch on the subclass that implements IndexVarIterationModifier.
+  static void match(std::shared_ptr<IndexVarIterationModifier> ptr,
+                    std::function<void(std::shared_ptr<AccessWindow>)> windowFunc,
+                    std::function<void(std::shared_ptr<IndexSet>)> indexSetFunc) {
+    auto windowPtr = std::dynamic_pointer_cast<AccessWindow>(ptr);
+    auto indexSetPtr = std::dynamic_pointer_cast<IndexSet>(ptr);
+    if (windowPtr != nullptr) {
+      windowFunc(windowPtr);
+    } else if (indexSetPtr != nullptr) {
+      indexSetFunc(indexSetPtr);
+    } else {
+      taco_iassert("IndexVarIterationModifier was not AccessWindow or IndexVarIterationModifier");
+    }
+  }
+};
+
 // An AccessNode carries the windowing information for an IndexVar + TensorVar
 // combination. An AccessWindow contains the lower and upper bounds of each
 // windowed mode (0-indexed). AccessWindow is extracted from AccessNode so that
 // it can be referenced externally.
-struct AccessWindow {
+struct AccessWindow : IndexVarIterationModifier {
+  ~AccessWindow() = default;
+
   int lo;
   int hi;
   int stride;
@@ -26,9 +57,33 @@ struct AccessWindow {
   }
 };
 
+// An AccessNode also carries the information about an index set for an IndexVar +
+// TensorVar combination. An IndexSet contains the set of dimensions projected
+// out from a tensor via an index set.
+struct IndexSet : IndexVarIterationModifier {
+  ~IndexSet() = default;
+
+  std::shared_ptr<std::vector<int>> set;
+  TensorBase tensor;
+  friend bool operator==(const IndexSet& a, const IndexSet& b) {
+    return *a.set == *b.set && a.tensor == b.tensor;
+  }
+};
+
 struct AccessNode : public IndexExprNode {
-  AccessNode(TensorVar tensorVar, const std::vector<IndexVar>& indices, const std::map<int, AccessWindow>& windows={})
-      : IndexExprNode(tensorVar.getType().getDataType()), tensorVar(tensorVar), indexVars(indices), windowedModes(windows) {}
+  AccessNode(TensorVar tensorVar,
+             const std::vector<IndexVar> &indices,
+             const std::map<int, std::shared_ptr<IndexVarIterationModifier>> &modifiers = {})
+      : IndexExprNode(tensorVar.getType().getDataType()), tensorVar(tensorVar), indexVars(indices) {
+    // Unpack the input modifiers into the appropriate maps for each mode.
+    for (auto &it : modifiers) {
+      IndexVarIterationModifier::match(it.second, [&](std::shared_ptr<AccessWindow> w) {
+        this->windowedModes[it.first] = *w;
+      }, [&](std::shared_ptr<IndexSet> i) {
+        this->indexSetModes[it.first] = *i;
+      });
+    }
+  }
 
   void accept(IndexExprVisitorStrict* v) const {
     v->visit(this);
@@ -36,9 +91,23 @@ struct AccessNode : public IndexExprNode {
 
   virtual void setAssignment(const Assignment& assignment) {}
 
+  // packageModifiers collects all IndexVarIterationModifiers applied to this
+  // AccessNode into a map.
+  std::map<int, std::shared_ptr<IndexVarIterationModifier>> packageModifiers() const {
+    std::map<int, std::shared_ptr<IndexVarIterationModifier>> ret;
+    for (auto& it : this->windowedModes) {
+      ret[it.first] = std::make_shared<AccessWindow>(it.second);
+    }
+    for (auto& it : this->indexSetModes) {
+      ret[it.first] = std::make_shared<IndexSet>(it.second);
+    }
+    return ret;
+  }
+
   TensorVar tensorVar;
   std::vector<IndexVar> indexVars;
   std::map<int, AccessWindow> windowedModes;
+  std::map<int, IndexSet> indexSetModes;
 
 protected:
   /// Initialize an AccessNode with just a TensorVar. If this constructor is used,

--- a/include/taco/lower/iterator.h
+++ b/include/taco/lower/iterator.h
@@ -183,6 +183,15 @@ public:
   /// is operating over. It can be used as temporary storage.
   ir::Expr getWindowVar() const;
 
+  /// Methods for querying and operating on tensor modes projected by an index set.
+
+  /// hasIndexSet returns true if this iterator is operating over an index set.
+  bool hasIndexSet() const;
+
+  /// getIndexSetIterator returns the iterator that corresponds to the tensor
+  /// backing the index set.
+  Iterator getIndexSetIterator() const;
+
   friend bool operator==(const Iterator&, const Iterator&);
   friend bool operator<(const Iterator&, const Iterator&);
   friend std::ostream& operator<<(std::ostream&, const Iterator&);
@@ -195,8 +204,12 @@ private:
   void setChild(const Iterator& iterator) const;
 
   friend class Iterators;
+
   /// setWindowBounds sets the window bounds of this iterator.
   void setWindowBounds(ir::Expr lo, ir::Expr hi, ir::Expr stride);
+
+  /// setIndexSetIterator sets the index set iterator of this iterator.
+  void setIndexSetIterator(Iterator iter);
 };
 
 /**
@@ -242,7 +255,8 @@ public:
   std::map<IndexVar, Iterator> modeIterators() const;
 
 private:
-  void createAccessIterators(Access access, Format format, ir::Expr tensorIR, ProvenanceGraph provGraph);
+  void createAccessIterators(Access access, Format format, ir::Expr tensorIR, ProvenanceGraph provGraph,
+                             const std::map<TensorVar, ir::Expr> &tensorVars);
 
   struct Content;
   std::shared_ptr<Content> content;

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -638,6 +638,9 @@ public:
   template <typename... IndexVars>
   Access operator()(const IndexVar& first, const IndexVars&... indices);
 
+  template <typename... IndexVars>
+  Access operator()(const IndexSetVar& first, const IndexVars&... indices);
+
   ScalarAccess<CType> operator()(const std::vector<int>& indices);
 
   /// Create an index expression that accesses (reads) this tensor.
@@ -1160,6 +1163,11 @@ Access Tensor<CType>::operator()(const IndexVar& first, const IndexVars&... indi
 template <typename CType>
 template <typename... IndexVars>
 Access Tensor<CType>::operator()(const WindowedIndexVar& first, const IndexVars&... indices) {
+  return this->_access_wrapper(first, indices...);
+}
+template <typename CType>
+template <typename... IndexVars>
+Access Tensor<CType>::operator()(const IndexSetVar& first, const IndexVars&... indices) {
   return this->_access_wrapper(first, indices...);
 }
 

--- a/src/error/error_checks.cpp
+++ b/src/error/error_checks.cpp
@@ -59,6 +59,8 @@ std::pair<bool, string> dimensionsTypecheck(const std::vector<IndexVar>& resultV
       auto a = Access(readNode);
       if (a.isModeWindowed(mode)) {
         dimension = Dimension(a.getWindowSize(mode));
+      } else if (a.isModeIndexSet(mode)) {
+        dimension = Dimension(a.getIndexSet(mode).size());
       }
 
       if (util::contains(indexVarDims,var) && indexVarDims.at(var) != dimension) {

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -23,6 +23,7 @@
 #include "taco/ir/ir.h"
 #include "taco/lower/lower.h"
 #include "taco/codegen/module.h"
+#include "taco/tensor.h"
 
 #include "taco/util/name_generator.h"
 #include "taco/util/scopedmap.h"
@@ -185,7 +186,11 @@ struct Isomorphic : public IndexNotationVisitorStrict {
         return;
       }
     }
-    eq = anode->windowedModes == bnode->windowedModes;
+    if (anode->windowedModes != bnode->windowedModes) {
+      eq = false;
+      return;
+    }
+    eq = anode->indexSetModes == bnode->indexSetModes;
   }
 
   void visit(const LiteralNode* anode) {
@@ -473,7 +478,11 @@ struct Equals : public IndexNotationVisitorStrict {
         return;
       }
     }
-    eq = true;
+    if (anode->windowedModes != bnode->windowedModes) {
+      eq = false;
+      return;
+    }
+    eq = anode->indexSetModes == bnode->indexSetModes;
   }
 
   void visit(const LiteralNode* anode) {
@@ -746,8 +755,10 @@ IndexExpr operator/(const IndexExpr& lhs, const IndexExpr& rhs) {
 Access::Access(const AccessNode* n) : IndexExpr(n) {
 }
 
-Access::Access(const TensorVar& tensor, const std::vector<IndexVar>& indices, const std::map<int, AccessWindow>& windows)
-    : Access(new AccessNode(tensor, indices, windows)) {
+Access::Access(const TensorVar& tensor,
+               const std::vector<IndexVar>& indices,
+               const std::map<int, std::shared_ptr<IndexVarIterationModifier>>& modifiers)
+    : Access(new AccessNode(tensor, indices, modifiers)) {
 }
 
 const TensorVar& Access::getTensorVar() const {
@@ -788,6 +799,25 @@ int Access::getStride(int mode) const {
   return getNode(*this)->windowedModes.at(mode).stride;
 }
 
+bool Access::hasIndexSetModes() const {
+  return !getNode(*this)->indexSetModes.empty();
+}
+
+bool Access::isModeIndexSet(int mode) const {
+  auto node = getNode(*this);
+  return util::contains(node->indexSetModes, mode);
+}
+
+TensorVar Access::getModeIndexSetTensor(int mode) const {
+  taco_iassert(this->isModeIndexSet(mode));
+  return getNode(*this)->indexSetModes.at(mode).tensor.getTensorVar();
+}
+
+const std::vector<int>& Access::getIndexSet(int mode) const {
+  taco_iassert(this->isModeIndexSet(mode));
+  return *getNode(*this)->indexSetModes.at(mode).set;
+}
+
 static void check(Assignment assignment) {
   auto lhs = assignment.getLhs();
   auto tensorVar = lhs.getTensorVar();
@@ -797,12 +827,14 @@ static void check(Assignment assignment) {
 
   // If the LHS access has any windowed modes, use the dimensions of those
   // windows as the shape, rather than the shape of the underlying tensor.
-  if (lhs.hasWindowedModes()) {
+  if (lhs.hasWindowedModes() || lhs.hasIndexSetModes()) {
     vector<Dimension> dims(shape.getOrder());
     for (int i = 0; i < shape.getOrder();i++) {
       dims[i] = shape.getDimension(i);
       if (lhs.isModeWindowed(i)) {
         dims[i] = Dimension(lhs.getWindowSize(i));
+      } else if (lhs.isModeIndexSet(i)) {
+        dims[i] = Dimension(lhs.getIndexSet(i).size());
       }
     }
     shape = Shape(dims);
@@ -1849,6 +1881,14 @@ WindowedIndexVar IndexVar::operator()(int lo, int hi, int stride) {
   return WindowedIndexVar(*this, lo, hi, stride);
 }
 
+IndexSetVar IndexVar::operator()(std::vector<int> indexSet) {
+  return IndexSetVar(*this, indexSet);
+}
+
+IndexSetVar IndexVar::operator()(std::vector<int>& indexSet) {
+  return IndexSetVar(*this, indexSet);
+}
+
 bool operator==(const IndexVar& a, const IndexVar& b) {
   return a.content == b.content;
 }
@@ -1863,6 +1903,8 @@ std::ostream& operator<<(std::ostream& os, const std::shared_ptr<IndexVarInterfa
     ss << *ivar;
   }, [&](std::shared_ptr<WindowedIndexVar> wvar) {
     ss << *wvar;
+  }, [&](std::shared_ptr<IndexSetVar> svar) {
+    ss << *svar;
   });
   return os << ss.str();
 }
@@ -1872,6 +1914,10 @@ std::ostream& operator<<(std::ostream& os, const IndexVar& var) {
 }
 
 std::ostream& operator<<(std::ostream& os, const WindowedIndexVar& var) {
+  return os << var.getIndexVar();
+}
+
+std::ostream& operator<<(std::ostream& os, const IndexSetVar& var) {
   return os << var.getIndexVar();
 }
 
@@ -1900,6 +1946,19 @@ int WindowedIndexVar::getStride() const {
 
 int WindowedIndexVar::getWindowSize() const {
   return (this->content->hi - this->content->lo) / this->content->stride;
+}
+
+IndexSetVar::IndexSetVar(IndexVar base, std::vector<int> indexSet): content (new Content) {
+  this->content->base = base;
+  this->content->indexSet = indexSet;
+}
+
+IndexVar IndexSetVar::getIndexVar() const {
+  return this->content->base;
+}
+
+const std::vector<int>& IndexSetVar::getIndexSet() const {
+  return this->content->indexSet;
 }
 
 // class TensorVar
@@ -2044,12 +2103,14 @@ static bool isValid(Assignment assignment, string* reason) {
 
   // If the LHS access has any windowed modes, use the dimensions of those
   // windows as the shape, rather than the shape of the underlying tensor.
-  if (lhs.hasWindowedModes()) {
+  if (lhs.hasWindowedModes() || lhs.hasIndexSetModes()) {
     vector<Dimension> dims(shape.getOrder());
     for (int i = 0; i < shape.getOrder();i++) {
       dims[i] = shape.getDimension(i);
       if (lhs.isModeWindowed(i)) {
         dims[i] = Dimension(lhs.getWindowSize(i));
+      } else if (lhs.isModeIndexSet(i)) {
+        dims[i] = Dimension(lhs.getIndexSet(i).size());
       }
     }
     shape = Shape(dims);
@@ -2454,6 +2515,19 @@ vector<TensorVar> getArguments(IndexStmt stmt) {
     if (!util::contains(collected, tensor)) {
       collected.insert(tensor);
       result.push_back(tensor);
+    }
+    // The arguments will include any index sets on this tensor
+    // argument as well.
+    if (access.hasIndexSetModes()) {
+      for (size_t i = 0; i < access.getIndexVars().size(); i++) {
+        if (access.isModeIndexSet(i)) {
+          auto t = access.getModeIndexSetTensor(i);
+          if (!util::contains(collected, t)) {
+            collected.insert(t);
+            result.push_back(t);
+          }
+        }
+      }
     }
   }
 

--- a/src/index_notation/index_notation_rewriter.cpp
+++ b/src/index_notation/index_notation_rewriter.cpp
@@ -327,7 +327,7 @@ struct ReplaceIndexVars : public IndexNotationRewriter {
       }
     }
     if (modified) {
-      expr = Access(op->tensorVar, indexVars, op->windowedModes);
+      expr = Access(op->tensorVar, indexVars, op->packageModifiers());
     }
     else {
       expr = op;

--- a/src/lower/lowerer_impl.cpp
+++ b/src/lower/lowerer_impl.cpp
@@ -127,6 +127,25 @@ LowererImpl::lower(IndexStmt stmt, string name,
   tensorVars.insert(resultVars.begin(), resultVars.end());
   vector<Expr> argumentsIR = createVars(arguments, &tensorVars, pack);
 
+  // Create variables for index sets on result tensors.
+  vector<Expr> indexSetArgs;
+  for (auto& access : getResultAccesses(stmt).first) {
+    // Any accesses that have index sets will be added.
+    if (access.hasIndexSetModes()) {
+      for (size_t i = 0; i < access.getIndexVars().size(); i++) {
+        if (access.isModeIndexSet(i)) {
+          auto t = access.getModeIndexSetTensor(i);
+          if (tensorVars.count(t) == 0) {
+            ir::Expr irVar = ir::Var::make(t.getName(), t.getType().getDataType(), true, true, pack);
+            tensorVars.insert({t, irVar});
+            indexSetArgs.push_back(irVar);
+          }
+        }
+      }
+    }
+  }
+  argumentsIR.insert(argumentsIR.begin(), indexSetArgs.begin(), indexSetArgs.end());
+
   // Create variables for temporaries
   // TODO Remove this
   for (auto& temp : temporaries) {
@@ -179,6 +198,10 @@ LowererImpl::lower(IndexStmt stmt, string name,
         // the mode input to getDimension is 0-indexed. So, we shift it up by 1.
         auto iter = iterators.levelIterator(ModeAccess(a, mode+1));
         return ir::Div::make(ir::Sub::make(iter.getWindowUpperBound(), iter.getWindowLowerBound()), iter.getStride());
+      } else if (a.isModeIndexSet(mode)) {
+        // If the mode has an index set, then the dimension is the size of
+        // the index set.
+        return ir::Literal::make(a.getIndexSet(mode).size());
       } else {
         return GetProperty::make(tensorVars.at(tv), TensorProperty::Dimension, mode);
       }
@@ -1335,6 +1358,48 @@ Stmt LowererImpl::lowerMergePoint(MergeLattice pointLattice,
   // Load coordinates from position iterators
   Stmt loadPosIterCoordinates = codeToLoadCoordinatesFromPosIterators(iterators, !resolvedCoordDeclared);
 
+  // Any iterators with an index set have extra work to do at the header
+  // of the merge point.
+  std::vector<ir::Stmt> indexSetStmts;
+  for (auto& iter : filter(iterators, [](Iterator it) { return it.hasIndexSet(); })) {
+    // For each iterator A with an index set B, emit the following code:
+    //   setMatch = min(A, B); // Check whether A matches its index set at this point.
+    //   if (A == setMatch && B == setMatch) {
+    //     // If there was a match, project down the values of the iterators
+    //     // to be the position variable of the index set iterator. This has the
+    //     // effect of remapping the index of A to be the i'th position of the set.
+    //     A_coord = B_pos;
+    //     B_coord = B_pos;
+    //   } else {
+    //     // Advance the iterator and it's index set iterator accordingly if
+    //     // there wasn't a match.
+    //     A_pos += (A == setMatch);
+    //     B_pos += (B == setMatch);
+    //     // We must continue so that we only proceed to the rest of the cases in
+    //     // the merge if there actually is a point present for A.
+    //     continue;
+    //   }
+    auto setMatch = ir::Var::make("setMatch", Int());
+    auto indexSetIter = iter.getIndexSetIterator();
+    indexSetStmts.push_back(ir::VarDecl::make(setMatch, ir::Min::make(this->coordinates({iter, indexSetIter}))));
+    // Equality checks for each iterator.
+    auto iterEq = ir::Eq::make(iter.getCoordVar(), setMatch);
+    auto setEq = ir::Eq::make(indexSetIter.getCoordVar(), setMatch);
+    // Code to shift down each iterator to the position space of the index set.
+    auto shiftDown = ir::Block::make(
+      ir::Assign::make(iter.getCoordVar(), indexSetIter.getPosVar()),
+      ir::Assign::make(indexSetIter.getCoordVar(), indexSetIter.getPosVar())
+    );
+    // Code to increment both iterator variables.
+    auto incr = ir::Block::make(
+      compoundAssign(iter.getIteratorVar(), ir::Cast::make(Eq::make(iter.getCoordVar(), setMatch), iter.getIteratorVar().type())),
+      compoundAssign(indexSetIter.getIteratorVar(), ir::Cast::make(Eq::make(indexSetIter.getCoordVar(), setMatch), indexSetIter.getIteratorVar().type())),
+      ir::Continue::make()
+    );
+    // Code that uses the defined parts together in the if-then-else.
+    indexSetStmts.push_back(ir::IfThenElse::make(ir::And::make(iterEq, setEq), shiftDown, incr));
+  }
+
   // Merge iterator coordinate variables
   Stmt resolvedCoordinate = resolveCoordinate(mergers, coordinate, !resolvedCoordDeclared);
 
@@ -1358,6 +1423,7 @@ Stmt LowererImpl::lowerMergePoint(MergeLattice pointLattice,
   /// While loop over rangers
   return While::make(checkThatNoneAreExhausted(rangers),
                      Block::make(loadPosIterCoordinates,
+                                 ir::Block::make(indexSetStmts),
                                  resolvedCoordinate,
                                  loadLocatorPosVars,
                                  deduplicationLoops,
@@ -1804,7 +1870,7 @@ Expr LowererImpl::lowerAccess(Access access) {
   }
 
   if (getIterators(access).back().isUnique()) {
-    if (var.getType().getDataType() == Datatype::Bool && getIterators(access).back().isZeroless())  {
+    if (var.getType().getDataType() == Bool && getIterators(access).back().isZeroless())  {
       return true;
     } else {
       return Load::make(getValuesArray(var), generateValueLocExpr(access));
@@ -2089,7 +2155,7 @@ Stmt LowererImpl::initResultArrays(vector<Access> writes,
 
         parentSize = size;
         // Writes into a windowed iterator require the allocation to be cleared.
-        clearValuesAllocation |= iterator.isWindowed();
+        clearValuesAllocation |= (iterator.isWindowed() || iterator.hasIndexSet());
       }
 
       // Pre-allocate memory for the value array if computing while assembling
@@ -2176,7 +2242,7 @@ ir::Stmt LowererImpl::finalizeResultArrays(std::vector<Access> writes) {
       result.push_back(finalize);
       parentSize = size;
       // Writes into a windowed iterator require the allocation to be cleared.
-      clearValuesAllocation |= iterator.isWindowed();
+      clearValuesAllocation |= (iterator.isWindowed() || iterator.hasIndexSet());
     }
 
     if (!generateComputeCode()) {
@@ -2382,6 +2448,14 @@ Stmt LowererImpl::declLocatePosVars(vector<Iterator> locators) {
         if (locateIterator.isWindowed()) {
           auto expr = coords[coords.size() - 1];
           coords[coords.size() - 1] = this->projectCanonicalSpaceToWindowedPosition(locateIterator, expr);
+        } else if (locateIterator.hasIndexSet()) {
+          // If this dimension iterator operates over an index set, follow the
+          // indirection by using the locator access the index set's crd array.
+          // The resulting value is where we should locate into the actual tensor.
+          auto expr = coords[coords.size() - 1];
+          auto indexSetIterator = locateIterator.getIndexSetIterator();
+          auto coordArray = indexSetIterator.posAccess(expr, coordinates(indexSetIterator)).getResults()[0];
+          coords[coords.size() - 1] = coordArray;
         }
         ModeFunction locate = locateIterator.locate(coords);
         taco_iassert(isValue(locate.getResults()[1], true));
@@ -2609,7 +2683,7 @@ Stmt LowererImpl::codeToIncIteratorVars(Expr coordinate, IndexVar coordinateVar,
     // duplicates and iterator will always advance (i.e., not merging with 
     // another iterator), then deduplication loop will take care of 
     // incrementing iterator variable.
-    return iterators[0].isLeaf() 
+    return iterators[0].isLeaf()
            ? Stmt()
            : Assign::make(ivar, iterators[0].getSegendVar());
   }

--- a/src/lower/merge_lattice.cpp
+++ b/src/lower/merge_lattice.cpp
@@ -122,6 +122,12 @@ private:
       pointIterators.push_back(iterators.modeIterator(i));
     }
 
+    // If the iterator has an index set, then consider that iterator as another
+    // iterator that is part of this point.
+    if (iterator.hasIndexSet()) {
+      pointIterators.push_back(iterator.getIndexSetIterator());
+    }
+
     IndexVar posIteratorDescendant;
     // if this loop is actually iterating over this access then can return iterator (+ coord ranger if applicable)
     // as entire merge point

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -478,6 +478,20 @@ struct AccessTensorNode : public AccessNode {
         this->windowedModes[i].lo = lo;
         this->windowedModes[i].hi = hi;
         this->windowedModes[i].stride = wvar->getStride();
+      }, [&](std::shared_ptr<IndexSetVar> svar) {
+        ivars[i] = svar->getIndexVar();
+        // Extract the user provided index set.
+        auto indexSet = svar->getIndexSet();
+        // Ensure that it has at most dim(t, i) elements.
+        taco_uassert(indexSet.size() <= size_t(tensor.getDimension(i)));
+        // Pack up the index set into a sparse tensor.
+        TensorBase indexSetTensor(tensor.getComponentType(), {int(indexSet.size())}, Compressed);
+        for (auto& coord : indexSet) {
+          indexSetTensor.insert({coord}, 1);
+        }
+        indexSetTensor.pack();
+        this->indexSetModes[i].set = std::make_shared<std::vector<int>>(indexSet);
+        this->indexSetModes[i].tensor = indexSetTensor;
       });
     }
     // Initialize this->indexVars.
@@ -715,6 +729,15 @@ static inline map<TensorVar, TensorBase> getTensors(const IndexExpr& expr) {
         arguments.insert({node->tensorVar, to<AccessTensorNode>(node)->tensor});
       }
 
+      // Also add any tensors backing index sets of tensor accesses.
+      for (auto& p : node->indexSetModes) {
+        auto tv = p.second.tensor.getTensorVar();
+        if (!util::contains(arguments, tv)) {
+          arguments.insert({tv, p.second.tensor});
+        }
+      }
+
+      // TODO (rohany): This seems like dead code.
       TensorBase tensor = to<AccessTensorNode>(node)->tensor;
       if (!util::contains(inserted, tensor)) {
         inserted.insert(tensor);
@@ -733,6 +756,15 @@ vector<void*> packArguments(const TensorBase& tensor) {
 
   // Pack the result tensor
   arguments.push_back(tensor.getStorage());
+
+  // Pack any index sets on the result tensor at the front of the arguments list.
+  auto lhs = getNode(tensor.getAssignment().getLhs());
+  if (isa<AccessTensorNode>(lhs)) {
+    auto indexSetModes = to<AccessTensorNode>(lhs)->indexSetModes;
+    for (auto& it : indexSetModes) {
+      arguments.push_back(it.second.tensor.getStorage());
+    }
+  }
 
   // Pack operand tensors
   auto operands = getArguments(makeConcreteNotation(tensor.getAssignment()));

--- a/test/tests-windowing.cpp
+++ b/test/tests-windowing.cpp
@@ -439,3 +439,94 @@ INSTANTIATE_TEST_CASE_P(
     stride,
     Combine(Values(Dense, Sparse), Values(Dense, Sparse))
 );
+
+// indexSet tests that tensors can be windowed by a user provided set
+// of elements. The test is parameterized by formats of the tested tensors.
+struct indexSetVectors : public TestWithParam<std::tuple<ModeFormat, ModeFormat, ModeFormat>> {};
+TEST_P(indexSetVectors, windowing) {
+  auto dim = 10;
+  auto x = std::get<0>(GetParam());
+  auto y = std::get<1>(GetParam());
+  auto z = std::get<2>(GetParam());
+
+  Tensor<int> a("a", {3}, x);
+  Tensor<int> b("b", {dim}, y);
+  Tensor<int> c("c", {dim}, z);
+  Tensor<int> expected("expected", {3}, Dense);
+  for (int i = 0; i < dim; i++) {
+    b.insert({i}, i);
+    c.insert({i}, i);
+  }
+  expected.insert({0}, 1); expected.insert({1}, 9); expected.insert({2}, 25);
+  b.pack(); c.pack(); expected.pack();
+
+  IndexVar i("i");
+  a(i) = b(i({1, 3, 5})) * c(i({1, 3, 5}));
+  a.evaluate();
+  ASSERT_TRUE(equals(a, expected)) << a << endl << expected << endl << x << " " << y << endl;
+
+  expected = Tensor<int>("expected", {3}, Dense);
+  expected.insert({0}, 2); expected.insert({1}, 6); expected.insert({2}, 10); expected.pack();
+  a(i) = b(i({1, 3, 5})) + c(i({1, 3, 5}));
+  a.evaluate();
+  ASSERT_TRUE(equals(a, expected)) << a << endl << expected << endl << x << " " << y << endl;
+}
+INSTANTIATE_TEST_CASE_P(
+    windowing,
+    indexSetVectors,
+    Combine(Values(Dense, Sparse), Values(Dense, Sparse), Values(Dense, Sparse))
+);
+
+struct indexSetMatrices : public TestWithParam<std::tuple<ModeFormat, ModeFormat, ModeFormat>> {};
+TEST_P(indexSetMatrices, windowing) {
+  auto dim = 10;
+  auto x = std::get<0>(GetParam());
+  auto y = std::get<1>(GetParam());
+  auto z = std::get<2>(GetParam());
+
+  Tensor<int> a("a", {3, 3}, {Dense, x});
+  Tensor<int> expected("expected", {3, 3}, {Dense, Dense});
+  Tensor<int> b("b", {dim, dim}, {Dense, y});
+  Tensor<int> c("c", {dim, dim}, {Dense, z});
+  for (int i = 0; i < dim; i++) {
+    for (int j = 0; j < dim; j++) {
+      b.insert({i, j}, i + j);
+      c.insert({i, j}, i + j);
+    }
+  }
+  expected.insert({0, 0}, 10); expected.insert({0, 1}, 14); expected.insert({0, 2}, 18);
+  expected.insert({1, 0}, 14); expected.insert({1, 1}, 18); expected.insert({1, 2}, 22);
+  expected.insert({2, 0}, 18); expected.insert({2, 1}, 22); expected.insert({2, 2}, 26);
+  b.pack(); c.pack(); expected.pack();
+
+  IndexVar i("i"), j("j");
+  a(i, j) = b(i({1, 3, 5}), j({2, 4, 6})) + c(i({3, 5, 7}), j({4, 6, 8}));
+  a.compile();
+  a.evaluate();
+  ASSERT_TRUE(equals(a, expected)) << a << endl << expected << endl;
+}
+INSTANTIATE_TEST_CASE_P(
+    windowing,
+    indexSetMatrices,
+    Combine(Values(Dense, Sparse), Values(Dense, Sparse), Values(Dense, Sparse))
+);
+
+// lhsIndexSet tests that assignments into tensors with indexSets.
+TEST(windowing, lhsIndexSet) {
+  auto dim = 10;
+  Tensor<int> a("a", {dim}, Dense);
+  Tensor<int> expected("expected", {dim}, Dense);
+  Tensor<int> b("b", {3}, Dense);
+
+  for (int i = 0; i < 3; i++) {
+    b.insert({i}, i+1);
+  }
+  expected.insert({1}, 1); expected.insert({3}, 2); expected.insert({5}, 3);
+  b.pack(); expected.pack();
+
+  IndexVar i("i");
+  a(i({1, 3, 5})) = b(i);
+  a.compile();
+  a.evaluate();
+  ASSERT_TRUE(equals(a, expected)) << a << endl << expected << endl;
+}


### PR DESCRIPTION
This commit adds support for using vectors to index arbitrary dimensions
of tensors. It works by packing the vector into a sparse tensor, and
coiterating over the sparse tensor to efficiently filter the chosen
dimensions. The syntax of indexing sets look as follows:

```
A(i) = B(i({1, 3, 5}))
```

which means that only elements 1, 3, and 5 from `B` will be used in the
computation.