### PR TITLE
tensor: allow `compute` to bypass caching mechanism

### DIFF
--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -420,7 +420,10 @@ public:
   void assemble();
 
   /// Compute the given expression and put the values in the tensor storage.
-  void compute();
+  /// If force is true, then tensor expression will be executed, whether or
+  /// or not the tensor expression has been evaluated already. force is useful
+  /// in situations like benchmarking.
+  void compute(bool force = false);
 
   /// Compile, assemble and compute as needed.
   void evaluate();

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -766,9 +766,10 @@ void TensorBase::assemble() {
   }
 }
 
-void TensorBase::compute() {
+void TensorBase::compute(bool force) {
   taco_uassert(!needsCompile()) << error::compute_without_compile;
-  if (!needsCompute()) {
+  // Return if the tensor doesn't need compute and the computation isn't forced.
+  if (!needsCompute() && !force) {
     return;
   }
   setNeedsCompute(false);


### PR DESCRIPTION
This commit adds a boolean to the `TensorBase::compute` method allowing
for bypass of the compute caching mechanism. This is useful when
benchmarking the generated kernels.