### PR TITLE
Unbreak cmake build of python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ if(NOT EXISTS "${TACO_PROJECT_DIR}/python_bindings/pybind11/CMakeLists.txt")
 endif()
 
 if(PYTHON)
+  add_subdirectory(python_bindings)
   message("-- Will build Python extension")
   add_definitions(-DPYTHON)
 endif(PYTHON)


### PR DESCRIPTION
This `add_subdirectory` line got removed somehow in #400, and I think it's still needed.  Without it, configuring with `-DPYTHON=ON` doesn't build Python bindings.

@RawnH , please review.