### PR TITLE
*: add the ability to stride window access (to array_algebra branch)

### DIFF
--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -249,6 +249,12 @@ public:
   int getWindowLowerBound(int mode) const;
   int getWindowUpperBound(int mode) const;
 
+  /// getWindowSize returns the dimension size of a window.
+  int getWindowSize(int mode) const;
+
+  /// getStride returns the stride of a window.
+  int getStride(int mode) const;
+
   /// Assign the result of an expression to a left-hand-side tensor access.
   /// ```
   /// a(i) = b(i) * c(i);
@@ -890,7 +896,7 @@ public:
 /// before IndexVar so that IndexVar can return objects of type WindowedIndexVar.
 class WindowedIndexVar : public util::Comparable<WindowedIndexVar>, public IndexVarInterface {
 public:
-  WindowedIndexVar(IndexVar base, int lo = -1, int hi = -1);
+  WindowedIndexVar(IndexVar base, int lo = -1, int hi = -1, int stride = 1);
   ~WindowedIndexVar() = default;
 
   /// getIndexVar returns the underlying IndexVar.
@@ -900,6 +906,11 @@ public:
   /// this index variable.
   int getLowerBound() const;
   int getUpperBound() const;
+  /// getStride returns the stride to access the window by.
+  int getStride() const;
+
+  /// getWindowSize returns the number of elements in the window.
+  int getWindowSize() const;
 
 private:
   struct Content;
@@ -931,7 +942,7 @@ public:
   typedef IndexVarNode Node;
 
   /// Indexing into an IndexVar returns a window into it.
-  WindowedIndexVar operator()(int lo, int hi);
+  WindowedIndexVar operator()(int lo, int hi, int stride = 1);
 
 private:
   struct Content;
@@ -946,6 +957,7 @@ struct WindowedIndexVar::Content {
   IndexVar base;
   int lo;
   int hi;
+  int stride;
 };
 
 std::ostream& operator<<(std::ostream&, const std::shared_ptr<IndexVarInterface>&);

--- a/include/taco/index_notation/index_notation_nodes.h
+++ b/include/taco/index_notation/index_notation_nodes.h
@@ -25,14 +25,18 @@ namespace taco {
 struct AccessWindow {
   int lo;
   int hi;
+  int stride;
   friend bool operator==(const AccessWindow& a, const AccessWindow& b) {
-    return a.lo == b.lo && a.hi == b.hi;
+    return a.lo == b.lo && a.hi == b.hi && a.stride == b.stride;
   }
   friend bool operator<(const AccessWindow& a, const AccessWindow& b) {
     if (a.lo != b.lo) {
       return a.lo < b.lo;
     }
-    return a.hi < b.hi;
+    if (a.hi != b.hi) {
+      return a.hi < b.hi;
+    }
+    return a.stride < b.stride;
   }
 };
 

--- a/include/taco/lower/iterator.h
+++ b/include/taco/lower/iterator.h
@@ -165,10 +165,22 @@ public:
   /// of a tensor mode.
   bool isWindowed() const;
 
+  /// isStrided returns true if this iterator has a stride != 1. Currently
+  /// only windowed iterators can have strides.
+  bool isStrided() const;
+
   /// getWindow{Lower,Upper}Bound return the {Lower,Upper} bound of the
   /// window that this iterator operates over.
   ir::Expr getWindowLowerBound() const;
   ir::Expr getWindowUpperBound() const;
+
+  /// getStride returns an Expr holding the stride that this iterator is
+  /// configured with.
+  ir::Expr getStride() const;
+
+  /// getWindowVar returns a Var specific to thw window that this iterator
+  /// is operating over. It can be used as temporary storage.
+  ir::Expr getWindowVar() const;
 
   friend bool operator==(const Iterator&, const Iterator&);
   friend bool operator<(const Iterator&, const Iterator&);
@@ -183,7 +195,7 @@ private:
 
   friend class Iterators;
   /// setWindowBounds sets the window bounds of this iterator.
-  void setWindowBounds(ir::Expr lo, ir::Expr hi);
+  void setWindowBounds(ir::Expr lo, ir::Expr hi, ir::Expr stride);
 };
 
 /**

--- a/include/taco/lower/lowerer_impl.h
+++ b/include/taco/lower/lowerer_impl.h
@@ -463,6 +463,12 @@ protected:
   // range of [lo, hi).
   ir::Expr projectCanonicalSpaceToWindowedPosition(Iterator iterator, ir::Expr expr);
 
+  /// strideBoundsGuard inserts a guard against accessing values from an
+  /// iterator that don't fit in the stride that the iterator is configured
+  /// with. It takes a boolean incrementPosVars to control whether the outer
+  /// loop iterator variable should be incremented when the guard is fired.
+  ir::Stmt strideBoundsGuard(Iterator iterator, ir::Expr access, bool incrementPosVar);
+
 private:
   bool assemble;
   bool compute;

--- a/src/error/error_checks.cpp
+++ b/src/error/error_checks.cpp
@@ -58,7 +58,7 @@ std::pair<bool, string> dimensionsTypecheck(const std::vector<IndexVar>& resultV
       // as the shape, rather than the shape of the underlying tensor.
       auto a = Access(readNode);
       if (a.isModeWindowed(mode)) {
-        dimension = Dimension(a.getWindowUpperBound(mode) - a.getWindowLowerBound(mode));
+        dimension = Dimension(a.getWindowSize(mode));
       }
 
       if (util::contains(indexVarDims,var) && indexVarDims.at(var) != dimension) {

--- a/src/lower/iterator.cpp
+++ b/src/lower/iterator.cpp
@@ -33,9 +33,15 @@ struct Iterator::Content {
   // the expressions representing an upper and lower bound. An iterator
   // is windowed if window is not NULL.
   struct Window {
-      ir::Expr lo;
-      ir::Expr hi;
-      Window(ir::Expr _lo, ir::Expr _hi) : lo(_lo), hi(_hi) {};
+    // windowVar is a Var specific to this iterator. It is intended to
+    // be used as temporary storage to avoid duplicate memory loads of
+    // expressions that are used in window/stride related bounds checking.
+    ir::Expr windowVar;
+    ir::Expr lo;
+    ir::Expr hi;
+    ir::Expr stride;
+    Window(ir::Expr _lo, ir::Expr _hi, ir::Expr _stride, ir::Expr _windowVar) :
+      windowVar(_windowVar), lo(_lo), hi(_hi), stride(_stride) {};
   };
   std::unique_ptr<Window> window;
 };
@@ -353,8 +359,28 @@ ir::Expr Iterator::getWindowUpperBound() const {
   return this->content->window->hi;
 }
 
-void Iterator::setWindowBounds(ir::Expr lo, ir::Expr hi) {
-  this->content->window = std::make_unique<Content::Window>(Content::Window(lo, hi));
+ir::Expr Iterator::getStride() const {
+  taco_iassert(this->isWindowed());
+  return this->content->window->stride;
+}
+
+ir::Expr Iterator::getWindowVar() const {
+  taco_iassert(this->isWindowed());
+  return this->content->window->windowVar;
+}
+
+bool Iterator::isStrided() const {
+  // It's not necessary but makes things simpler to require a window in order
+  // to have a stride.
+  taco_iassert(this->isWindowed());
+  auto strideLiteral = this->content->window->stride.as<ir::Literal>();
+  return !(strideLiteral != nullptr && strideLiteral->getIntValue() == 1);
+}
+
+void Iterator::setWindowBounds(ir::Expr lo, ir::Expr hi, ir::Expr stride) {
+  auto windowVarName = this->getIndexVar().getName() + this->getMode().getName() + "_window";
+  auto wvar = ir::Var::make(windowVarName, Int());
+  this->content->window = std::make_unique<Content::Window>(Content::Window(lo, hi, stride, wvar));
 }
 
 bool operator==(const Iterator& a, const Iterator& b) {
@@ -516,7 +542,8 @@ Iterators::createAccessIterators(Access access, Format format, Expr tensorIR, Pr
       if (access.isModeWindowed(modeNumber)) {
         auto lo = ir::Literal::make(access.getWindowLowerBound(modeNumber));
         auto hi = ir::Literal::make(access.getWindowUpperBound(modeNumber));
-        iterator.setWindowBounds(lo, hi);
+        auto stride = ir::Literal::make(access.getStride(modeNumber));
+        iterator.setWindowBounds(lo, hi, stride);
       }
 
       content->levelIterators.insert({{access,modeNumber+1}, iterator});

--- a/src/lower/lowerer_impl.cpp
+++ b/src/lower/lowerer_impl.cpp
@@ -182,7 +182,7 @@ LowererImpl::lower(IndexStmt stmt, string name,
         // The mode value used to access .levelIterator is 1-indexed, while
         // the mode input to getDimension is 0-indexed. So, we shift it up by 1.
         auto iter = iterators.levelIterator(ModeAccess(a, mode+1));
-        return ir::Sub::make(iter.getWindowUpperBound(), iter.getWindowLowerBound());
+        return ir::Div::make(ir::Sub::make(iter.getWindowUpperBound(), iter.getWindowLowerBound()), iter.getStride());
       } else {
         return GetProperty::make(tensorVars.at(tv), TensorProperty::Dimension, mode);
       }
@@ -1048,6 +1048,7 @@ Stmt LowererImpl::lowerForallPosition(Forall forall, Iterator iterator,
 {
   Expr coordinate = getCoordinateVar(forall.getIndexVar());
   Stmt declareCoordinate = Stmt();
+  Stmt strideGuard = Stmt();
   Stmt boundsGuard = Stmt();
   if (provGraph.isCoordVariable(forall.getIndexVar())) {
     Expr coordinateArray = iterator.posAccess(iterator.getPosVar(),
@@ -1055,6 +1056,13 @@ Stmt LowererImpl::lowerForallPosition(Forall forall, Iterator iterator,
     // If the iterator is windowed, we must recover the coordinate index
     // variable from the windowed space.
     if (iterator.isWindowed()) {
+      if (iterator.isStrided()) {
+        // In this case, we're iterating over a compressed level with a for
+        // loop. Since the iterator variable will get incremented by the for
+        // loop, the guard introduced for stride checking doesn't need to
+        // increment the iterator variable.
+        strideGuard = this->strideBoundsGuard(iterator, coordinateArray, false /* incrementPosVar */);
+      }
       coordinateArray = this->projectWindowedPositionToCanonicalSpace(iterator, coordinateArray);
       // If this forall is being parallelized via CPU threads (OpenMP), then we can't
       // emit a `break` statement, since OpenMP doesn't support breaking out of a
@@ -1133,7 +1141,7 @@ Stmt LowererImpl::lowerForallPosition(Forall forall, Iterator iterator,
   return Block::blanks(
                        boundsCompute,
                        For::make(iterator.getPosVar(), startBound, endBound, 1,
-                                 Block::make(declareCoordinate, boundsGuard, body),
+                                 Block::make(strideGuard, declareCoordinate, boundsGuard, body),
                                  kind,
                                  ignoreVectorize ? ParallelUnit::NotParallel : forall.getParallelUnit(), ignoreVectorize ? 0 : forall.getUnrollFactor()),
                        posAppend);
@@ -1402,15 +1410,34 @@ Stmt LowererImpl::resolveCoordinate(std::vector<Iterator> mergers, ir::Expr coor
       ModeFunction posAccess = merger.posAccess(merger.getPosVar(),
                                                 coordinates(merger));
       auto access = posAccess[0];
+      auto windowVarDecl = Stmt();
+      auto stride = Stmt();
       auto guard = Stmt();
       // If the iterator is windowed, we must recover the coordinate index
       // variable from the windowed space.
       if (merger.isWindowed()) {
+
+        // If the iterator is strided, then we have to skip over coordinates
+        // that don't match the stride. To do that, we insert a guard on the
+        // access. We first extract the access into a temp to avoid emitting
+        // a duplicate load on the _crd array.
+        if (merger.isStrided()) {
+          windowVarDecl = VarDecl::make(merger.getWindowVar(), access);
+          access = merger.getWindowVar();
+          // Since we're merging values from a compressed array (not iterating over it),
+          // we need to advance the outer loop if the current coordinate is not
+          // along the desired stride. So, we pass true to the incrementPosVar
+          // argument of strideBoundsGuard.
+          stride = this->strideBoundsGuard(merger, access, true /* incrementPosVar */);
+        }
+
         access = this->projectWindowedPositionToCanonicalSpace(merger, access);
         guard = this->upperBoundGuardForWindowPosition(merger, coordinate);
       }
       Stmt resolution = emitVarDecl ? VarDecl::make(coordinate, access) : Assign::make(coordinate, access);
       return Block::make(posAccess.compute(),
+                         windowVarDecl,
+                         stride,
                          resolution,
                          guard);
     }
@@ -2938,6 +2965,21 @@ Stmt LowererImpl::codeToLoadCoordinatesFromPosIterators(vector<Iterator> iterato
       // TODO (rohany): Would be cleaner to have this logic be moved into the
       //  ModeFunction, rather than having to check in some places?
       if (posIter.isWindowed()) {
+
+        // If the iterator is strided, then we have to skip over coordinates
+        // that don't match the stride. To do that, we insert a guard on the
+        // access. We first extract the access into a temp to avoid emitting
+        // a duplicate load on the _crd array.
+        if (posIter.isStrided()) {
+          loadPosIterCoordinateStmts.push_back(VarDecl::make(posIter.getWindowVar(), access));
+          access = posIter.getWindowVar();
+          // Since we're locating into a compressed array (not iterating over it),
+          // we need to advance the outer loop if the current coordinate is not
+          // along the desired stride. So, we pass true to the incrementPosVar
+          // argument of strideBoundsGuard.
+          loadPosIterCoordinateStmts.push_back(this->strideBoundsGuard(posIter, access, true /* incrementPosVar */));
+        }
+
         access = this->projectWindowedPositionToCanonicalSpace(posIter, access);
       }
       if (declVars) {
@@ -3113,19 +3155,37 @@ Expr LowererImpl::searchForEndOfWindowPosition(Iterator iterator, ir::Expr start
 }
 
 Stmt LowererImpl::upperBoundGuardForWindowPosition(Iterator iterator, ir::Expr access) {
-    taco_iassert(iterator.isWindowed());
-    return ir::IfThenElse::make(
-            ir::Gte::make(access, ir::Sub::make(iterator.getWindowUpperBound(), iterator.getWindowLowerBound())),
-            ir::Break::make()
-    );
+  taco_iassert(iterator.isWindowed());
+  return ir::IfThenElse::make(
+    ir::Gte::make(access, ir::Sub::make(iterator.getWindowUpperBound(), iterator.getWindowLowerBound())),
+    ir::Break::make()
+  );
+}
+
+Stmt LowererImpl::strideBoundsGuard(Iterator iterator, ir::Expr access, bool incrementPosVar) {
+  Stmt cont = ir::Continue::make();
+  // If requested to increment the iterator's position variable, add the increment
+  // before the continue statement.
+  if (incrementPosVar) {
+    cont = ir::Block::make({
+                               ir::Assign::make(iterator.getPosVar(),
+                                                ir::Add::make(iterator.getPosVar(), ir::Literal::make(1))),
+                               cont
+                           });
+  }
+  // The guard makes sure that the coordinate being accessed is along the stride.
+  return ir::IfThenElse::make(
+      ir::Neq::make(ir::Rem::make(access, iterator.getStride()), ir::Literal::make(0)),
+      cont
+  );
 }
 
 Expr LowererImpl::projectWindowedPositionToCanonicalSpace(Iterator iterator, ir::Expr expr) {
-  return ir::Sub::make(expr, iterator.getWindowLowerBound());
+  return ir::Div::make(ir::Sub::make(expr, iterator.getWindowLowerBound()), iterator.getStride());
 }
 
 Expr LowererImpl::projectCanonicalSpaceToWindowedPosition(Iterator iterator, ir::Expr expr) {
-  return ir::Add::make(expr, iterator.getWindowLowerBound());
+  return ir::Mul::make(ir::Add::make(expr, iterator.getWindowLowerBound()), iterator.getStride());
 }
 
 }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -495,6 +495,7 @@ struct AccessTensorNode : public AccessNode {
           "slice upper bound must be <= tensor dimension (" << tensor.getDimension(i) << ")";
         this->windowedModes[i].lo = lo;
         this->windowedModes[i].hi = hi;
+        this->windowedModes[i].stride = wvar->getStride();
       });
     }
     // Initialize this->indexVars.


### PR DESCRIPTION
This commit extends the windowing syntax to include an optional third
parameter to a window expression on an index variable:

```
a(i) = b(i(0, n, 5 /* stride */))
```

This stride parameters means that the window should be accessed along
the provided stride, which defaults to 1.

Striding is implemented with a similar idea as windowing, where
coordinates in the stride are mapped to a canonical index space of `[0,n)`.
For compressed modes, coordinates that don't match the stride are
skipped.