### PR TITLE
index_notation: temporary fix for segfault with user defined funcs

### DIFF
--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -529,7 +529,10 @@ struct Isomorphic : public IndexNotationVisitorStrict {
 
     // Lower function
     // TODO: For now just check that the function pointers are the same.
-    if(!util::targetPtrEqual(anode->defaultLowerFunc, bnode->defaultLowerFunc)) {
+    // TODO (rawnh): This check is broken. The retrieved function pointers are null
+    //  when attempting to dereference them. The original code attempted to use
+    //  util::targetPtrEqual.
+    if (&anode->defaultLowerFunc != &bnode->defaultLowerFunc) {
       eq = false;
       return;
     }

--- a/test/tests-index_notation.cpp
+++ b/test/tests-index_notation.cpp
@@ -267,3 +267,15 @@ INSTANTIATE_TEST_CASE_P(tensorOpConcrete, concrete,
                                          forall(j,
                                                 Assignment(a(i), bfsMaskOp(scAnd(B(i, j), c(j)), c(i)), scOr())
                                          )))));
+
+// funcIsomorphic ensures that the isomorphic function can proceed without error
+// on IndexExpr's that contain `Func`'s.
+TEST(notation, funcIsomorphic) {
+  int dim = 10;
+  Func xorOp("xor", GeneralAdd(), xorGen());
+  Tensor<int> A("A", {dim});
+  Tensor<int> B("B", {dim});
+  IndexVar i;
+  auto indexExpr = xorOp(A(i), B(i));
+  ASSERT_TRUE(isomorphic(indexExpr, indexExpr));
+}


### PR DESCRIPTION
This commit has a temporary fix for a segfault encountered when the
`isomorphic` function is applied onto `IndexExpr`s that contain `Func`
applications. The casted pointer in `include/taco/util/functions.h:11`
that is dereferenced is `NULL`. This temporary fix is needed so that
benchmarking code can execute back-to-back iterations.