### PR TITLE
taco: add parser support for windowing/striding/index sets

### DIFF
--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -877,6 +877,7 @@ Multi multi(IndexStmt stmt1, IndexStmt stmt2);
 class IndexVarInterface {
 public:
   virtual ~IndexVarInterface() = default;
+  virtual IndexVar getIndexVar() const = 0;
 
   /// match performs a dynamic case analysis of the implementers of IndexVarInterface
   /// as a utility for handling the different values within. It mimics the dynamic
@@ -912,7 +913,7 @@ public:
   ~WindowedIndexVar() = default;
 
   /// getIndexVar returns the underlying IndexVar.
-  IndexVar getIndexVar() const;
+  IndexVar getIndexVar() const override;
 
   /// get{Lower,Upper}Bound returns the {lower,upper} bound of the window of
   /// this index variable.
@@ -940,7 +941,7 @@ public:
   ~IndexSetVar() = default;
 
   /// getIndexVar returns the underlying IndexVar.
-  IndexVar getIndexVar() const;
+  IndexVar getIndexVar() const override;
   /// getIndexSet returns the index set.
   const std::vector<int>& getIndexSet() const;
 
@@ -957,6 +958,9 @@ public:
   ~IndexVar() = default;
   IndexVar(const std::string& name);
 
+  // getIndexVar implements the IndexVarInterface.
+  IndexVar getIndexVar() const override { return *this; }
+
   /// Returns the name of the index variable.
   std::string getName() const;
 
@@ -967,7 +971,7 @@ public:
   WindowedIndexVar operator()(int lo, int hi, int stride = 1);
 
   /// Indexing into an IndexVar with a vector returns an index set into it.
-  IndexSetVar operator()(std::vector<int> indexSet);
+  IndexSetVar operator()(std::vector<int>&& indexSet);
   IndexSetVar operator()(std::vector<int>& indexSet);
 
 private:

--- a/include/taco/parser/parser.h
+++ b/include/taco/parser/parser.h
@@ -14,6 +14,7 @@ namespace taco {
 class TensorBase;
 class Format;
 class IndexVar;
+class IndexVarInterface;
 class IndexExpr;
 class Access;
 
@@ -88,10 +89,13 @@ private:
   Access parseAccess();
 
   /// varlist ::= var {, var}
-  std::vector<IndexVar> parseVarList();
+  std::vector<std::shared_ptr<IndexVarInterface>> parseVarList();
 
   /// var ::= identifier
-  IndexVar parseVar();
+  ///       | identifier '(' int ',' int ')' -- Windowed access.
+  ///       | identifier '(' int ',' int ',' int ')' -- Windowed access with a stride.
+  ///       | identifier '(' '{' int, ... '}' ')' -- Access with an index set.
+  std::shared_ptr<IndexVarInterface> parseVar();
 
   std::string currentTokenString();
 

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -1978,7 +1978,7 @@ WindowedIndexVar IndexVar::operator()(int lo, int hi, int stride) {
   return WindowedIndexVar(*this, lo, hi, stride);
 }
 
-IndexSetVar IndexVar::operator()(std::vector<int> indexSet) {
+IndexSetVar IndexVar::operator()(std::vector<int>&& indexSet) {
   return IndexSetVar(*this, indexSet);
 }
 

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -486,7 +486,7 @@ struct AccessTensorNode : public AccessNode {
         // Ensure that it has at most dim(t, i) elements.
         taco_uassert(indexSet.size() <= size_t(tensor.getDimension(i)));
         // Pack up the index set into a sparse tensor.
-        TensorBase indexSetTensor(tensor.getComponentType(), {int(indexSet.size())}, Compressed);
+        Tensor<int> indexSetTensor({int(indexSet.size())}, Compressed);
         for (auto& coord : indexSet) {
           indexSetTensor.insert({coord}, 1);
         }

--- a/tools/taco.cpp
+++ b/tools/taco.cpp
@@ -90,6 +90,9 @@ static void printUsageInfo() {
   cout << "  taco \"a(i) = b(i) + c(i)\" -f=b:s -f=c:s -f=a:s       # Sparse vector add" << endl;
   cout << "  taco \"a(i) = B(i,j) * c(j)\" -f=B:ds                  # SpMV" << endl;
   cout << "  taco \"A(i,l) = B(i,j,k) * C(j,l) * D(k,l)\" -f=B:sss  # MTTKRP" << endl;
+  cout << "  taco \"a(i) = b(i(1, 5))\" -d=a:4                      # Slice b[1:4]" << endl;
+  cout << "  taco \"a(i) = b(i(1, 5, 2))\" -d=a:2                   # Slice b[1:4:2]" << endl;
+  cout << "  taco \"a(i) = b(i({1, 3, 5, 7}))\" -d=a:4              # Slice b[[1, 3, 5, 7]]" << endl;
   cout << endl;
   cout << "Options:" << endl;
   printFlag("d=<var/tensor>:<size>",


### PR DESCRIPTION
Fixes #413.

This commit adds support for the command line tool to accept index
expressions containing windowing, striding and index sets. An example
of each of these features is added to the help message of taco:
```
taco "a(i) = b(i(1, 5))" -d=a:4          # Slice b[1:4]
taco "a(i) = b(i(1, 5, 2))" -d=a:2       # Slice b[1:4:2]
taco "a(i) = b(i({1, 3, 5, 7}))" -d=a:4  # Slice b[[1, 3, 5, 7]]
```