### PR TITLE
Fix package version issue in CI tests

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -59,6 +59,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: apt-get update
+        run: sudo apt-get update
       - name: install numpy and scipy
         run: sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3-numpy python3-scipy
       - name: create_build


### PR DESCRIPTION
The CI tests currenty fail with:

```
Get:5 http://azure.archive.ubuntu.com/ubuntu bionic/main amd64 python3-olefile all 0.45.1-1 [33.3 kB]
Ign:6 http://azure.archive.ubuntu.com/ubuntu bionic-updates/main amd64 python3-pil amd64 5.1.0-1ubuntu0.4
Get:7 http://azure.archive.ubuntu.com/ubuntu bionic/universe amd64 python3-scipy amd64 0.19.1-2ubuntu1 [9619 kB]
Err:6 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 python3-pil amd64 5.1.0-1ubuntu0.4
  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/p/pillow/python3-pil_5.1.0-1ubuntu0.4_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
Fetched 11.6 MB in 1s (23.0 MB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```

Run "apt-get update" to update the package list before installing numpy/scipy.
