### PR TITLE
Remove a default parameter in a lambda.

### DIFF
--- a/python_bindings/src/pytaco.cpp
+++ b/python_bindings/src/pytaco.cpp
@@ -69,7 +69,7 @@ Examples
 
 
 
-  m.def("set_parallel_schedule", [](std::string sched_type, int chunk_size = 0){
+  m.def("set_parallel_schedule", [](std::string sched_type, int chunk_size) {
     std::transform(sched_type.begin(), sched_type.end(), sched_type.begin(), ::tolower);
 
     if(sched_type == "static") {


### PR DESCRIPTION
Ubuntu 18.04.5 LTS
g++ (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
cmake -DPYTHON=ON

This fixes the following build failure:
```
[ 94%] Building CXX object python_bindings/CMakeFiles/core_modules.dir/src/pytaco.cpp.o
.../taco/python_bindings/src/pytaco.cpp: In function 'void addHelpers(pybind11::module&)':
.../taco/python_bindings/src/pytaco.cpp:72:78: error: default argument specified for lambda parameter [-Wpedantic]
   m.def("set_parallel_schedule", [](std::string sched_type, int chunk_size = 0){
                                                                              ^
```

Cc: @RawnH

Apparently, when you configure without a `CMAKE_BUILD_TYPE` value, the default is to build in c++11 mode.  This syntax is only allowed in C++14 onwards.

Is this the right fix?  It fixes the build and lets tests pass.  But I don't know what happens when called from Python without a second parameter.
