### PR TITLE
index_notation,tensor: small bugfixes for index sets

### DIFF
--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -967,7 +967,7 @@ public:
   WindowedIndexVar operator()(int lo, int hi, int stride = 1);
 
   /// Indexing into an IndexVar with a vector returns an index set into it.
-  IndexSetVar operator()(std::vector<int> indexSet);
+  IndexSetVar operator()(std::vector<int>&& indexSet);
   IndexSetVar operator()(std::vector<int>& indexSet);
 
 private:

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -1978,7 +1978,7 @@ WindowedIndexVar IndexVar::operator()(int lo, int hi, int stride) {
   return WindowedIndexVar(*this, lo, hi, stride);
 }
 
-IndexSetVar IndexVar::operator()(std::vector<int> indexSet) {
+IndexSetVar IndexVar::operator()(std::vector<int>&& indexSet) {
   return IndexSetVar(*this, indexSet);
 }
 

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -486,7 +486,7 @@ struct AccessTensorNode : public AccessNode {
         // Ensure that it has at most dim(t, i) elements.
         taco_uassert(indexSet.size() <= size_t(tensor.getDimension(i)));
         // Pack up the index set into a sparse tensor.
-        TensorBase indexSetTensor(tensor.getComponentType(), {int(indexSet.size())}, Compressed);
+        TensorBase indexSetTensor(type<int>(), {int(indexSet.size())}, Compressed);
         for (auto& coord : indexSet) {
           indexSetTensor.insert({coord}, 1);
         }


### PR DESCRIPTION
* Fixes a runtime error when using index sets on tensors not of integer types
* Fixes a compile error when using a vector typed variable as argument
  for an index set.