### PR TITLE
Allow CLI precompute() to specify the workspace name

### DIFF
--- a/tools/taco.cpp
+++ b/tools/taco.cpp
@@ -355,11 +355,17 @@ static bool setSchedulingCommands(vector<vector<string>> scheduleCommands, parse
       IndexVar divide2(i2);
       stmt = stmt.divide(findVar(i), divide1, divide2, divideFactor);
     } else if (command == "precompute") {
-      string exprStr, i, iw;
-      taco_uassert(scheduleCommand.size() == 3) << "'precompute' scheduling directive takes 3 parameters: precompute(expr, i, iw)";
+      string exprStr, i, iw, name;
+      taco_uassert(scheduleCommand.size() == 3 || scheduleCommand.size() == 4)
+        << "'precompute' scheduling directive takes 3 or 4 parameters: "
+        << "precompute(expr, i, iw [, workspace_name])";
       exprStr = scheduleCommand[0];
       i       = scheduleCommand[1];
       iw      = scheduleCommand[2];
+      if (scheduleCommand.size() == 4)
+        name  = scheduleCommand[3];
+      else
+        name  = "workspace";
 
       IndexVar orig = findVar(i);
       IndexVar pre;
@@ -432,9 +438,8 @@ static bool setSchedulingCommands(vector<vector<string>> scheduleCommands, parse
         dim = Dimension(orig);
       }
 
-      TensorVar workspace("workspace", Type(Float64, {dim}), Dense);
+      TensorVar workspace(name, Type(Float64, {dim}), Dense);
       stmt = stmt.precompute(visitor.expr, orig, pre, workspace);
-      std::cout << "stmt: " << stmt << std::endl;
 
     } else if (command == "reorder") {
       taco_uassert(scheduleCommand.size() > 1) << "'reorder' scheduling directive needs at least 2 parameters: reorder(outermost, ..., innermost)";


### PR DESCRIPTION
The C++ scheduling API allows naming the workspace for `precompute()` calls.  The CLI tool always uses the name "workspace".

This patch adds an optional 4th parameter to the CLI `precompute()` directive, to specify the name of the workspace.  This makes it more consistent with the C++ API.  The patch also removes a debug message that was left in the CLI precompute code.

Here's an example with output:

```c
taco 'A(i) = B(i)*1 * C(i)' -s='precompute(B(i)*1,i,i,bi)' 
// Generated by the Tensor Algebra Compiler (tensor-compiler.org)

int compute(taco_tensor_t *A, taco_tensor_t *B, taco_tensor_t *C) {
  int A1_dimension = (int)(A->dimensions[0]);
  double* restrict A_vals = (double*)(A->vals);
  int B1_dimension = (int)(B->dimensions[0]);
  double* restrict B_vals = (double*)(B->vals);
  int C1_dimension = (int)(C->dimensions[0]);
  double* restrict C_vals = (double*)(C->vals);

  double* restrict bi = 0;
  bi = (double*)malloc(sizeof(double) * C1_dimension);
  for (int32_t pbi = 0; pbi < C1_dimension; pbi++) {
    bi[pbi] = 0.0;
  }
  for (int32_t i = 0; i < C1_dimension; i++) {
    bi[i] = B_vals[i];
  }
  for (int32_t i = 0; i < C1_dimension; i++) {
    A_vals[i] = bi[i] * C_vals[i];
  }
  free(bi);

  A->vals = (uint8_t*)A_vals;
  return 0;
}
```

Is it possible to use multiple workspaces in the same generated compute function?  If so, this will help with that.