### PR TITLE
CLI tool treats double hyphens as a single hyphen

### DIFF
--- a/tools/taco.cpp
+++ b/tools/taco.cpp
@@ -630,6 +630,10 @@ int main(int argc, char* argv[]) {
 
   for (int i = 1; i < argc; i++) {
     string arg = argv[i];
+    if(arg.rfind("--", 0) == 0) {
+      // treat leading "--" as if it were "-"
+      arg = string(argv[i]+1);
+    }
     vector<string> argparts = util::split(arg, "=");
     if (argparts.size() > 2) {
       return reportError("Too many '\"' signs in argument", 5);


### PR DESCRIPTION
I am constantly making the mistake of typing `--print-nocolor` instead of `-print-nocolor`, `--version` instead of `-version`, `--write-source` instead of `-write-source`.  This is my own fault, I'm too used to other command line tools that use `getopt_long` and take double hyphens for long options.  But it's a hard habit to break.

This patch detects two leading hyphens and ignores the first one.  The result is that TACO accepts both option passing styles.

Before:

```
% bin/taco 'a(i) = b(i)' --print-nocolor
Usage: taco <index expression> [options]

Examples:
  taco "a(i) = b(i) + c(i)"                            # Dense vector add
  taco "a(i) = b(i) + c(i)" -f=b:s -f=c:s -f=a:s       # Sparse vector add
[etc etc]
```

After:

```
% bin/taco 'a(i) = b(i)' --print-nocolor
// Generated by the Tensor Algebra Compiler (tensor-compiler.org)

int compute(taco_tensor_t *a, taco_tensor_t *b) {
  int a1_dimension = (int)(a->dimensions[0]);
  double* restrict a_vals = (double*)(a->vals);
  int b1_dimension = (int)(b->dimensions[0]);
  double* restrict b_vals = (double*)(b->vals);

  #pragma omp parallel for schedule(runtime)
  for (int32_t i = 0; i < b1_dimension; i++) {
    a_vals[i] = b_vals[i];
  }
  return 0;
}

```
