### PR TITLE
Better error message for guarding unguardable loops

### DIFF
--- a/src/lower/lowerer_impl.cpp
+++ b/src/lower/lowerer_impl.cpp
@@ -896,6 +896,10 @@ Stmt LowererImpl::lowerForallCloned(Forall forall) {
   }
 
   Stmt unvectorizedLoop;
+
+  taco_uassert(guardCondition.defined())
+    << "Unable to vectorize or unroll loop over unbound variable " << forall.getIndexVar();
+
   // build loop with guards (not vectorized)
   if (!varsWithGuard.empty()) {
     ignoreVectorize = true;


### PR DESCRIPTION
This improves error reporting in the case where the lowerer fails to emit guard conditions for unrolled/vectorized loops.

See #437 for examples of this.

Before:
```sh
$ bin/taco "a(i) = b(i) * c(i)" -s="parallelize(i,CPUVector,NoRaces)"
terminate called after throwing an instance of 'taco::TacoException'
  what():  Compiler bug at /home/infinoid/workspace/taco/git/src/ir/ir.cpp:599 in make
Please report it to developers
 Condition failed: then.defined()
 
Aborted
$ bin/taco "a(i) = b(i) * c(i)" -s="unroll(i,4)"
terminate called after throwing an instance of 'taco::TacoException'
  what():  Compiler bug at /home/infinoid/workspace/taco/git/src/ir/ir.cpp:599 in make
Please report it to developers
 Condition failed: then.defined()
 
Aborted
```

After:

```sh
$ bin/taco "a(i) = b(i) * c(i)" -s="parallelize(i,CPUVector,NoRaces)"
terminate called after throwing an instance of 'taco::TacoException'
  what():  Error at /home/infinoid/workspace/taco/git/src/lower/lowerer_impl.cpp:900 in lowerForallCloned:
 Unable to vectorize or unroll loop over unbound variable i
Aborted
$ bin/taco "a(i) = b(i) * c(i)" -s="unroll(i,4)"
terminate called after throwing an instance of 'taco::TacoException'
  what():  Error at /home/infinoid/workspace/taco/git/src/lower/lowerer_impl.cpp:900 in lowerForallCloned:
 Unable to vectorize or unroll loop over unbound variable i
Aborted
```

In both cases, the problem can be solved with a bound() or a split(), and unrolling/vectorizing on the inner index.  But this patch just makes the error message more readable.

Fixes: #437