### PR TITLE
Use full precision when IR printing float constants

### DIFF
--- a/include/taco/util/strings.h
+++ b/include/taco/util/strings.h
@@ -5,6 +5,8 @@
 #include <sstream>
 #include <vector>
 #include <map>
+#include <iomanip>
+#include <limits>
 
 // To get the value of a compiler macro variable
 #define STRINGIFY(x) #x
@@ -24,12 +26,12 @@ toString(const T &val) {
 }
 
 /// Turn any floating point that can be written to a stream into a string,
-/// forcing inclusion of the decimal point.
+/// forcing full precision and inclusion of the decimal point.
 template <class T>
 typename std::enable_if<std::is_floating_point<T>::value, std::string>::type
 toString(const T &val) {
   std::stringstream sstream;
-  sstream << std::showpoint << val;
+  sstream << std::setprecision(std::numeric_limits<T>::max_digits10) << std::showpoint << val;
   return sstream.str();
 }
 


### PR DESCRIPTION
The default precision when printing a floating point value is 6 digits.
This causes a lot of double values to get truncated. Print these with
full precision to avoid losing data.