### PR TITLE
Define CUDA CI actions

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -77,33 +77,3 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
           CTEST_PARALLEL_LEVEL: 2
         working-directory: build
-
-  build-gpu:
-    name: build taco for gpu, but does not run tests
-    runs-on: ubuntu-18.04
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: download cuda
-        run: wget http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run
-      - name: install cuda
-        run: sudo sh cuda_10.2.89_440.33.01_linux.run --silent --toolkit --installpath="$GITHUB_WORKSPACE/cuda"
-      - name: add path
-        run: echo "$GITHUB_WORKSPACE/cuda/bin" >> $GITHUB_PATH
-      - name: set ld_library_path
-        run: echo "LD_LIBRARY_PATH=$GITHUB_WORKSPACE/cuda/lib64" >> $GITHUB_ENV
-      - name: set library_path
-        run: echo "LIBRARY_PATH=$GITHUB_WORKSPACE/cuda/lib64" >> $GITHUB_ENV
-      - name: print environment
-        run: |
-          echo ${PATH}
-          echo ${LD_LIBRARY_PATH}
-          echo ${LIBRARY_PATH}
-      - name: create_build
-        run: mkdir build
-      - name: cmake
-        run: cmake -DCUDA=ON ..
-        working-directory: build
-      - name: make
-        run: make -j2
-        working-directory: build

--- a/.github/workflows/cuda-test-manual.yml
+++ b/.github/workflows/cuda-test-manual.yml
@@ -1,0 +1,42 @@
+name: "CUDA build and test (manual)"
+
+# Note: This workflow is triggered by hand by TACO developers.
+# It should be run after the code has been reviewed by humans.
+# This review step is important to ensure the safety of the
+# self-hosted runner.
+
+on:
+  workflow_dispatch:
+    inputs:
+      CMAKE_BUILD_TYPE:
+        description: CMAKE_BUILD_TYPE
+        required: true
+        default: Debug
+      OPENMP:
+        description: OPENMP
+        required: true
+        default: 'ON'
+      PYTHON:
+        description: PYTHON
+        required: true
+        default: 'OFF'
+jobs:
+  ubuntu1604-cuda:
+    name: tests ubuntu 16.04 with CUDA 9
+    runs-on: [self-hosted, ubuntu-16.04, cuda]
+    steps:
+    - uses: actions/checkout@v2
+    - name: create_build
+      run: mkdir build
+    - name: cmake
+      run: cmake -DCMAKE_BUILD_TYPE=${{ github.event.inputs.CMAKE_BUILD_TYPE }} -DCUDA=ON -DOPENMP=${{ github.event.inputs.OPENMP }} -DPYTHON=${{ github.event.inputs.PYTHON }} ..
+      working-directory: build
+    - name: make
+      run: make -j8
+      working-directory: build
+    - name: test
+      run: make test
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
+        CTEST_PARALLEL_LEVEL: 8
+      working-directory: build


### PR DESCRIPTION
This PR adds github workflows to run the CUDA tests on a self-hosted runner.

Two workflows:
1. manually triggered
2. triggered by pushes to master

Once a self-hosted runner is set up, merging this will allow you to run tests on it.

Closes: #457