### PR TITLE
Add a second CUDA CI workflow for automatic testing of pushes.

### DIFF
--- a/.github/workflows/cuda-test-master.yml
+++ b/.github/workflows/cuda-test-master.yml
@@ -1,0 +1,28 @@
+name: "CUDA build and test (on push)"
+
+# Note: NOT triggered by pull requests.  Pull requests should be reviewed
+# by a human first, then triggered manually.  See cuda-test-manual.yml.
+on:
+  push:
+    branches:
+      - master
+jobs:
+  ubuntu1604-cuda:
+    name: tests ubuntu 16.04 with CUDA 9
+    runs-on: [self-hosted, ubuntu-16.04, cuda]
+    steps:
+    - uses: actions/checkout@v2
+    - name: create_build
+      run: mkdir build
+    - name: cmake
+      run: cmake -DCMAKE_BUILD_TYPE=Debug -DCUDA=ON -DOPENMP=ON -DPYTHON=OFF ..
+      working-directory: build
+    - name: make
+      run: make -j8
+      working-directory: build
+    - name: test
+      run: make test
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
+        CTEST_PARALLEL_LEVEL: 8
+      working-directory: build


### PR DESCRIPTION
This is a followup to #458.  It adds a second CI workflow, for automatic CUDA testing of pushes to master.  It does NOT run on pull requests - see #457 for reasons why not.

The plan is, once the current batch of CUDA failures is fixed, we can push this PR and keep it that way.
