### PR TITLE
Clean up an invalid memory access in makeCSR()

### DIFF
--- a/include/taco/storage/typed_value.h
+++ b/include/taco/storage/typed_value.h
@@ -20,7 +20,7 @@ public:
 
 protected:
   /// Gets the value of this TypedComponent as a size_t (for use in indexing)
-  size_t getAsIndex(const ComponentTypeUnion mem) const;
+  size_t getAsIndex(const ComponentTypeUnion &mem) const;
   /// Sets mem to value (ensure that it does not write to bytes past the size of the type in the union)
   void set(ComponentTypeUnion& mem, const ComponentTypeUnion& value);
   /// Sets mem to casted value of integer
@@ -237,4 +237,3 @@ bool operator!=(const TypedComponentVal& a, const int other);
 
 }
 #endif
-

--- a/src/storage/typed_value.cpp
+++ b/src/storage/typed_value.cpp
@@ -10,7 +10,7 @@ const Datatype& TypedComponent::getType() const {
   return dType;
 }
 
-size_t TypedComponent::getAsIndex(const ComponentTypeUnion mem) const {
+size_t TypedComponent::getAsIndex(const ComponentTypeUnion &mem) const {
   switch (dType.getKind()) {
     case Datatype::Bool: return (size_t) mem.boolValue;
     case Datatype::UInt8: return (size_t) mem.uint8Value;

--- a/test/test-typedcomponent-memory.cpp
+++ b/test/test-typedcomponent-memory.cpp
@@ -1,0 +1,35 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <sys/mman.h>
+
+#include "test.h"
+
+#include "taco/tensor.h"
+
+using namespace taco;
+
+TEST(makecsr, access_past_pos) {
+    int pagesize = getpagesize();
+    int matrixsize = pagesize / sizeof(int) - 1;
+    // carefully arrange pos[] array memory so that pos[1024] will segfault
+    int *fence = (int*)mmap(NULL , pagesize*2, PROT_NONE             , MAP_PRIVATE | MAP_ANON            , -1, 0);
+    int *pos   = (int*)mmap(fence, pagesize  , PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_FIXED, -1, 0);
+    int *crd = new int[matrixsize];
+    double *value = new double[matrixsize];
+    ASSERT_EQ(pos, fence) << "Unable to create guard zone for test";
+    // 1023x1023 CSR identity matrix
+    pos[matrixsize] = matrixsize;
+    for(int i = 0; i < matrixsize; i++) {
+        pos[i] = i;
+        crd[i] = i;
+        value[i] = 1.0;
+    }
+    {
+        taco::Tensor<double> A = makeCSR("A", {matrixsize, matrixsize}, pos, crd, value);
+    }
+    delete []crd;
+    delete []value;
+    munmap(pos, pagesize);
+    munmap(fence, pagesize*2);
+    printf("Success!\n");
+}


### PR DESCRIPTION
The pointer variant of `makeCSR()` can read past the end of the `pos` array.  In some (rare, unlucky) cases, this can cause the program to segfault.

The issue is that `TypedComponentRef::getAsIndex` does two 64-bit reads (of a 128-bit union type) and then passes (by value) down to the accessor method.  The solution is to pass a reference instead, so the accessor method only does a 32-bit read, and does not touch the other memory locations.

I also added a test case that carefully arranges memory to guarantee that out-of-bounds accesses will segfault.

Fixes: #455

Here's what valgrind says before the patch was applied:

```
valgrind --track-origins=yes ./test
==1009579== Memcheck, a memory error detector
==1009579== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==1009579== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==1009579== Command: ./test
==1009579== 
==1009579== Invalid read of size 8
==1009579==    at 0x4F736E7: taco::TypedComponentRef::getAsIndex() const (typed_value.cpp:370)
==1009579==    by 0x4F6630B: taco::Index::getSize() const (index.cpp:59)
==1009579==    by 0x10BDB9: taco::TensorBase taco::makeCSR<double>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<int, std::allocator<int> > const&, int*, int*, double*, taco::Array::Policy) (tensor.h:760)
==1009579==    by 0x10A531: main (test.cpp:26)
==1009579==  Address 0x56a0fb8 is 4 bytes after a block of size 4 alloc'd
==1009579==    at 0x483877F: malloc (vg_replace_malloc.c:307)
==1009579==    by 0x4F4BECF: taco::makeArray(taco::Datatype, unsigned long) (array.cpp:217)
==1009579==    by 0x4D07BF9: taco::Array taco::makeArray<int>(std::vector<int, std::allocator<int> > const&) (array.h:72)
==1009579==    by 0x4CFA756: taco::Array taco::makeArray<int>(std::initializer_list<int> const&) (array.h:80)
==1009579==    by 0x4F668C3: taco::makeCSRIndex(unsigned long, int*, int*) (index.cpp:110)
==1009579==    by 0x10BDA1: taco::TensorBase taco::makeCSR<double>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<int, std::allocator<int> > const&, int*, int*, double*, taco::Array::Policy) (tensor.h:758)
==1009579==    by 0x10A531: main (test.cpp:26)
==1009579== 
==1009579== Invalid read of size 8
==1009579==    at 0x4F736E4: taco::TypedComponentRef::getAsIndex() const (typed_value.cpp:370)
==1009579==    by 0x4F663E0: taco::Index::getSize() const (index.cpp:61)
==1009579==    by 0x10BDB9: taco::TensorBase taco::makeCSR<double>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<int, std::allocator<int> > const&, int*, int*, double*, taco::Array::Policy) (tensor.h:760)
==1009579==    by 0x10A531: main (test.cpp:26)
==1009579==  Address 0x50efffc is in a rw- anonymous segment
==1009579== 
==1009579== 
==1009579== Process terminating with default action of signal 11 (SIGSEGV)
==1009579==  Bad permissions for mapped region at address 0x50F0000
==1009579==    at 0x4F736E4: taco::TypedComponentRef::getAsIndex() const (typed_value.cpp:370)
==1009579==    by 0x4F663E0: taco::Index::getSize() const (index.cpp:61)
==1009579==    by 0x10BDB9: taco::TensorBase taco::makeCSR<double>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<int, std::allocator<int> > const&, int*, int*, double*, taco::Array::Policy) (tensor.h:760)
==1009579==    by 0x10A531: main (test.cpp:26)
==1009579== 
==1009579== HEAP SUMMARY:
==1009579==     in use at exit: 28,432 bytes in 113 blocks
==1009579==   total heap usage: 364 allocs, 251 frees, 139,157 bytes allocated
```

And after applying the patch:

```
valgrind --track-origins=yes ./test
==1010084== Memcheck, a memory error detector
==1010084== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==1010084== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==1010084== Command: ./test
==1010084== 
==1010084== 
==1010084== HEAP SUMMARY:
==1010084==     in use at exit: 128 bytes in 1 blocks
==1010084==   total heap usage: 370 allocs, 369 frees, 139,293 bytes allocated
```
