### PR TITLE
Run CI tests on macos

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -77,3 +77,26 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
           CTEST_PARALLEL_LEVEL: 2
         working-directory: build
+
+  build-test-python-macos-clang:
+    name: builds taco and pytaco on macos with clang and runs all tests
+    runs-on: macos-10.15
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: install numpy and scipy
+        run: pip3 install numpy scipy
+      - name: create_build
+        run: mkdir build
+      - name: cmake
+        run: cmake -DCMAKE_BUILD_TYPE=Debug -DPYTHON=ON ..
+        working-directory: build
+      - name: make
+        run: make -j2
+        working-directory: build
+      - name: test
+        run: make test
+        env:
+          CTEST_OUTPUT_ON_FAILURE: 1
+          CTEST_PARALLEL_LEVEL: 2
+        working-directory: build


### PR DESCRIPTION
Github provides buildbots for MacOS, this adds it to our test workflow.

This adds a bit of much-needed variety; all of our other buildbots use gcc on Linux.

For the unfamiliar: `gcc` is a symlink to `clang` on MacOS, so no special build flags are required.