### PR TITLE
Fix some precompute transformation algorithm bugs that arose

### DIFF
--- a/test/tests-workspaces.cpp
+++ b/test/tests-workspaces.cpp
@@ -470,16 +470,12 @@ TEST(workspaces, DISABLED_tile_dotProduct_1) {
   stmt = stmt.bound(i, i_bounded, (size_t)N, BoundType::MaxExact)
              .split(i_bounded, i0, i1, 32);
   stmt = stmt.precompute(precomputedExpr, i1, i1, precomputed);
-    
-  cout << stmt << endl;
-  cout << endl;
 
   stmt = stmt.precompute(BExpr, i1, i1, B_new) 
           .precompute(CExpr, i1, i1, C_new);
 
 
   stmt = stmt.concretize();
-  cout << stmt << endl;
 
   A.compile(stmt);
   A.assemble();
@@ -527,9 +523,6 @@ TEST(workspaces, DISABLED_tile_dotProduct_2) {
 
   stmt = stmt.precompute(precomputedExpr, i, i, precomputed);
     
-  cout << stmt << endl;
-  cout << endl;
-
   stmt = stmt.precompute(BExpr, i, i, B_new) 
           .precompute(CExpr, i, i, C_new);
 
@@ -537,7 +530,6 @@ TEST(workspaces, DISABLED_tile_dotProduct_2) {
              .split(i_bounded, i0, i1, 32);
 
   stmt = stmt.concretize();
-  cout << stmt << endl;
 
   A.compile(stmt);
   A.assemble();

--- a/test/tests-workspaces.cpp
+++ b/test/tests-workspaces.cpp
@@ -443,8 +443,8 @@ TEST(workspaces, DISABLED_tile_dotProduct_1) {
   // would result in scattering. 
   int N = 1024;
   Tensor<double> A("A");
-  Tensor<double> B("B", {N}, {Dense});
-  Tensor<double> C("C", {N}, {Dense});
+  Tensor<double> B("B", {N}, Format({Dense}));
+  Tensor<double> C("C", {N}, Format({Dense}));
 
   for (int i = 0; i < N; i++) {
     B.insert({i}, (double) i);
@@ -497,8 +497,8 @@ TEST(workspaces, DISABLED_tile_dotProduct_2) {
 
   int N = 1024;
   Tensor<double> A("A");
-  Tensor<double> B("B", {N}, {Dense});
-  Tensor<double> C("C", {N}, {Dense});
+  Tensor<double> B("B", {N}, Format({Dense}));
+  Tensor<double> C("C", {N}, Format({Dense}));
 
   for (int i = 0; i < N; i++) {
     B.insert({i}, (double) i);

--- a/test/tests-workspaces.cpp
+++ b/test/tests-workspaces.cpp
@@ -45,7 +45,7 @@ TEST(workspaces, tile_vecElemMul_NoTail) {
   expected.compile();
   expected.assemble();
   expected.compute();
-  ASSERT_TENSOR_EQ(A, expected);
+  ASSERT_TENSOR_EQ(expected, A);
 }
 
 TEST(workspaces, tile_vecElemMul_Tail1) {
@@ -83,7 +83,7 @@ TEST(workspaces, tile_vecElemMul_Tail1) {
   expected.compile();
   expected.assemble();
   expected.compute();
-  ASSERT_TENSOR_EQ(A, expected);
+  ASSERT_TENSOR_EQ(expected, A);
 }
 
 TEST(workspaces, tile_vecElemMul_Tail2) {
@@ -121,7 +121,7 @@ TEST(workspaces, tile_vecElemMul_Tail2) {
   expected.compile();
   expected.assemble();
   expected.compute();
-  ASSERT_TENSOR_EQ(A, expected);
+  ASSERT_TENSOR_EQ(expected, A);
 
 //  ir::IRPrinter irp = ir::IRPrinter(cout);
 //    
@@ -171,7 +171,7 @@ TEST(workspaces, tile_denseMatMul) {
   expected.compile();
   expected.assemble();
   expected.compute();
-  ASSERT_TENSOR_EQ(A, expected);
+  ASSERT_TENSOR_EQ(expected, A);
 
 //  ir::IRPrinter irp = ir::IRPrinter(cout);
 //    
@@ -218,7 +218,7 @@ TEST(workspaces, precompute2D_add) {
   expected.compile();
   expected.assemble();
   expected.compute();
-  ASSERT_TENSOR_EQ(A, expected);
+  ASSERT_TENSOR_EQ(expected, A);
 
 }
 
@@ -263,7 +263,7 @@ TEST(workspaces, precompute4D_add) {
   expected.compile();
   expected.assemble();
   expected.compute();
-  ASSERT_TENSOR_EQ(A, expected);
+  ASSERT_TENSOR_EQ(expected, A);
 }
 
 TEST(workspaces, precompute4D_multireduce) {
@@ -305,7 +305,7 @@ TEST(workspaces, precompute4D_multireduce) {
   expected.compile();
   expected.assemble();
   expected.compute();
-  ASSERT_TENSOR_EQ(A, expected);
+  ASSERT_TENSOR_EQ(expected, A);
 }
 
 TEST(workspaces, precompute3D_TspV) {
@@ -344,7 +344,7 @@ TEST(workspaces, precompute3D_TspV) {
   expected.compile();
   expected.assemble();
   expected.compute();
-  ASSERT_TENSOR_EQ(A, expected);
+  ASSERT_TENSOR_EQ(expected, A);
 
 }
 
@@ -388,7 +388,7 @@ TEST(workspaces, precompute3D_multipleWS) {
   expected.compile();
   expected.assemble();
   expected.compute();
-  ASSERT_TENSOR_EQ(A, expected);
+  ASSERT_TENSOR_EQ(expected, A);
 
 }
 
@@ -431,6 +431,123 @@ TEST(workspaces, precompute3D_renamedIVars_TspV) {
   expected.compile();
   expected.assemble();
   expected.compute();
-  ASSERT_TENSOR_EQ(A, expected);
+  ASSERT_TENSOR_EQ(expected, A);
 
 }
+
+TEST(workspaces, DISABLED_tile_dotProduct_1) {
+  // FIXME: Disabled because currently the precompute algorithm does not appropriately
+  // optimize = from += when rewriting a statement for BOTH the producer and consumer 
+  // side of a where statement insertion. 
+  // Although always using += is CORRECT functionally, this fails the GPU tests since it 
+  // would result in scattering. 
+  int N = 1024;
+  Tensor<double> A("A");
+  Tensor<double> B("B", {N}, {Dense});
+  Tensor<double> C("C", {N}, {Dense});
+
+  for (int i = 0; i < N; i++) {
+    B.insert({i}, (double) i);
+    C.insert({i}, (double) i);
+  }
+
+  B.pack();
+  C.pack();
+
+  IndexVar i("i");
+  IndexVar i_bounded("i_bounded");
+  IndexVar i0("i0"), i1("i1");
+  IndexExpr BExpr = B(i);
+  IndexExpr CExpr = C(i);
+  IndexExpr precomputedExpr = (BExpr) * (CExpr);
+  A() = precomputedExpr;
+
+  IndexStmt stmt = A.getAssignment().concretize();
+  TensorVar B_new("B_new", Type(Float64, {(size_t)N}), taco::dense);
+  TensorVar C_new("C_new", Type(Float64, {(size_t)N}), taco::dense);
+  TensorVar precomputed("precomputed", Type(Float64, {(size_t)N}), taco::dense);
+
+  stmt = stmt.bound(i, i_bounded, (size_t)N, BoundType::MaxExact)
+             .split(i_bounded, i0, i1, 32);
+  stmt = stmt.precompute(precomputedExpr, i1, i1, precomputed);
+    
+  cout << stmt << endl;
+  cout << endl;
+
+  stmt = stmt.precompute(BExpr, i1, i1, B_new) 
+          .precompute(CExpr, i1, i1, C_new);
+
+
+  stmt = stmt.concretize();
+  cout << stmt << endl;
+
+  A.compile(stmt);
+  A.assemble();
+  A.compute();
+
+  Tensor<double> expected("expected");
+  expected() = B(i) * C(i);
+  expected.compile();
+  expected.assemble();
+  expected.compute();
+  ASSERT_TENSOR_EQ(expected, A);
+}
+
+TEST(workspaces, DISABLED_tile_dotProduct_2) {
+  // FIXME: This is also currently disabled since split(...) scheduling commands
+  // only split on the FIRST INSTANCE of an indexVar (assumes only one). 
+  // This is wrong if the indexVar is not renamed across iw_vars since an indexVar can 
+  // then occur on BOTH the consumer and producer side and should be split across both. 
+
+  int N = 1024;
+  Tensor<double> A("A");
+  Tensor<double> B("B", {N}, {Dense});
+  Tensor<double> C("C", {N}, {Dense});
+
+  for (int i = 0; i < N; i++) {
+    B.insert({i}, (double) i);
+    C.insert({i}, (double) i);
+  }
+
+  B.pack();
+  C.pack();
+
+  IndexVar i("i");
+  IndexVar i_bounded("i_bounded");
+  IndexVar i0("i0"), i1("i1");
+  IndexExpr BExpr = B(i);
+  IndexExpr CExpr = C(i);
+  IndexExpr precomputedExpr = (BExpr) * (CExpr);
+  A() = precomputedExpr;
+
+  IndexStmt stmt = A.getAssignment().concretize();
+  TensorVar B_new("B_new", Type(Float64, {(size_t)N}), taco::dense);
+  TensorVar C_new("C_new", Type(Float64, {(size_t)N}), taco::dense);
+  TensorVar precomputed("precomputed", Type(Float64, {(size_t)N}), taco::dense);
+
+  stmt = stmt.precompute(precomputedExpr, i, i, precomputed);
+    
+  cout << stmt << endl;
+  cout << endl;
+
+  stmt = stmt.precompute(BExpr, i, i, B_new) 
+          .precompute(CExpr, i, i, C_new);
+
+  stmt = stmt.bound(i, i_bounded, (size_t)N, BoundType::MaxExact)
+             .split(i_bounded, i0, i1, 32);
+
+  stmt = stmt.concretize();
+  cout << stmt << endl;
+
+  A.compile(stmt);
+  A.assemble();
+  A.compute();
+
+  Tensor<double> expected("expected");
+  expected() = B(i) * C(i);
+  expected.compile();
+  expected.assemble();
+  expected.compute();
+  ASSERT_TENSOR_EQ(expected, A);
+}
+


### PR DESCRIPTION
Fix a bug in the algorithm so that the precompute transformation can only occur on cascaded `ForallNodes` without any `WhereNodes` inside the `forall->stmt`. The current test `DISABLED_tile_dotProduct_1` tests this case but is currently disabled because of the issue stated in the test's comments/FIXME. 

Also fix a minor bug where `expected` and `A` were flipped in `test/tests-workspaces.cpp` when calling `ASSERT_TENSOR_EQ(expected, A)`.

Also added in some disabled precompute tests that **should** work but currently do not due to certain new bugs found in the algorithm. I would like to add these tests in to the regression disabled and track re-enabling them using Git issues. 