### PR TITLE
Don't check tensor when comparing IndexSets

### DIFF
--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -189,10 +189,19 @@ struct Isomorphic : public IndexNotationVisitorStrict {
       }
     }
     if (anode->isAccessingStructure != bnode->isAccessingStructure ||
-        anode->windowedModes != bnode->windowedModes ||
-        anode->indexSetModes != bnode->indexSetModes) {
+        anode->windowedModes != bnode->windowedModes) {
       eq = false;
       return;
+    }
+    if (anode->indexSetModes.size() != bnode->indexSetModes.size()) {
+      eq = false;
+      return;
+    }
+    for (auto aset = anode->indexSetModes.begin(), bset = bnode->indexSetModes.begin(); aset != anode->indexSetModes.end(); ++aset, ++bset) {
+      if (aset->first != bset->first || *aset->second.set != *bset->second.set) {
+        eq = false;
+        return;
+      }
     }
     eq = true;
   }


### PR DESCRIPTION
This fixes my use case, at least. I'm not sure where else this comparison is used. The tensor member gets read and written in a bunch of places, so I assume it's still needed.