### PR TITLE
Only check size of index set for isomorphism

### DIFF
--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -198,7 +198,7 @@ struct Isomorphic : public IndexNotationVisitorStrict {
       return;
     }
     for (auto aset = anode->indexSetModes.begin(), bset = bnode->indexSetModes.begin(); aset != anode->indexSetModes.end(); ++aset, ++bset) {
-      if (aset->first != bset->first || *aset->second.set != *bset->second.set) {
+      if (aset->first != bset->first || aset->second.set->size() != bset->second.set->size()) {
         eq = false;
         return;
       }


### PR DESCRIPTION
Since the vector of indices is passed as a pointer, the generated
kernels are identical regardless of the index values being accessed. So
when checking for isomorphism, we shouldn't compare the values.