### PR TITLE
Add persistent kernel cache on disk

### DIFF
--- a/include/taco/codegen/module.h
+++ b/include/taco/codegen/module.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <utility>
 #include <random>
+#include <unordered_map>
 
 #include "taco/target.h"
 #include "taco/ir/ir.h"
@@ -16,10 +17,18 @@ namespace ir {
 class Module {
 public:
   /// Create a module for some target
-  Module(Target target=getTargetFromEnvironment())
-    : lib_handle(nullptr), moduleFromUserSource(false), target(target) {
+  Module(const std::string& cacheStr = "", Target target=getTargetFromEnvironment())
+    : cacheStr(cacheStr), lib_handle(nullptr), moduleFromUserSource(false), target(target) {
     setJITLibname();
     setJITTmpdir();
+
+    if (cacheStr != "") {
+      std::hash<std::string> hasher;
+      size_t hash = hasher(cacheStr);
+      std::ostringstream s;
+      s << std::hex << hash;
+      cacheStrHashed = s.str();
+    }
   }
 
   /// Compile the source into a library, returning its full path
@@ -67,6 +76,8 @@ public:
   void setSource(std::string source);
   
 private:
+  std::string cacheStr;
+  std::string cacheStrHashed;
   std::stringstream source;
   std::stringstream header;
   std::string libname;

--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -814,6 +814,9 @@ public:
   SubType as() {
     return to<SubType>(*this);
   }
+
+  /// Get string to use for this index statement in cache.
+  std::string getCacheString() const;
 };
 
 /// Check if two index statements are isomorphic.
@@ -1231,6 +1234,9 @@ public:
 
   friend bool operator==(const TensorVar&, const TensorVar&);
   friend bool operator<(const TensorVar&, const TensorVar&);
+
+  /// Get string to use for this tensor in cache.
+  std::string getCacheString() const;
 
 private:
   struct Content;

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -2074,6 +2074,15 @@ IndexStmt IndexStmt::wsaccel(TensorVar& ws, bool shouldAccel, const std::vector<
     return *this;
 }
 
+std::string IndexStmt::getCacheString() const {
+    std::ostringstream s;
+    for (auto& var : getTensorVars(*this)) {
+        s << var.getCacheString() << "|";
+    }
+    s << *this;
+    return s.str();
+}
+
 std::ostream& operator<<(std::ostream& os, const IndexStmt& expr) {
   if (!expr.defined()) return os << "IndexStmt()";
   IndexNotationPrinter printer(os);
@@ -2694,6 +2703,13 @@ std::ostream& operator<<(std::ostream& os, const TensorVar& var) {
   return os << var.getName() << " : " << var.getType();
 }
 
+string TensorVar::getCacheString() const {
+  ostringstream s;
+  s << getName() << ":";
+  s << getType().getDataType() << ";";
+  s << getFormat();
+  return s.str();
+}
 
 static bool isValid(Assignment assignment, string* reason) {
   if (reason == nullptr) {

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -666,7 +666,7 @@ void TensorBase::compile(taco::IndexStmt stmt, bool assembleWhileCompute) {
   // If we have to recompile the kernel, we need to create a new Module. Since
   // the module we are holding on to could have been retrieved from the cache,
   // we can't modify it.
-  content->module = make_shared<Module>();
+  content->module = make_shared<Module>(stmtToCompile.getCacheString());
   content->module->addFunction(content->assembleFunc);
   content->module->addFunction(content->computeFunc);
   content->module->compile();


### PR DESCRIPTION
This adds another layer of kernel caching, that lives on disk and persists between program runs. This includes the generated source, header, and compiled object files for each kernel.

The file name is a hash of the names, types, and formats of each tensor, plus a serialization of the IndexStmt. This should be sufficient to uniquely identify a kernel.

When the environment variable TACO_CACHE_DIR is set, the value is used as the cache directory. If unset, the disk-level cache is disabled.