### PR TITLE
Fix spmvGPU and ttvGPU

### DIFF
--- a/src/index_notation/transformations.cpp
+++ b/src/index_notation/transformations.cpp
@@ -436,7 +436,7 @@ IndexStmt Precompute::apply(IndexStmt stmt, std::string* reason) const {
             /// The reduceOp depends on the relation between indexVar sets of rhs and lhs. For rcl and inter, reduceOp
             /// must be +=. For lcr, reduceOp must be =. For none and equal, reduceOp can't be decided at this stage.
             switch (rel) {
-                case none: a = Assignment(a.getLhs(), a.getRhs());break;
+                case none: a = Assignment(a.getLhs(), a.getRhs(), Add());break;
                 case rcl:  a = Assignment(a.getLhs(), a.getRhs(), Add());break;
                 case lcr: a = Assignment(a.getLhs(), a.getRhs());break;
                 case inter: a = Assignment(a.getLhs(), a.getRhs(), Add());break;
@@ -456,7 +456,7 @@ IndexStmt Precompute::apply(IndexStmt stmt, std::string* reason) const {
             /// The reduceOp depends on the relation between indexVar sets of rhs and lhs. For rcl and inter, reduceOp
             /// must be +=. For lcr, reduceOp must be =. For none and equal, reduceOp can't be decided at this stage.
             switch (rel) {
-                case none: a = Assignment(a.getLhs(), a.getRhs());break;
+                case none: a = Assignment(a.getLhs(), a.getRhs(), Add());break;
                 case rcl:  a = Assignment(a.getLhs(), a.getRhs(), Add());break;
                 case lcr: a = Assignment(a.getLhs(), a.getRhs());break;
                 case inter: a = Assignment(a.getLhs(), a.getRhs(), Add());break;

--- a/test/tests-scheduling-eval.cpp
+++ b/test/tests-scheduling-eval.cpp
@@ -1241,7 +1241,8 @@ TEST(scheduling_eval, spmvGPU) {
   IndexStmt stmt = y.getAssignment().concretize();
   stmt = scheduleSpMVGPU(stmt, A, precomputed);
 
-  //printToFile("spmv_gpu", stmt);
+  std::cout << stmt << std::endl;
+  printToFile("spmv_gpu", stmt);
 
   y.compile(stmt);
   y.assemble();

--- a/test/tests-scheduling-eval.cpp
+++ b/test/tests-scheduling-eval.cpp
@@ -1241,8 +1241,7 @@ TEST(scheduling_eval, spmvGPU) {
   IndexStmt stmt = y.getAssignment().concretize();
   stmt = scheduleSpMVGPU(stmt, A, precomputed);
 
-  std::cout << stmt << std::endl;
-  printToFile("spmv_gpu", stmt);
+  //printToFile("spmv_gpu", stmt);
 
   y.compile(stmt);
   y.assemble();


### PR DESCRIPTION
Change the initial state of the reduction symbol for the "none" relation.