### PR TITLE
[CMake] Update CMake minimum required version to suppress deprecation warnings.

### DIFF
--- a/apps/tensor_times_vector/CMakeLists.txt
+++ b/apps/tensor_times_vector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.4)
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()


### PR DESCRIPTION
When I use the following CMake build commands to build the taco compiler, I encounter a warning:
```
cmake -GNinja .. \
	   -DCMAKE_BUILD_TYPE=Debug \
	   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
```
Here is the warning log:
```
CMake Deprecation Warning at apps/tensor_times_vector/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Submodule update
Submodule 'python_bindings/pybind11' (https://github.com/pybind/pybind11) registered for path 'python_bindings/pybind11'
Submodule 'test/bats' (https://github.com/bats-core/bats-core) registered for path 'test/bats'
Cloning into '/home/harrison/Projects/taco/python_bindings/pybind11'...
Cloning into '/home/harrison/Projects/taco/test/bats'...
Submodule path 'python_bindings/pybind11': checked out '8de7772cc72daca8e947b79b83fea46214931604'
Submodule path 'test/bats': checked out 'dcaec03e32e0b152f8ef9cf14b75296cf5caeaff'
-- Configuring done (49.2s)
-- Generating done (0.0s)
-- Build files have been written to: /home/harrison/Projects/taco/build
```
Therefore, I think we need to upgrade the version specified in `apps/tensor_times_vector/CMakeLists.txt`.