### PR TITLE
[BUILD] Fix narrowing conversion from double to unsigned int build issue.

### DIFF
--- a/test/tests-tensor_types.cpp
+++ b/test/tests-tensor_types.cpp
@@ -45,7 +45,7 @@ TYPED_TEST_P(VectorTensorTest, types) {
   ASSERT_EQ(t, a.getComponentType());
   ASSERT_EQ(1, a.getOrder());
   ASSERT_EQ(5, a.getDimension(0));
-  map<vector<int>,TypeParam> vals = {{{0}, 1.0}, {{2}, 2.0}};
+  map<vector<int>, TypeParam> vals = {{{0}, 1}, {{2}, 2}};
   for (auto& val : vals) {
     a.insert(val.first, val.second);
   }


### PR DESCRIPTION
When I built the TACO compiler, I encountered a build issue:
```bash
/home/harrison/Projects/taco/test/tests-tensor_types.cpp:48:30: error: narrowing conversion of ‘1.0e+0’ from ‘double’ to ‘unsigned int’ [-Wnarrowing]
   48 |   map<vector<int>,TypeParam> vals = {{{0}, 1.0}, {{2}, 2.0}};
      |                              ^~~~
/home/harrison/Projects/taco/test/tests-tensor_types.cpp: In instantiation of ‘void gtest_case_VectorTensorTest_::types<gtest_TypeParam_>::TestBody() [with gtest_TypeParam_ = short unsigned int]’:
/home/harrison/Projects/taco/test/tests-tensor_types.cpp:42:1:   required from here
17961 |   gtest_case_##TestCaseName##_
      |   ^~~~~~~~~~~
/home/harrison/Projects/taco/test/tests-tensor_types.cpp:48:30: error: narrowing conversion of ‘1.0e+0’ from ‘double’ to ‘short unsigned int’ [-Wnarrowing]
   48 |   map<vector<int>,TypeParam> vals = {{{0}, 1.0}, {{2}, 2.0}};
      |                              ^~~~
ninja: build stopped: subcommand failed.
```
This error indicates a narrowing conversion from double to unsigned int, causing the build to fail.