### PR TITLE
fix compiler errors for modern linux+clang+python+cuda setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ CMakeCache.txt
 doc
 .idea/
 apps/tensor_times_vector/tensor_times_vector
+*.lock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()
@@ -7,7 +7,7 @@ if(POLICY CMP0054)
 endif()
 project(taco
   VERSION 0.1
-  LANGUAGES C CXX
+  LANGUAGES C CXX CUDA
 )
 option(CUDA "Build for NVIDIA GPU (CUDA must be preinstalled)" OFF)
 option(PYTHON "Build TACO for python environment" OFF)
@@ -18,7 +18,7 @@ set(TACO_FEATURE_OPENMP 0)
 set(TACO_FEATURE_PYTHON 0)
 if(CUDA)
   message("-- Searching for CUDA Installation")
-  find_package(CUDA REQUIRED)
+  find_package(CUDAToolkit)
   add_definitions(-DCUDA_BUILT)
   set(TACO_FEATURE_CUDA 1)
 endif(CUDA)
@@ -126,12 +126,19 @@ if(GIT_FOUND AND EXISTS "${TACO_PROJECT_DIR}/.git")
   # Update submodules as needed
   option(GIT_SUBMODULE "Check submodules during build" ON)
   if(GIT_SUBMODULE)
-    message(STATUS "Submodule update")
+    message(STATUS "Updating submodules with shared lock file: ${CMAKE_SOURCE_DIR}/submodules.lock")
+    file(LOCK "${CMAKE_SOURCE_DIR}/submodules.lock" TIMEOUT 120)
     execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
             RESULT_VARIABLE GIT_SUBMOD_RESULT)
     if(NOT GIT_SUBMOD_RESULT EQUAL "0")
       message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+    endif()
+    execute_process(COMMAND ${GIT_EXECUTABLE} checkout stable
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/python_bindings/pybind11
+            RESULT_VARIABLE GIT_PYBIND11_CHECKOUT_RESULT)
+    if(NOT GIT_PYBIND11_CHECKOUT_RESULT EQUAL "0")
+      message(WARNING "git checkout stable failed with ${GIT_SUBMOD_RESULT}, build might be unstable")
     endif()
   endif()
   # get git revision

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ TL;DR build taco using CMake. Run `make test`.
 # Build and test
 ![Build and Test](https://github.com/RSenApps/taco/workflows/Build%20and%20Test/badge.svg?branch=master)
 
-Build taco using CMake 3.4.0 or greater:
+Build taco using CMake 3.18 or greater:
 
     cd <taco-directory>
     mkdir build

--- a/apps/tensor_times_vector/CMakeLists.txt
+++ b/apps/tensor_times_vector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+
 if (TACO_SHARED_LIBRARY)
   set(TACO_LIBRARY_TYPE SHARED)
   message("-- Shared library")
@@ -21,8 +23,7 @@ add_definitions(${TACO_DEFINITIONS})
 include_directories(${TACO_SRC_DIR})
 add_library(taco ${TACO_LIBRARY_TYPE} ${TACO_HEADERS} ${TACO_SOURCES})
 if (CUDA)
-  include_directories(${CUDA_INCLUDE_DIRS})
-  target_link_libraries(taco PUBLIC ${CUDA_LIBRARIES})
+  target_link_libraries(taco PUBLIC CUDA::cudart)
 endif (CUDA)
 install(TARGETS taco DESTINATION lib)
 

--- a/src/lower/lowerer_impl_imperative.cpp
+++ b/src/lower/lowerer_impl_imperative.cpp
@@ -497,7 +497,6 @@ Stmt LowererImplImperative::lowerAssignment(Assignment assignment)
     if (isAssembledByUngroupedInsertion(result)) {
       std::vector<Expr> coords;
       Expr prevPos = 0;
-      size_t i = 0;
       const auto resultIterators = getIterators(assignment.getLhs());
       for (const auto& it : resultIterators) {
         // TODO: Should only assemble levels that can be assembled together
@@ -517,7 +516,6 @@ Stmt LowererImplImperative::lowerAssignment(Assignment assignment)
         }
 
         prevPos = pos;
-        ++i;
       }
     }
 

--- a/test/tests-scheduling.cpp
+++ b/test/tests-scheduling.cpp
@@ -567,8 +567,8 @@ TEST(scheduling, multilevel_tiling) {
 
   vector<IndexVar> reordering = {iX1, iX2, iY1, iY2};
   sort(reordering.begin(), reordering.end());
-  int countCorrect = 0;
-  int countIncorrect = 0;
+  //int countCorrect = 0;
+  //int countIncorrect = 0;
   do {
     // TODO: Precondition (can be broken) bottom most loop must remain unchanged if sparse
     bool valid_reordering = reordering[3] == iY2;
@@ -583,7 +583,7 @@ TEST(scheduling, multilevel_tiling) {
     C.compute();
     if (!equals(C, expected)) {
       //cout << util::join(reordering) << endl;
-      countIncorrect++;
+      //countIncorrect++;
 
       std::shared_ptr<ir::CodeGen> codegen = ir::CodeGen::init_default(cout, ir::CodeGen::ImplementationGen);
       ir::Stmt compute = lower(reordered, "compute",  false, true);
@@ -591,9 +591,7 @@ TEST(scheduling, multilevel_tiling) {
       ASSERT_TENSOR_EQ(expected, C);
       exit(1);
     }
-    else {
-      countCorrect++;
-    }
+    //else{countCorrect++;}
   } while (next_permutation(reordering.begin(), reordering.end()));
 }
 

--- a/test/tests-tensor_types.cpp
+++ b/test/tests-tensor_types.cpp
@@ -45,7 +45,7 @@ TYPED_TEST_P(VectorTensorTest, types) {
   ASSERT_EQ(t, a.getComponentType());
   ASSERT_EQ(1, a.getOrder());
   ASSERT_EQ(5, a.getDimension(0));
-  map<vector<int>,TypeParam> vals = {{{0}, 1.0}, {{2}, 2.0}};
+  map<vector<int>,TypeParam> vals = {{{0}, static_cast<TypeParam>(1)}, {{2}, static_cast<TypeParam>(2)}};
   for (auto& val : vals) {
     a.insert(val.first, val.second);
   }


### PR DESCRIPTION
- fix deprecation errors with new cmake versions regarding how CUDA is loaded
  (by upgrading cmake and the associated CUDA configuration)
- fix several minor compiler errors and warnings appearing on clang (see changes)
- fix usage of unstable pybind dependency (that crashed my compilation)
  (by using git checkout after submodules are loaded)
- fix unsynchronised update of submodules (crashes cmake configuration if multiple configurations run in parallel)
  (by introducing a lock file)

These changes are tested on my local setup:
```
Ubuntu                          24.04.2 LTS
clang                           18.1.3
ninja                           1.11.1
cmake                           3.28.3
CUDA SDK                        12.6.3
CUDA C++ Core Compute Libraries 12.6.77
CUDA Runtime (cudart)           12.6.77
Python                          3.12.3
```

using ` -DCUDA=ON -DPYTHON=ON` with build types `Release` and `Debug`.

BUT THERE WHERE SOME FAILING TESTS!
```
The following tests FAILED:
 54 - */expr.storage/* (Failed)
 99 - qcd.mul1 (Failed)
119 - scheduling_eval.spmvGPU (Failed)
124 - scheduling_eval.ttvGPU (Failed)
159 - scheduling.mergeby (Failed)
225 - */stride.windowing/* (Failed)
226 - */indexSetVectors.windowing/* (Failed)
227 - */indexSetMatrices.windowing/* (Failed)
```

As I did not change any logic in the code I assume these are not based on my changes but on my setup.

I understand that raising the cmake version is not appreciated by everyone, but modern cmake will not support version lower than 3.10 in the future.
As with 3.18 the CUDA support is improved a lot I upgraded not only to 3.10 but 3.18 which is reasonable in my opinion.
