### PR TITLE
make benchmarking functions public

### DIFF
--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -445,6 +445,11 @@ public:
   /// True if the Tensor needs to be computed.
   bool needsCompute();
 
+  void setNeedsPack(bool needsPack);
+  void setNeedsCompile(bool needsCompile);
+  void setNeedsAssemble(bool needsAssemble);
+  void setNeedsCompute(bool needsCompute);
+
   /// Set to true to perform the assemble and compute stages simultaneously.
   void setAssembleWhileCompute(bool assembleWhileCompute);
 
@@ -510,10 +515,6 @@ private:
   bool neverPacked();
 
   void unsetNeverPacked();
-  void setNeedsPack(bool needsPack);
-  void setNeedsCompile(bool needsCompile);
-  void setNeedsAssemble(bool needsAssemble);
-  void setNeedsCompute(bool needsCompute);
 
   void addDependentTensor(TensorBase& tensor);
   void removeDependentTensor(TensorBase& tensor);


### PR DESCRIPTION
This is required for benchmark loops which would like to test the runtime of assembly. e.g.

```
  // Assemble output indices and numerically compute the result
  auto time = benchmark(
    [&y]() {
      y.setNeedsAssemble(true);
      y.setNeedsCompute(true);
    },
    [&y]() {
      y.assemble();
      y.compute();
    }
  );
```