### PR TITLE
fix: parse integer MTX files and fix tensor buffer ownership

### DIFF
--- a/src/index_notation/kernel.cpp
+++ b/src/index_notation/kernel.cpp
@@ -66,9 +66,9 @@ void unpackResults(size_t numResults, const vector<void*> arguments,
       } else if (modeType.getName() == Sparse.getName()) {
         auto size = ((int*)tensorData->indices[i][0])[num];
         Array pos = Array(type<int>(), tensorData->indices[i][0],
-                          num+1, Array::UserOwns);
+                          num+1, Array::Free);
         Array idx = Array(type<int>(), tensorData->indices[i][1],
-                          size, Array::UserOwns);
+                          size, Array::Free);
         modeIndices.push_back(ModeIndex({pos, idx}));
         num = size;
       } else {
@@ -76,7 +76,7 @@ void unpackResults(size_t numResults, const vector<void*> arguments,
       }
     }
     storage.setIndex(Index(format, modeIndices));
-    storage.setValues(Array(storage.getComponentType(), tensorData->vals, num));
+    storage.setValues(Array(storage.getComponentType(), tensorData->vals, num, Array::Free));
   }
 }
 

--- a/src/lower/lowerer_impl_imperative.cpp
+++ b/src/lower/lowerer_impl_imperative.cpp
@@ -1932,7 +1932,7 @@ std::vector<ir::Stmt> LowererImplImperative::constructInnerLoopCasePreamble(ir::
   for(size_t i = 0; i < coordComparisons.size(); ++i) {
     Expr nonZeroCase;
     if(coordComparisons[i].defined() && valueComparisons[i].defined()) {
-      nonZeroCase = taco::ir::conjunction({coordComparisons[i], valueComparisons[i]});
+      nonZeroCase = conjunction({coordComparisons[i], valueComparisons[i]});
     } else if (valueComparisons[i].defined()) {
       nonZeroCase = valueComparisons[i];
     } else if (coordComparisons[i].defined()) {

--- a/src/storage/file_io_mtx.cpp
+++ b/src/storage/file_io_mtx.cpp
@@ -51,7 +51,7 @@ TensorBase dispatchReadMTX(std::istream& stream, const T& format, bool pack) {
                                        << "Unknown type of MatrixMarket";
   // formats = [coordinate array]
   // field = [real integer complex pattern]
-  taco_uassert(field=="real")          << "MatrixMarket field not available";
+  taco_uassert(field=="real" || field=="integer")          << "MatrixMarket field not available";
   // symmetry = [general symmetric skew-symmetric Hermitian]
   taco_uassert((symmetry=="general") || (symmetry=="symmetric"))
                                        << "MatrixMarket symmetry not available";

--- a/src/taco_tensor_t.cpp
+++ b/src/taco_tensor_t.cpp
@@ -40,15 +40,7 @@ taco_tensor_t* init_taco_tensor_t(int32_t order, int32_t csize,
   t->indices = (uint8_t ***) alloc_mem(order * sizeof(uint8_t***));
   t->csize         = csize;
 
-  int fill_bytes = csize / 8;
-  t->fill_value = (uint8_t*) alloc_mem(fill_bytes);
-
-  if (fill_ptr) {
-    uint8_t* fill_inp = (uint8_t*) fill_ptr;
-    for (int i = 0; i < fill_bytes; ++i) {
-      t->fill_value[i] = fill_inp[i];
-    }
-  }
+  t->fill_value = (uint8_t*) fill_ptr;
 
   for (int32_t i = 0; i < order; i++) {
     t->dimensions[i]    = dimensions[i];
@@ -60,6 +52,9 @@ taco_tensor_t* init_taco_tensor_t(int32_t order, int32_t csize,
         break;
       case taco_mode_sparse:
         t->indices[i] = (uint8_t **) alloc_mem(2 * sizeof(uint8_t **));
+        break;
+      case taco_mode_dia1:
+        t->indices[i] = (uint8_t **) alloc_mem(3 * sizeof(uint8_t **));
         break;
     }
   }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -275,19 +275,19 @@ static size_t unpackTensorData(const taco_tensor_t& tensorData,
       numVals *= ((int*)tensorData.indices[i][0])[0];
     } else if (modeType.getName() == Sparse.getName()) {
       auto size = ((int*)tensorData.indices[i][0])[numVals];
-      Array pos = Array(type<int>(), tensorData.indices[i][0], numVals+1, Array::UserOwns);
-      Array idx = Array(type<int>(), tensorData.indices[i][1], size, Array::UserOwns);
+      Array pos = Array(type<int>(), tensorData.indices[i][0], numVals+1, Array::Free);
+      Array idx = Array(type<int>(), tensorData.indices[i][1], size, Array::Free);
       modeIndices.push_back(ModeIndex({pos, idx}));
       numVals = size;
     } else if (modeType.getName() == Singleton.getName()) {
-      Array idx = Array(type<int>(), tensorData.indices[i][1], numVals, Array::UserOwns);
+      Array idx = Array(type<int>(), tensorData.indices[i][1], numVals, Array::Free);
       modeIndices.push_back(ModeIndex({makeArray(type<int>(), 0), idx}));
     } else {
       taco_not_supported_yet;
     }
   }
   storage.setIndex(Index(format, modeIndices));
-  storage.setValues(Array(tensor.getComponentType(), tensorData.vals, numVals));
+  storage.setValues(Array(tensor.getComponentType(), tensorData.vals, numVals, Array::Free));
   return numVals;
 }
 


### PR DESCRIPTION
This PR fixes two sparse tensor correctness issues:

  - Allow MatrixMarket files with `integer` fields to be parsed in addition to `real`.
  - Fix heap memory leaks when packed or generated sparse tensor buffers are transferred back into TACO storage.

  ## Problem

  TACO previously rejected valid MatrixMarket files whose field type was `integer`, even though those files can be
  handled by the existing MatrixMarket read path.

  TACO also leaked heap memory after packing or reading sparse tensors. The affected allocations came from generated
  pack/assemble kernels and from `taco_tensor_t` fill-value handling.

  There were two ownership issues:

  - `init_taco_tensor_t` allocated a separate `fill_value`, but `deinit_taco_tensor_t` never released it. In practice,
  `TensorStorage::operator taco_tensor_t*()` may also replace `tensorData->fill_value` with
  `content->fillValue.getValPtr()`, so treating `fill_value` as owned storage is unsafe.
  - `unpackTensorData` and `Kernel::unpackResults` wrapped generated sparse `pos`, `idx`, and `vals` buffers with
  `Array::UserOwns`. These buffers are allocated by generated TACO code using `malloc`/`realloc`; after transfer into
  `TensorStorage`, there is no other owner, so they must be released by the receiving `Array`.

  ## Changes

  - Accept MatrixMarket `integer` fields alongside `real` fields.
  - Wrap transferred sparse position, index, singleton index, and value buffers with `Array::Free` instead of
  `Array::UserOwns`.
  - Update `Kernel::unpackResults` to use the same ownership behavior for generated sparse result buffers.
  - Change `init_taco_tensor_t` so `fill_value` aliases the supplied `fill_ptr` rather than allocating a separate copy.
  - Allocate the expected index pointer storage for `taco_mode_dia1`.

  ## Validation

  Valgrind was run on a MatrixMarket CSR read + SpMM case that previously reported definitely-lost allocations from
  generated pack code and `taco_tensor_t` initialization.

  After this change:

  ```text
  definitely lost: 0 bytes in 0 blocks
  indirectly lost: 0 bytes in 0 blocks
  possibly lost: 0 bytes in 0 blocks
   ```
  ## Notes

  The ownership model is now explicit: generated sparse buffers are transferred into TACO storage and released through
  Array::Free, while taco_tensor_t::fill_value remains a non-owning reference to storage managed by the TensorStorage/
  Literal path.