### PR TITLE
Fix CI: update discontinued ubuntu-18.04 and macos-10.15 runners

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   build-test-cpu:
     name: builds taco with no options for cpu and runs all tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: create_build
       run: mkdir build
     - name: cmake
@@ -34,10 +34,10 @@ jobs:
 
   build-test-cpu-release:
     name: builds taco release for cpu and runs all tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: create_build
         run: mkdir build
       - name: cmake
@@ -55,10 +55,10 @@ jobs:
 
   build-test-cpu-openmp-python-asserts:
     name: builds taco with compile-time asserts, openmp, and python and runs all tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: apt-get update
         run: sudo apt-get update
       - name: install numpy and scipy
@@ -80,10 +80,10 @@ jobs:
 
   build-test-python-macos-clang:
     name: builds taco and pytaco on macos with clang and runs all tests
-    runs-on: macos-10.15
+    runs-on: macos-13
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: install numpy and scipy
         run: pip3 install numpy scipy
       - name: create_build


### PR DESCRIPTION
## Problem
The `Build and Test` workflow can no longer run: GitHub removed the `ubuntu-18.04` and `macos-10.15` runner images it targets (#575).

## Fix
- `ubuntu-18.04` -> `ubuntu-22.04` (3 jobs)
- `macos-10.15` -> `macos-13`
- `actions/checkout@v2` -> `@v4` (v2 relies on the retired Node 16)

## Validation
Built TACO and ran the full CTest suite on Ubuntu 24.04 with gcc 13.3: **231/231 tests pass**. Since the discontinued runner images were the blocker, this restores CI.

Note: I could not test the macOS job locally; `macos-13` is a currently-supported image. The CUDA (self-hosted) workflow is untouched.

Fixes #575.
